### PR TITLE
fix(payload-agents-core): pre-deploy hardening (runtimeSecret warning + token estimate)

### DIFF
--- a/.changeset/pre-deploy-hardening.md
+++ b/.changeset/pre-deploy-hardening.md
@@ -1,0 +1,5 @@
+---
+"@zetesis/payload-agents-core": patch
+---
+
+Warn on empty runtimeSecret at plugin init. Use conservative token estimate (message/3 + 2000 overhead) instead of message/4.

--- a/packages/payload-agents-core/src/endpoints/chat.ts
+++ b/packages/payload-agents-core/src/endpoints/chat.ts
@@ -118,7 +118,9 @@ export function createChatHandler(config: ResolvedPluginConfig): PayloadHandler 
     // ── Token budget ────────────────────────────────────────────────────
     const userId = (user as unknown as { id: string | number }).id
     const usage = await getTokenUsage(payload, userId, config.getDailyLimit)
-    const estimated = Math.ceil(message.length / 4)
+    // Conservative estimate: user message tokens + fixed overhead for
+    // system prompt, RAG context, tool calls, and model output.
+    const estimated = Math.ceil(message.length / 3) + 2000
     if (!usage.canUse(estimated)) {
       return Response.json(
         {

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -14,9 +14,13 @@ import type { AgentPluginConfig, ResolvedPluginConfig } from './types'
 import { defaultExtractTenantId } from './utils/extract-tenant'
 
 function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
+  const runtimeSecret = userConfig.runtimeSecret ?? ''
+  if (!runtimeSecret) {
+    console.warn('[agent-plugin] runtimeSecret is empty — all runtime requests will be unauthenticated')
+  }
   return {
     runtimeUrl: userConfig.runtimeUrl,
-    runtimeSecret: userConfig.runtimeSecret ?? '',
+    runtimeSecret,
     getDailyLimit: userConfig.getDailyLimit,
     extractTenantId: userConfig.extractTenantId ?? defaultExtractTenantId,
     collectionSlug: userConfig.collectionSlug ?? 'agents',


### PR DESCRIPTION
## Summary

- Warn on empty `runtimeSecret` at plugin init (#153)
- Conservative token estimate: `message.length/3 + 2000` overhead instead of `message.length/4` (#156)

Closes Zetesis-Labs/ZetesisPortal#153
Closes Zetesis-Labs/ZetesisPortal#156

## Test plan

- [ ] Start the app without `INTERNAL_SECRET` → warning in logs
- [ ] Send a chat message near the token limit → more conservative gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
