### PR TITLE
fix: authenticate all runtime requests with X-Internal-Secret

### DIFF
--- a/.changeset/fix-runtime-internal-auth.md
+++ b/.changeset/fix-runtime-internal-auth.md
@@ -1,0 +1,5 @@
+---
+"@zetesis/payload-agents-core": patch
+---
+
+Add X-Internal-Secret authentication to all runtime requests. Previously only the reload endpoint was authenticated; now all proxy calls (chat, sessions) include the header and the Python runtime rejects unauthenticated requests.

--- a/packages/payload-agents-core/src/endpoints/chat.ts
+++ b/packages/payload-agents-core/src/endpoints/chat.ts
@@ -10,7 +10,7 @@
  */
 
 import type { PayloadHandler, Where } from 'payload'
-import { reloadAgents } from '../lib/runtime-client'
+import { reloadAgents, runtimeFetch } from '../lib/runtime-client'
 import { createSessionId, validateSessionOwnership } from '../lib/session-id'
 import { translateAgnoStream } from '../lib/sse-translator'
 import { getTokenUsage } from '../lib/token-usage'
@@ -143,7 +143,7 @@ export function createChatHandler(config: ResolvedPluginConfig): PayloadHandler 
     const upstreamUrl = `${config.runtimeUrl}/agents/${encodeURIComponent(agentSlugValue)}/runs`
 
     const callRuntime = () =>
-      fetch(upstreamUrl, {
+      runtimeFetch(upstreamUrl, config.runtimeSecret, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({

--- a/packages/payload-agents-core/src/endpoints/session.ts
+++ b/packages/payload-agents-core/src/endpoints/session.ts
@@ -8,6 +8,7 @@
  */
 
 import type { PayloadHandler } from 'payload'
+import { runtimeFetch } from '../lib/runtime-client'
 import { validateSessionOwnership } from '../lib/session-id'
 import { dedupSources, extractSources } from '../lib/sources'
 import type { ResolvedPluginConfig, Source } from '../types'
@@ -144,16 +145,17 @@ function extractMessagesFromRuns(runs: Array<{ messages?: AgnoMessage[] }>): Agn
 /** Fetch session detail + runs and return a formatted response body. */
 async function fetchSessionDetail(
   runtimeUrl: string,
+  runtimeSecret: string,
   sessionId: string,
   userId: string | number
 ): Promise<Record<string, unknown> | null> {
   const encodedId = encodeURIComponent(sessionId)
   const params = new URLSearchParams({ type: 'agent', user_id: String(userId) })
   const [sessionRes, runsRes] = await Promise.all([
-    fetch(`${runtimeUrl}/sessions/${encodedId}?${params}`, {
+    runtimeFetch(`${runtimeUrl}/sessions/${encodedId}?${params}`, runtimeSecret, {
       signal: AbortSignal.timeout(5_000)
     }),
-    fetch(`${runtimeUrl}/sessions/${encodedId}/runs?${params}`, {
+    runtimeFetch(`${runtimeUrl}/sessions/${encodedId}/runs?${params}`, runtimeSecret, {
       signal: AbortSignal.timeout(5_000)
     })
   ])
@@ -190,12 +192,12 @@ export function createSessionGetHandler(config: ResolvedPluginConfig): PayloadHa
         if (!validateSessionOwnership(conversationId, tenantId, userId)) {
           return Response.json({ error: 'Forbidden' }, { status: 403 })
         }
-        const detail = await fetchSessionDetail(config.runtimeUrl, conversationId, userId)
+        const detail = await fetchSessionDetail(config.runtimeUrl, config.runtimeSecret, conversationId, userId)
         return detail ? Response.json(detail) : Response.json(null, { status: 404 })
       }
 
       if (isActive) {
-        return await handleActiveSession(config.runtimeUrl, tenantId, userId)
+        return await handleActiveSession(config.runtimeUrl, config.runtimeSecret, tenantId, userId)
       }
 
       return Response.json(null, { status: 400 })
@@ -206,7 +208,12 @@ export function createSessionGetHandler(config: ResolvedPluginConfig): PayloadHa
   }
 }
 
-async function handleActiveSession(runtimeUrl: string, tenantId: string, userId: string | number): Promise<Response> {
+async function handleActiveSession(
+  runtimeUrl: string,
+  runtimeSecret: string,
+  tenantId: string,
+  userId: string | number
+): Promise<Response> {
   const params = new URLSearchParams({
     type: 'agent',
     user_id: String(userId),
@@ -214,7 +221,7 @@ async function handleActiveSession(runtimeUrl: string, tenantId: string, userId:
     sort_order: 'desc',
     limit: '10'
   })
-  const listRes = await fetch(`${runtimeUrl}/sessions?${params}`, {
+  const listRes = await runtimeFetch(`${runtimeUrl}/sessions?${params}`, runtimeSecret, {
     signal: AbortSignal.timeout(5_000)
   })
   if (!listRes.ok) return Response.json(null)
@@ -223,7 +230,7 @@ async function handleActiveSession(runtimeUrl: string, tenantId: string, userId:
   const match = (listBody.data || []).find(s => validateSessionOwnership(s.session_id, tenantId, userId))
   if (!match) return Response.json(null)
 
-  const detail = await fetchSessionDetail(runtimeUrl, match.session_id, userId)
+  const detail = await fetchSessionDetail(runtimeUrl, runtimeSecret, match.session_id, userId)
   return detail ? Response.json(detail) : Response.json(null)
 }
 
@@ -259,8 +266,9 @@ export function createSessionPatchHandler(config: ResolvedPluginConfig): Payload
 
     try {
       const renameParams = new URLSearchParams({ type: 'agent', user_id: String(userId) })
-      const res = await fetch(
+      const res = await runtimeFetch(
         `${config.runtimeUrl}/sessions/${encodeURIComponent(conversationId)}/rename?${renameParams}`,
+        config.runtimeSecret,
         {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
@@ -301,10 +309,14 @@ export function createSessionDeleteHandler(config: ResolvedPluginConfig): Payloa
 
     try {
       const deleteParams = new URLSearchParams({ type: 'agent', user_id: String(userId) })
-      const res = await fetch(`${config.runtimeUrl}/sessions/${encodeURIComponent(conversationId)}?${deleteParams}`, {
-        method: 'DELETE',
-        signal: AbortSignal.timeout(5_000)
-      })
+      const res = await runtimeFetch(
+        `${config.runtimeUrl}/sessions/${encodeURIComponent(conversationId)}?${deleteParams}`,
+        config.runtimeSecret,
+        {
+          method: 'DELETE',
+          signal: AbortSignal.timeout(5_000)
+        }
+      )
       if (!res.ok) {
         return Response.json({ error: 'Delete failed' }, { status: res.status })
       }

--- a/packages/payload-agents-core/src/endpoints/sessions.ts
+++ b/packages/payload-agents-core/src/endpoints/sessions.ts
@@ -5,6 +5,7 @@
  */
 
 import type { PayloadHandler } from 'payload'
+import { runtimeFetch } from '../lib/runtime-client'
 import type { ResolvedPluginConfig } from '../types'
 
 export function createSessionsListHandler(config: ResolvedPluginConfig): PayloadHandler {
@@ -31,7 +32,7 @@ export function createSessionsListHandler(config: ResolvedPluginConfig): Payload
     }
 
     try {
-      const res = await fetch(`${config.runtimeUrl}/sessions?${params}`, {
+      const res = await runtimeFetch(`${config.runtimeUrl}/sessions?${params}`, config.runtimeSecret, {
         signal: AbortSignal.timeout(5_000)
       })
 

--- a/packages/payload-agents-core/src/index.ts
+++ b/packages/payload-agents-core/src/index.ts
@@ -1,7 +1,7 @@
 // Plugin
 
 export { decrypt, encrypt, isEncrypted } from './lib/encryption'
-export { reloadAgents } from './lib/runtime-client'
+export { reloadAgents, runtimeFetch } from './lib/runtime-client'
 export type { SessionIdParts } from './lib/session-id'
 export { createSessionId, parseSessionId, validateSessionOwnership } from './lib/session-id'
 // Utilities (for advanced consumers)

--- a/packages/payload-agents-core/src/lib/runtime-client.ts
+++ b/packages/payload-agents-core/src/lib/runtime-client.ts
@@ -1,25 +1,32 @@
 /**
  * Agent Runtime HTTP client.
  *
- * Thin wrapper around the internal HTTP API exposed by the Python
- * agent-runtime service. Used by Payload hooks to tell the runtime
- * to refresh its in-memory agent registry.
+ * All requests to the runtime include the `X-Internal-Secret` header
+ * so the runtime can verify the caller is trusted.
  */
 
 import type { ReloadResult } from '../types'
 
 const RELOAD_TIMEOUT_MS = 5_000
 
+/**
+ * Authenticated fetch to the agent-runtime.
+ * Merges the `X-Internal-Secret` header into whatever headers the
+ * caller provides.
+ */
+export function runtimeFetch(url: string, runtimeSecret: string, init?: RequestInit): Promise<Response> {
+  const headers = new Headers(init?.headers)
+  headers.set('X-Internal-Secret', runtimeSecret)
+  return fetch(url, { ...init, headers })
+}
+
 export async function reloadAgents(runtimeUrl: string, runtimeSecret: string): Promise<ReloadResult | null> {
   const url = `${runtimeUrl}/internal/agents/reload`
 
   try {
-    const res = await fetch(url, {
+    const res = await runtimeFetch(url, runtimeSecret, {
       method: 'POST',
-      headers: {
-        'X-Internal-Secret': runtimeSecret,
-        'Content-Type': 'application/json'
-      },
+      headers: { 'Content-Type': 'application/json' },
       signal: AbortSignal.timeout(RELOAD_TIMEOUT_MS)
     })
 

--- a/services/agent-runtime/agent_runtime/main.py
+++ b/services/agent-runtime/agent_runtime/main.py
@@ -37,7 +37,7 @@ from agent_runtime.exceptions import (
 )
 from agent_runtime.health import router as health_router
 from agent_runtime.logging import configure_logging, get_logger
-from agent_runtime.middleware import RequestIdMiddleware
+from agent_runtime.middleware import InternalAuthMiddleware, RequestIdMiddleware
 from agent_runtime.registry import AgentRegistry
 from agent_runtime.schemas import ErrorResponse, ReloadResponse
 
@@ -105,6 +105,7 @@ agent_os = AgentOS(
 
 app = agent_os.get_app()
 app.add_middleware(RequestIdMiddleware)
+app.add_middleware(InternalAuthMiddleware, secret=settings.internal_secret)
 app.add_exception_handler(AgentRuntimeError, agent_runtime_exception_handler)  # type: ignore[arg-type]
 app.include_router(health_router)
 

--- a/services/agent-runtime/agent_runtime/middleware.py
+++ b/services/agent-runtime/agent_runtime/middleware.py
@@ -1,7 +1,13 @@
-"""Request correlation ID middleware (pure ASGI — safe for SSE streaming)."""
+"""ASGI middlewares (pure ASGI — safe for SSE streaming).
+
+- ``RequestIdMiddleware``: propagates ``X-Request-ID`` via contextvars.
+- ``InternalAuthMiddleware``: validates ``X-Internal-Secret`` on all
+  routes except health probes and docs.
+"""
 
 from __future__ import annotations
 
+import hmac
 import uuid
 from contextvars import ContextVar
 
@@ -37,3 +43,50 @@ class RequestIdMiddleware:
             await send(message)
 
         await self.app(scope, receive, send_with_rid)
+
+
+# Paths that must remain unauthenticated (health probes, OpenAPI docs).
+_PUBLIC_PATHS = frozenset({"/health", "/ready", "/docs", "/openapi.json"})
+
+
+class InternalAuthMiddleware:
+    """Reject requests without a valid ``X-Internal-Secret`` header.
+
+    Health and docs endpoints are excluded so that Kubernetes probes
+    and Swagger UI keep working without credentials.
+    """
+
+    def __init__(self, app: ASGIApp, *, secret: str) -> None:
+        self.app = app
+        self._secret = secret
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope.get("path", "")
+        if path in _PUBLIC_PATHS:
+            await self.app(scope, receive, send)
+            return
+
+        headers = dict(scope.get("headers", []))
+        token = headers.get(b"x-internal-secret", b"").decode()
+
+        if not hmac.compare_digest(token, self._secret):
+            await _send_401(send)
+            return
+
+        await self.app(scope, receive, send)
+
+
+async def _send_401(send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 401,
+            "headers": [(b"content-type", b"application/json")],
+        }
+    )
+    await send({"type": "http.response.body", "body": b'{"error":"Unauthorized"}'})
+


### PR DESCRIPTION
## Summary

- **TypeScript**: Add `runtimeFetch()` helper to `runtime-client.ts` that always includes `X-Internal-Secret`. Replace all bare `fetch()` calls to the runtime in chat, session, and sessions endpoints.
- **Python**: Add `InternalAuthMiddleware` (ASGI) that validates `X-Internal-Secret` on all routes except health probes and docs. Registered on the FastAPI app alongside the existing `RequestIdMiddleware`.

Uses the existing `INTERNAL_SECRET` env var — no new secrets needed.

Closes Zetesis-Labs/ZetesisPortal#149

## Test plan

- [ ] Call any AgentOS endpoint without `X-Internal-Secret` header → 401
- [ ] Call `/health` and `/ready` without header → 200 (excluded from auth)
- [ ] Chat flow through the Payload proxy works end-to-end (header injected automatically)
- [ ] Session CRUD through the proxy works end-to-end
- [ ] `pnpm lint && pnpm --filter @zetesis/payload-agents-core build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
