### PR TITLE
fix(payload-agents-core): cap sessions list limit to 100

### DIFF
--- a/.changeset/fix-sessions-limit-cap.md
+++ b/.changeset/fix-sessions-limit-cap.md
@@ -1,0 +1,5 @@
+---
+"@zetesis/payload-agents-core": patch
+---
+
+Cap the `limit` query parameter on the sessions list endpoint to a maximum of 100, preventing unbounded upstream queries.

--- a/packages/payload-agents-core/src/endpoints/sessions.ts
+++ b/packages/payload-agents-core/src/endpoints/sessions.ts
@@ -23,7 +23,7 @@ export function createSessionsListHandler(config: ResolvedPluginConfig): Payload
       user_id: String(userId),
       sort_by: 'updated_at',
       sort_order: 'desc',
-      limit: url.searchParams.get('limit') || '20',
+      limit: String(Math.min(Math.max(1, Number(url.searchParams.get('limit')) || 20), 100)),
       page: url.searchParams.get('page') || '1'
     })
     if (agentSlug) {


### PR DESCRIPTION
## Summary

Parse the user-provided `limit` query parameter as an integer, clamp to `[1, 100]`, default to 20. Prevents unbounded session list queries.

Closes Zetesis-Labs/ZetesisPortal#155

## Test plan

- [ ] `GET /sessions?limit=999999` → uses limit=100
- [ ] `GET /sessions?limit=-1` → uses limit=1
- [ ] `GET /sessions?limit=abc` → uses limit=20 (default)
- [ ] `GET /sessions` → uses limit=20 (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
