### PR TITLE
fix(payload-agents-core): validate session ID ownership on all endpoints

### DIFF
--- a/.changeset/fix-session-ownership.md
+++ b/.changeset/fix-session-ownership.md
@@ -1,0 +1,5 @@
+---
+"@zetesis/payload-agents-core": patch
+---
+
+Validate session ID ownership on all chat endpoints. Prevents cross-tenant session access and session hijacking via user-controlled chatId.

--- a/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.ts
+++ b/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.ts
@@ -11,7 +11,7 @@ import { decrypt, encrypt, isEncrypted } from '../../lib/encryption'
 import type { ResolvedPluginConfig } from '../../types'
 
 export function createEncryptBeforeChangeHook(config: ResolvedPluginConfig): CollectionBeforeChangeHook {
-  return async ({ data, originalDoc }) => {
+  return async ({ data }) => {
     if (!config.encryptionKey) return data
 
     if (data.apiKey) {

--- a/packages/payload-agents-core/src/endpoints/chat.ts
+++ b/packages/payload-agents-core/src/endpoints/chat.ts
@@ -11,6 +11,7 @@
 
 import type { PayloadHandler, Where } from 'payload'
 import { reloadAgents } from '../lib/runtime-client'
+import { createSessionId, validateSessionOwnership } from '../lib/session-id'
 import { translateAgnoStream } from '../lib/sse-translator'
 import { getTokenUsage } from '../lib/token-usage'
 import type { ResolvedPluginConfig } from '../types'
@@ -135,7 +136,10 @@ export function createChatHandler(config: ResolvedPluginConfig): PayloadHandler 
 
     // ── Session ID ──────────────────────────────────────────────────────
     const agentSlugValue = agent.slug as string
-    const sessionId = chatId || `${agentSlugValue}:${tenantId}:${userId}:${crypto.randomUUID()}`
+    if (chatId && !validateSessionOwnership(chatId, tenantId, userId)) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
+    }
+    const sessionId = chatId || createSessionId(agentSlugValue, tenantId, userId)
     const upstreamUrl = `${config.runtimeUrl}/agents/${encodeURIComponent(agentSlugValue)}/runs`
 
     const callRuntime = () =>

--- a/packages/payload-agents-core/src/endpoints/session.ts
+++ b/packages/payload-agents-core/src/endpoints/session.ts
@@ -195,7 +195,7 @@ export function createSessionGetHandler(config: ResolvedPluginConfig): PayloadHa
       }
 
       if (isActive) {
-        return await handleActiveSession(config.runtimeUrl, userId)
+        return await handleActiveSession(config.runtimeUrl, tenantId, userId)
       }
 
       return Response.json(null, { status: 400 })
@@ -206,13 +206,13 @@ export function createSessionGetHandler(config: ResolvedPluginConfig): PayloadHa
   }
 }
 
-async function handleActiveSession(runtimeUrl: string, userId: string | number): Promise<Response> {
+async function handleActiveSession(runtimeUrl: string, tenantId: string, userId: string | number): Promise<Response> {
   const params = new URLSearchParams({
     type: 'agent',
     user_id: String(userId),
     sort_by: 'updated_at',
     sort_order: 'desc',
-    limit: '1'
+    limit: '10'
   })
   const listRes = await fetch(`${runtimeUrl}/sessions?${params}`, {
     signal: AbortSignal.timeout(5_000)
@@ -220,10 +220,10 @@ async function handleActiveSession(runtimeUrl: string, userId: string | number):
   if (!listRes.ok) return Response.json(null)
 
   const listBody = (await listRes.json()) as { data: Array<{ session_id: string }> }
-  const latest = listBody.data?.[0]
-  if (!latest) return Response.json(null)
+  const match = (listBody.data || []).find(s => validateSessionOwnership(s.session_id, tenantId, userId))
+  if (!match) return Response.json(null)
 
-  const detail = await fetchSessionDetail(runtimeUrl, latest.session_id, userId)
+  const detail = await fetchSessionDetail(runtimeUrl, match.session_id, userId)
   return detail ? Response.json(detail) : Response.json(null)
 }
 

--- a/packages/payload-agents-core/src/endpoints/session.ts
+++ b/packages/payload-agents-core/src/endpoints/session.ts
@@ -8,6 +8,7 @@
  */
 
 import type { PayloadHandler } from 'payload'
+import { validateSessionOwnership } from '../lib/session-id'
 import { dedupSources, extractSources } from '../lib/sources'
 import type { ResolvedPluginConfig, Source } from '../types'
 
@@ -179,12 +180,16 @@ export function createSessionGetHandler(config: ResolvedPluginConfig): PayloadHa
     }
 
     const userId = (user as unknown as { id: string | number }).id
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
     const url = new URL(req.url || '', 'http://localhost')
     const conversationId = url.searchParams.get('conversationId')
     const isActive = url.searchParams.get('active') === 'true'
 
     try {
       if (conversationId) {
+        if (!validateSessionOwnership(conversationId, tenantId, userId)) {
+          return Response.json({ error: 'Forbidden' }, { status: 403 })
+        }
         const detail = await fetchSessionDetail(config.runtimeUrl, conversationId, userId)
         return detail ? Response.json(detail) : Response.json(null, { status: 404 })
       }
@@ -232,10 +237,14 @@ export function createSessionPatchHandler(config: ResolvedPluginConfig): Payload
     }
 
     const userId = (user as unknown as { id: string | number }).id
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
     const url = new URL(req.url || '', 'http://localhost')
     const conversationId = url.searchParams.get('conversationId')
     if (!conversationId) {
       return Response.json({ error: 'Missing conversationId' }, { status: 400 })
+    }
+    if (!validateSessionOwnership(conversationId, tenantId, userId)) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
 
     let body: { title?: string }
@@ -280,10 +289,14 @@ export function createSessionDeleteHandler(config: ResolvedPluginConfig): Payloa
     }
 
     const userId = (user as unknown as { id: string | number }).id
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
     const url = new URL(req.url || '', 'http://localhost')
     const conversationId = url.searchParams.get('conversationId')
     if (!conversationId) {
       return Response.json({ error: 'Missing conversationId' }, { status: 400 })
+    }
+    if (!validateSessionOwnership(conversationId, tenantId, userId)) {
+      return Response.json({ error: 'Forbidden' }, { status: 403 })
     }
 
     try {

--- a/packages/payload-agents-core/src/index.ts
+++ b/packages/payload-agents-core/src/index.ts
@@ -2,6 +2,7 @@
 
 export { decrypt, encrypt, isEncrypted } from './lib/encryption'
 export { reloadAgents } from './lib/runtime-client'
+export { createSessionId, parseSessionId, validateSessionOwnership } from './lib/session-id'
 
 // Utilities (for advanced consumers)
 export { dedupSources, extractSources } from './lib/sources'
@@ -18,4 +19,5 @@ export type {
   Source,
   TokenUsageResult
 } from './types'
+export type { SessionIdParts } from './lib/session-id'
 export { defaultExtractTenantId } from './utils/extract-tenant'

--- a/packages/payload-agents-core/src/index.ts
+++ b/packages/payload-agents-core/src/index.ts
@@ -2,8 +2,8 @@
 
 export { decrypt, encrypt, isEncrypted } from './lib/encryption'
 export { reloadAgents } from './lib/runtime-client'
+export type { SessionIdParts } from './lib/session-id'
 export { createSessionId, parseSessionId, validateSessionOwnership } from './lib/session-id'
-
 // Utilities (for advanced consumers)
 export { dedupSources, extractSources } from './lib/sources'
 export { translateAgnoStream } from './lib/sse-translator'
@@ -19,5 +19,4 @@ export type {
   Source,
   TokenUsageResult
 } from './types'
-export type { SessionIdParts } from './lib/session-id'
 export { defaultExtractTenantId } from './utils/extract-tenant'

--- a/packages/payload-agents-core/src/lib/session-id.ts
+++ b/packages/payload-agents-core/src/lib/session-id.ts
@@ -36,11 +36,7 @@ export function parseSessionId(sessionId: string): SessionIdParts | null {
  * Verify that `sessionId` was created for the given tenant + user.
  * Returns `false` for malformed IDs or mismatched ownership.
  */
-export function validateSessionOwnership(
-  sessionId: string,
-  tenantId: string,
-  userId: string | number
-): boolean {
+export function validateSessionOwnership(sessionId: string, tenantId: string, userId: string | number): boolean {
   const parsed = parseSessionId(sessionId)
   if (!parsed) return false
   return parsed.tenantId === tenantId && parsed.userId === String(userId)

--- a/packages/payload-agents-core/src/lib/session-id.ts
+++ b/packages/payload-agents-core/src/lib/session-id.ts
@@ -1,0 +1,47 @@
+/**
+ * Session ID ownership — creation, parsing, and validation.
+ *
+ * Format: `{agentSlug}:{tenantId}:{userId}:{uuid}`
+ *
+ * All segments are colon-free by convention (slugs are kebab-case,
+ * tenant/user IDs are numeric or 'default', UUIDs use hyphens).
+ * Ownership is verified by matching the embedded tenantId + userId
+ * against the authenticated user.
+ */
+
+export interface SessionIdParts {
+  agentSlug: string
+  tenantId: string
+  userId: string
+  uuid: string
+}
+
+const SEGMENT_COUNT = 4
+
+/** Build a new session ID with a random UUID. */
+export function createSessionId(agentSlug: string, tenantId: string, userId: string | number): string {
+  return `${agentSlug}:${tenantId}:${userId}:${crypto.randomUUID()}`
+}
+
+/** Decompose a session ID into its segments, or `null` if malformed. */
+export function parseSessionId(sessionId: string): SessionIdParts | null {
+  const segments = sessionId.split(':')
+  if (segments.length !== SEGMENT_COUNT) return null
+  const [agentSlug, tenantId, userId, uuid] = segments as [string, string, string, string]
+  if (!agentSlug || !tenantId || !userId || !uuid) return null
+  return { agentSlug, tenantId, userId, uuid }
+}
+
+/**
+ * Verify that `sessionId` was created for the given tenant + user.
+ * Returns `false` for malformed IDs or mismatched ownership.
+ */
+export function validateSessionOwnership(
+  sessionId: string,
+  tenantId: string,
+  userId: string | number
+): boolean {
+  const parsed = parseSessionId(sessionId)
+  if (!parsed) return false
+  return parsed.tenantId === tenantId && parsed.userId === String(userId)
+}


### PR DESCRIPTION
## Summary

- Add `lib/session-id.ts` module that centralises session ID creation, parsing, and ownership validation
- Validate `chatId` in POST `/chat` — reject with 403 if embedded tenantId/userId don't match the authenticated user
- Validate `conversationId` in GET/PATCH/DELETE `/session` — extract tenantId (previously missing) and reject with 403 on mismatch
- Export `createSessionId`, `parseSessionId`, `validateSessionOwnership` and `SessionIdParts` from the package
- Fix pre-existing lint issues (unused `originalDoc` param, import ordering)

Session ID format: `{agentSlug}:{tenantId}:{userId}:{uuid}`. An attacker cannot forge an ID that passes validation **and** targets another user.

Closes Zetesis-Labs/ZetesisPortal#147
Closes Zetesis-Labs/ZetesisPortal#148

## Test plan

- [ ] POST `/chat` with `chatId` belonging to another user → 403
- [ ] GET/PATCH/DELETE `/session?conversationId=...` with another user's session → 403
- [ ] POST `/chat` without `chatId` → new session created normally
- [ ] POST `/chat` with own valid `chatId` → continue existing session
- [ ] `pnpm lint && pnpm --filter @zetesis/payload-agents-core build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)