### PR TITLE
fix(payload-agents-core): read active tenant from cookie

### DIFF
--- a/.changeset/fix-extract-tenant-cookie.md
+++ b/.changeset/fix-extract-tenant-cookie.md
@@ -1,5 +1,5 @@
 ---
-"@zetesis/payload-agents-core": minor
+"@zetesis/payload-agents-core": patch
 ---
 
 Read active tenant from payload-tenant cookie instead of always using the first tenant in the user's array. Fixes agents not appearing for multi-tenant users.

--- a/.changeset/fix-extract-tenant-cookie.md
+++ b/.changeset/fix-extract-tenant-cookie.md
@@ -1,0 +1,5 @@
+---
+"@zetesis/payload-agents-core": minor
+---
+
+Read active tenant from payload-tenant cookie instead of always using the first tenant in the user's array. Fixes agents not appearing for multi-tenant users.

--- a/packages/payload-agents-core/src/endpoints/agents-list.ts
+++ b/packages/payload-agents-core/src/endpoints/agents-list.ts
@@ -22,7 +22,7 @@ export function createAgentsListHandler(config: ResolvedPluginConfig): PayloadHa
       return Response.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>, req)
     const where: Where = { isActive: { equals: true } }
     if (tenantId !== 'default') {
       where.tenant = { equals: tenantId }

--- a/packages/payload-agents-core/src/endpoints/chat.ts
+++ b/packages/payload-agents-core/src/endpoints/chat.ts
@@ -93,7 +93,7 @@ export function createChatHandler(config: ResolvedPluginConfig): PayloadHandler 
     }
 
     // ── Load agent from Payload ─────────────────────────────────────────
-    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>, req)
     const where: Where = { isActive: { equals: true } }
 
     if (tenantId !== 'default') {

--- a/packages/payload-agents-core/src/endpoints/session.ts
+++ b/packages/payload-agents-core/src/endpoints/session.ts
@@ -182,7 +182,7 @@ export function createSessionGetHandler(config: ResolvedPluginConfig): PayloadHa
     }
 
     const userId = (user as unknown as { id: string | number }).id
-    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>, req)
     const url = new URL(req.url || '', 'http://localhost')
     const conversationId = url.searchParams.get('conversationId')
     const isActive = url.searchParams.get('active') === 'true'
@@ -244,7 +244,7 @@ export function createSessionPatchHandler(config: ResolvedPluginConfig): Payload
     }
 
     const userId = (user as unknown as { id: string | number }).id
-    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>, req)
     const url = new URL(req.url || '', 'http://localhost')
     const conversationId = url.searchParams.get('conversationId')
     if (!conversationId) {
@@ -297,7 +297,7 @@ export function createSessionDeleteHandler(config: ResolvedPluginConfig): Payloa
     }
 
     const userId = (user as unknown as { id: string | number }).id
-    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>)
+    const tenantId = config.extractTenantId(user as unknown as Record<string, unknown>, req)
     const url = new URL(req.url || '', 'http://localhost')
     const conversationId = url.searchParams.get('conversationId')
     if (!conversationId) {

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -31,10 +31,16 @@ export interface AgentPluginConfig {
   getDailyLimit: (payload: Payload, userId: string | number) => Promise<number>
 
   /**
-   * Extract a tenant identifier from the authenticated Payload user.
-   * Defaults to `'default'` when not provided.
+   * Extract the active tenant identifier from the authenticated user.
+   *
+   * The default reads the `payload-tenant` cookie from the request
+   * (set by the multi-tenant plugin), falling back to the first tenant
+   * in the user's `tenants` array.
    */
-  extractTenantId?: (user: Record<string, unknown>) => string
+  extractTenantId?: (
+    user: Record<string, unknown>,
+    req: { headers: { get: (name: string) => string | null } }
+  ) => string
 
   /**
    * Override the Payload collection slug. Default: `'agents'`.
@@ -131,7 +137,7 @@ export interface ResolvedPluginConfig {
   runtimeUrl: string
   runtimeSecret: string
   getDailyLimit: (payload: Payload, userId: string | number) => Promise<number>
-  extractTenantId: (user: Record<string, unknown>) => string
+  extractTenantId: (user: Record<string, unknown>, req: { headers: { get: (name: string) => string | null } }) => string
   collectionSlug: string
   basePath: string
   encryptionKey: string | undefined

--- a/packages/payload-agents-core/src/utils/extract-tenant.ts
+++ b/packages/payload-agents-core/src/utils/extract-tenant.ts
@@ -1,11 +1,19 @@
 /**
- * Default tenant extraction from a Payload user object.
+ * Default tenant extraction from a Payload request.
  *
- * Users have a `tenants` array field via the multi-tenant plugin;
- * each entry is `{ tenant: number | { id: number } }`.
- * We take the first one; fallback to `'default'` for users without tenants.
+ * 1. Reads the `payload-tenant` cookie set by the multi-tenant plugin
+ *    (this is the tenant the user actively selected in the UI).
+ * 2. Falls back to the first entry in the user's `tenants` array.
+ * 3. Returns `'default'` for users without tenants.
  */
-export function defaultExtractTenantId(user: Record<string, unknown>): string {
+export function defaultExtractTenantId(
+  user: Record<string, unknown>,
+  req: { headers: { get: (name: string) => string | null } }
+): string {
+  const cookieHeader = req.headers.get('cookie') ?? ''
+  const match = cookieHeader.match(/(?:^|;\s*)payload-tenant=(\d+)/)
+  if (match?.[1]) return match[1]
+
   const tenants = user.tenants as Array<{ tenant: number | { id: number } }> | undefined | null
   if (!tenants?.[0]) return 'default'
   const t = tenants[0].tenant


### PR DESCRIPTION
## Summary

`extractTenantId` now reads the `payload-tenant` cookie from the request instead of always taking the first tenant from the user's array. Falls back to the array if the cookie is not present.

Breaks the `extractTenantId` signature: `(user) => string` → `(user, req) => string`.

Closes Zetesis-Labs/ZetesisPortal#182

## Test plan

- [ ] Multi-tenant user with `payload-tenant=2` cookie → agents from tenant 2 returned
- [ ] Single-tenant user without cookie → falls back to first tenant
- [ ] `pnpm lint && pnpm --filter @zetesis/payload-agents-core build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
