### PR TITLE
fix(payload-agents-core): pass req to extractTenantId

### DIFF
--- a/.changeset/extract-tenant-id-with-req.md
+++ b/.changeset/extract-tenant-id-with-req.md
@@ -1,0 +1,33 @@
+---
+'@zetesis/payload-agents-core': patch
+---
+
+`multiTenantSessionStrategy`: `extractTenantId` now receives `(user, req)` instead of `(user)`.
+
+The previous signature couldn't read request state (cookies, headers, subdomain), which made the helper unable to reflect a cookie-driven active tenant — it would silently fall back to `user.tenants[0]` and tag sessions with the wrong tenant.
+
+**Migration** — add the `req` parameter to your extractor. If you only need the user object, just ignore `req`:
+
+```ts
+// before
+multiTenantSessionStrategy({
+  extractTenantId: user => user.tenants?.[0]?.tenant
+})
+
+// after
+multiTenantSessionStrategy({
+  extractTenantId: (user, req) => user.tenants?.[0]?.tenant
+})
+```
+
+Apps that resolve the active tenant from the `payload-tenant` cookie can now do so directly:
+
+```ts
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
+
+multiTenantSessionStrategy({
+  extractTenantId: (user, req) =>
+    getTenantFromCookie(req.headers, req.payload.db.defaultIDType) ??
+    (user.tenants as Array<{ tenant: number | { id: number } }> | undefined)?.[0]?.tenant
+})
+```

--- a/packages/payload-agents-core/src/lib/multi-tenant.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.ts
@@ -11,16 +11,22 @@
  * such a plugin, add the filter yourself via `collectionOverrides`.
  */
 
+import type { PayloadRequest } from 'payload'
 import type { BuildSessionId, ValidateSessionOwnership } from '../types'
 
 export interface MultiTenantSessionStrategyOptions {
   /**
-   * Extract the tenant id from the authenticated Payload user.
+   * Resolve the tenant id for the current request.
+   *
+   * Receives the authenticated Payload user and the current `PayloadRequest`,
+   * so consumers can read the active tenant from whatever source their app
+   * uses (cookie, header, subdomain…) instead of being restricted to the
+   * user object.
    *
    * Return `undefined` (or a falsy value) for users without a tenant —
    * sessions will fall back to `'default'`.
    */
-  extractTenantId: (user: Record<string, unknown>) => string | number | undefined | null
+  extractTenantId: (user: Record<string, unknown>, req: PayloadRequest) => string | number | undefined | null
 }
 
 export interface MultiTenantSessionStrategy {
@@ -39,14 +45,12 @@ export interface MultiTenantSessionStrategy {
  * @example
  * ```ts
  * import { agentPlugin, multiTenantSessionStrategy } from '@zetesis/payload-agents-core'
+ * import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
  *
  * const { buildSessionId, validateSessionOwnership } = multiTenantSessionStrategy({
- *   extractTenantId: user => {
- *     const tenants = user.tenants as Array<{ tenant: number | { id: number } }> | undefined
- *     if (!tenants?.[0]) return undefined
- *     const t = tenants[0].tenant
- *     return typeof t === 'object' && t !== null ? t.id : t
- *   }
+ *   extractTenantId: (user, req) =>
+ *     getTenantFromCookie(req.headers, req.payload.db.defaultIDType) ??
+ *     (user.tenants as Array<{ tenant: number | { id: number } }> | undefined)?.[0]?.tenant
  * })
  *
  * agentPlugin({
@@ -57,20 +61,20 @@ export interface MultiTenantSessionStrategy {
  * ```
  */
 export function multiTenantSessionStrategy(options: MultiTenantSessionStrategyOptions): MultiTenantSessionStrategy {
-  const resolveTenant = (user: Record<string, unknown>): string => {
-    const value = options.extractTenantId(user)
+  const resolveTenant = (user: Record<string, unknown>, req: PayloadRequest): string => {
+    const value = options.extractTenantId(user, req)
     return value === undefined || value === null || value === '' ? 'default' : String(value)
   }
 
-  const buildSessionId: BuildSessionId = ({ user, agentSlug, chatId }) => {
+  const buildSessionId: BuildSessionId = ({ user, agentSlug, chatId, req }) => {
     if (chatId) return chatId
-    const tenantId = resolveTenant(user)
+    const tenantId = resolveTenant(user, req)
     const userId = String((user as { id?: string | number }).id ?? 'anonymous')
     return `${agentSlug}:${tenantId}:${userId}:${crypto.randomUUID()}`
   }
 
-  const validateSessionOwnership: ValidateSessionOwnership = (sessionId, { user }) => {
-    const tenantId = resolveTenant(user)
+  const validateSessionOwnership: ValidateSessionOwnership = (sessionId, { user, req }) => {
+    const tenantId = resolveTenant(user, req)
     const userId = String((user as { id?: string | number }).id ?? '')
     if (!userId) return false
     return sessionId.includes(`:${tenantId}:${userId}:`)


### PR DESCRIPTION
## Summary

- `multiTenantSessionStrategy`'s `extractTenantId` now receives `(user, req)` instead of just `(user)`, so consumers can resolve the active tenant from request state (cookie, header, subdomain) and not be restricted to picking it from the user object.
- Updates the docstring example to show the cookie-driven pattern using `getTenantFromCookie` from `@payloadcms/plugin-multi-tenant/utilities`.
- Existing extractors that ignore the new `req` parameter remain assignable to the new type, so the API change is non-breaking at the type level — released as a `patch`.

## Motivation

Caught while triaging Zetesis-Labs/ZetesisPortal#182: in multi-tenant apps the session id was tagged with `user.tenants[0]` regardless of the cookie-selected tenant, because the helper had no way to read request state. With `req` in scope, an app can return whatever tenant id its frontend is currently acting on.

## Test plan

- [ ] `pnpm --filter @zetesis/payload-agents-core build`
- [ ] `pnpm lint`
- [ ] `pnpm tsc --noEmit`
- [ ] Verify a downstream extractor with `(user) => …` still typechecks against the new signature.
- [ ] Verify `(user, req) => getTenantFromCookie(req.headers, …)` returns the active tenant in the consumer app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/20" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
