### PR TITLE
fix(runtime): fan out agent reloads via Postgres LISTEN/NOTIFY

### DIFF
--- a/.changeset/drop-reload-http-client.md
+++ b/.changeset/drop-reload-http-client.md
@@ -1,0 +1,14 @@
+---
+'@zetesis/payload-agents-core': minor
+---
+
+Drop `reloadAgents` client and the chat endpoint's self-heal retry.
+
+The helper only reached a single replica via the K8s Service round-robin; the chat endpoint used it as a best-effort retry when the runtime returned 404 for an unknown slug. With the Agents collection hooks now broadcasting reloads via Postgres `NOTIFY agent_reload` (plus the 5-minute periodic resync), every replica stays fresh and the retry dance was solving a problem that no longer exists.
+
+Removed:
+
+- `reloadAgents(runtimeUrl, runtimeSecret)` client function and its `ReloadResult` type.
+- `callWithRetry` / `retryAfterReload` internals in the chat endpoint (replaced by `callRuntimeOnce`).
+
+`runtimeFetch` stays — still used by the chat endpoint to reach `/agents/{slug}/runs`. The runtime's `POST /internal/agents/reload` HTTP endpoint is also kept for manual `curl` debugging.

--- a/.changeset/extract-tenant-id-with-req.md
+++ b/.changeset/extract-tenant-id-with-req.md
@@ -1,0 +1,33 @@
+---
+'@zetesis/payload-agents-core': patch
+---
+
+`multiTenantSessionStrategy`: `extractTenantId` now receives `(user, req)` instead of `(user)`.
+
+The previous signature couldn't read request state (cookies, headers, subdomain), which made the helper unable to reflect a cookie-driven active tenant — it would silently fall back to `user.tenants[0]` and tag sessions with the wrong tenant.
+
+**Migration** — add the `req` parameter to your extractor. If you only need the user object, just ignore `req`:
+
+```ts
+// before
+multiTenantSessionStrategy({
+  extractTenantId: user => user.tenants?.[0]?.tenant
+})
+
+// after
+multiTenantSessionStrategy({
+  extractTenantId: (user, req) => user.tenants?.[0]?.tenant
+})
+```
+
+Apps that resolve the active tenant from the `payload-tenant` cookie can now do so directly:
+
+```ts
+import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
+
+multiTenantSessionStrategy({
+  extractTenantId: (user, req) =>
+    getTenantFromCookie(req.headers, req.payload.db.defaultIDType) ??
+    (user.tenants as Array<{ tenant: number | { id: number } }> | undefined)?.[0]?.tenant
+})
+```

--- a/.changeset/indexer-outage-status.md
+++ b/.changeset/indexer-outage-status.md
@@ -1,0 +1,17 @@
+---
+'@zetesis/payload-indexer': patch
+---
+
+Distinguish "not indexed" from "lookup failed" in `checkBatchSyncStatus`.
+
+Previously, when Typesense was down or the adapter lacked
+`searchDocumentsByFilter`, every document in the batch came back as
+`'not-indexed'` — so the admin list view implied the index was empty
+instead of surfacing the outage.
+
+`getIndexedHashes` now returns a lookup shape with three distinct states
+(`hashes` / `errored` / `adapterUnsupported`). `checkBatchSyncStatus` maps
+those to `status: 'error'` with a descriptive `error` string, matching
+what the single-document `checkSyncStatus` already returns.
+
+Closes Zetesis-Labs/ZetesisPortal#107.

--- a/.changeset/reload-via-listen-notify.md
+++ b/.changeset/reload-via-listen-notify.md
@@ -1,0 +1,9 @@
+---
+'@zetesis/payload-agents-core': patch
+---
+
+Fan out agent reloads to every runtime replica via Postgres `LISTEN/NOTIFY`.
+
+The Agents collection hooks used to `POST /internal/agents/reload` at the runtime Service, which K8s round-robins to a single pod — other replicas kept serving stale config until their next restart. Now `afterChange`/`afterDelete` issue `pg_notify('agent_reload', slug)` via Payload's drizzle handle and the runtime service listens on the channel, so every pod refreshes in lockstep.
+
+The HTTP `/internal/agents/reload` endpoint and the `reloadAgents` client helper stay for manual triggering and for the chat endpoint's best-effort self-heal retry — the fan-out bug only affected the automatic hook path.

--- a/.changeset/require-collection-slugs.md
+++ b/.changeset/require-collection-slugs.md
@@ -1,0 +1,20 @@
+---
+'@zetesis/payload-agents-core': minor
+---
+
+Make `mediaCollectionSlug` and `taxonomyCollectionSlug` required on `agentPlugin()`.
+
+The previous defaults (`'media'` and `'taxonomy'`) matched the conventions we use, but hid a footgun: if a consumer renamed either collection, the Agents' `avatar` upload and `taxonomies` relationship broke silently — no error at boot, just empty references on every write.
+
+Both fields are now required in `AgentPluginConfig`, and the plugin validates at registration time that each referenced slug is present in the Payload config, throwing with a clear `[agent-plugin] collection "…" referenced by …CollectionSlug is not registered` if you try to boot without them.
+
+**Migration** — set the slugs explicitly in your plugin config. If you were relying on the defaults the values stay the same:
+
+```ts
+agentPlugin({
+  runtimeUrl: '…',
+  mediaCollectionSlug: 'media',
+  taxonomyCollectionSlug: 'taxonomy',
+  // …
+})
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,29 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  agent-runtime:
+    name: Agent Runtime (Python)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: services/agent-runtime
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Install Python + dependencies
+        run: uv sync --frozen
+
+      - name: Lint (ruff)
+        run: uv run ruff check agent_runtime/
+
+      - name: Format check (ruff)
+        run: uv run ruff format --check agent_runtime/
+
+      - name: Type check (mypy)
+        run: uv run mypy agent_runtime/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,13 @@ jobs:
         run: uv sync --frozen
 
       - name: Lint (ruff)
-        run: uv run ruff check agent_runtime/
+        run: uv run ruff check .
 
       - name: Format check (ruff)
-        run: uv run ruff format --check agent_runtime/
+        run: uv run ruff format --check .
 
       - name: Type check (mypy)
         run: uv run mypy agent_runtime/
+
+      - name: Tests (pytest)
+        run: uv run pytest -q

--- a/packages/payload-agents-core/src/collections/hooks/reload-runtime.ts
+++ b/packages/payload-agents-core/src/collections/hooks/reload-runtime.ts
@@ -1,32 +1,50 @@
 /**
- * Hooks that tell the agent runtime to refresh its in-memory registry
- * after an Agent is created, updated, or deleted.
+ * Hooks that fan out an Agent change to every agent-runtime replica.
+ *
+ * Uses Postgres `NOTIFY agent_reload` instead of an HTTP call so the message
+ * reaches every pod listening on the channel — the previous HTTP approach hit
+ * a single replica via the K8s Service round-robin and left other replicas
+ * with stale config.
  *
  * Best-effort: failures are logged but not thrown — the runtime self-heals
  * on next restart via its FastAPI lifespan hook.
  */
 
-import type { CollectionAfterChangeHook, CollectionAfterDeleteHook } from 'payload'
-import { reloadAgents } from '../../lib/runtime-client'
+import { sql } from 'drizzle-orm'
+import type { CollectionAfterChangeHook, CollectionAfterDeleteHook, Payload } from 'payload'
 import type { ResolvedPluginConfig } from '../../types'
 
-export function createAfterChangeHook(config: ResolvedPluginConfig): CollectionAfterChangeHook {
-  return async ({ doc, operation }) => {
+const RELOAD_CHANNEL = 'agent_reload'
+
+type Drizzle = { execute: (q: ReturnType<typeof sql>) => Promise<unknown> }
+
+function getDrizzle(payload: Payload): Drizzle {
+  return (payload.db as unknown as { drizzle: Drizzle }).drizzle
+}
+
+async function notifyReload(payload: Payload, slug: string): Promise<void> {
+  try {
+    const drizzle = getDrizzle(payload)
+    await drizzle.execute(sql`SELECT pg_notify(${RELOAD_CHANNEL}, ${slug})`)
+  } catch (err) {
+    console.warn('[Agents] NOTIFY agent_reload failed:', err)
+  }
+}
+
+export function createAfterChangeHook(_config: ResolvedPluginConfig): CollectionAfterChangeHook {
+  return async ({ doc, operation, req }) => {
     const slug = (doc as Record<string, unknown>).slug as string
-    console.log(`[Agents] ${operation} → triggering agent-runtime reload for "${slug}"`)
-    const result = await reloadAgents(config.runtimeUrl, config.runtimeSecret)
-    if (result) {
-      console.log(`[Agents] runtime registry now holds ${result.count} agents`)
-    }
+    console.log(`[Agents] ${operation} → notifying agent-runtime to reload "${slug}"`)
+    await notifyReload(req.payload, slug)
     return doc
   }
 }
 
-export function createAfterDeleteHook(config: ResolvedPluginConfig): CollectionAfterDeleteHook {
-  return async ({ doc }) => {
+export function createAfterDeleteHook(_config: ResolvedPluginConfig): CollectionAfterDeleteHook {
+  return async ({ doc, req }) => {
     const slug = (doc as Record<string, unknown>).slug as string
-    console.log(`[Agents] delete → triggering agent-runtime reload (removed "${slug}")`)
-    await reloadAgents(config.runtimeUrl, config.runtimeSecret)
+    console.log(`[Agents] delete → notifying agent-runtime to reload (removed "${slug}")`)
+    await notifyReload(req.payload, slug)
     return doc
   }
 }

--- a/packages/payload-agents-core/src/endpoints/chat.ts
+++ b/packages/payload-agents-core/src/endpoints/chat.ts
@@ -10,7 +10,7 @@
  */
 
 import type { PayloadHandler, Where } from 'payload'
-import { reloadAgents, runtimeFetch } from '../lib/runtime-client'
+import { runtimeFetch } from '../lib/runtime-client'
 import { translateAgnoStream } from '../lib/sse-translator'
 import { getTokenUsage } from '../lib/token-usage'
 import type { ResolvedPluginConfig } from '../types'
@@ -24,52 +24,27 @@ interface ChatRequest {
 const SERVICE_UNAVAILABLE = { error: 'AI service temporarily unavailable' }
 
 /**
- * Attempt to call the runtime, retrying once after a reload if the first
- * attempt fails (network error or 4xx).
+ * Call the runtime once and surface failures directly.
+ *
+ * Previously tried a second time after firing an HTTP `/internal/agents/reload`
+ * at the Service, but that only reloaded one replica (round-robin) and the
+ * retry landed on whichever replica the LB picked — there was no guarantee
+ * it was the same one that just reloaded. With the collection hooks now
+ * broadcasting reloads via Postgres `NOTIFY agent_reload`, every replica
+ * stays fresh; the retry dance was solving a problem that no longer
+ * exists, so it's gone.
  */
-async function callWithRetry(
-  callRuntime: () => Promise<Response>,
-  runtimeUrl: string,
-  runtimeSecret: string
-): Promise<Response | null> {
-  let upstream: Response | undefined
-
+async function callRuntimeOnce(callRuntime: () => Promise<Response>): Promise<Response | null> {
   try {
-    upstream = await callRuntime()
+    const upstream = await callRuntime()
+    if (upstream.ok && upstream.body) return upstream
+    const text = await upstream.text().catch(() => '')
+    console.error(`[chat] agent-runtime returned ${upstream.status}: ${text}`)
+    return null
   } catch (err) {
-    console.error('[chat] agent-runtime fetch failed, attempting reload:', err)
-    return retryAfterReload(callRuntime, runtimeUrl, runtimeSecret)
+    console.error('[chat] agent-runtime fetch failed:', err)
+    return null
   }
-
-  if (upstream.ok && upstream.body) return upstream
-
-  if (upstream.status === 404) {
-    console.warn('[chat] agent-runtime returned 404 (agent not found), attempting reload')
-    return retryAfterReload(callRuntime, runtimeUrl, runtimeSecret)
-  }
-
-  const text = await upstream.text().catch(() => '')
-  console.error(`[chat] agent-runtime returned ${upstream.status}: ${text}`)
-  return null
-}
-
-async function retryAfterReload(
-  callRuntime: () => Promise<Response>,
-  runtimeUrl: string,
-  runtimeSecret: string
-): Promise<Response | null> {
-  const reloaded = await reloadAgents(runtimeUrl, runtimeSecret)
-  if (!reloaded || reloaded.count === 0) return null
-
-  try {
-    const retry = await callRuntime()
-    if (retry.ok && retry.body) return retry
-    const text = await retry.text().catch(() => '')
-    console.error(`[chat] agent-runtime returned ${retry.status} after reload: ${text}`)
-  } catch (retryErr) {
-    console.error('[chat] agent-runtime fetch failed after reload:', retryErr)
-  }
-  return null
 }
 
 export function createChatHandler(config: ResolvedPluginConfig): PayloadHandler {
@@ -161,7 +136,7 @@ export function createChatHandler(config: ResolvedPluginConfig): PayloadHandler 
         signal: AbortSignal.timeout(120_000)
       })
 
-    const upstream = await callWithRetry(callRuntime, config.runtimeUrl, config.runtimeSecret)
+    const upstream = await callRuntimeOnce(callRuntime)
     if (!upstream?.body) {
       return Response.json(SERVICE_UNAVAILABLE, { status: 503 })
     }

--- a/packages/payload-agents-core/src/index.ts
+++ b/packages/payload-agents-core/src/index.ts
@@ -6,7 +6,7 @@ export { costBreakdown, effectiveTokens, estimateRunCost } from './lib/cost-calc
 export { decrypt, encrypt, isEncrypted } from './lib/encryption'
 export type { MultiTenantSessionStrategy, MultiTenantSessionStrategyOptions } from './lib/multi-tenant'
 export { multiTenantSessionStrategy } from './lib/multi-tenant'
-export { reloadAgents, runtimeFetch } from './lib/runtime-client'
+export { runtimeFetch } from './lib/runtime-client'
 export { defaultBuildSessionId, defaultValidateSessionOwnership } from './lib/session-id'
 export { dedupSources, extractSources } from './lib/sources'
 export { translateAgnoStream } from './lib/sse-translator'
@@ -19,7 +19,6 @@ export type {
   BuildSessionIdContext,
   CollectionOverrides,
   DailyTokenUsage,
-  ReloadResult,
   ResolvedPluginConfig,
   Source,
   TokenUsageResult,

--- a/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
@@ -1,0 +1,101 @@
+import type { Payload, PayloadRequest } from 'payload'
+import { describe, expect, it } from 'vitest'
+import { multiTenantSessionStrategy } from './multi-tenant'
+
+/** Minimal stub of PayloadRequest — the strategy only reads whatever the
+ *  consumer's `extractTenantId` looks at, so we can stay small. */
+function makeReq(cookieTenantId: number | string | null, payloadDb?: Partial<Payload['db']>): PayloadRequest {
+  const headers = new Headers()
+  if (cookieTenantId !== null) headers.set('cookie', `payload-tenant=${cookieTenantId}`)
+  return {
+    headers,
+    payload: { db: { defaultIDType: 'number', ...payloadDb } }
+  } as unknown as PayloadRequest
+}
+
+/** Re-implements the consumer's extractor (apps/server/src/payload.config.ts):
+ *  read the `payload-tenant` cookie, fall back to `user.tenants[0]`. */
+function extractTenantLikeConsumer(user: Record<string, unknown>, req: PayloadRequest): string | number | undefined {
+  const cookie = req.headers.get('cookie') ?? ''
+  const match = cookie.match(/payload-tenant=(\d+)/)
+  if (match?.[1]) return Number(match[1])
+  const tenants = user.tenants as Array<{ tenant: number | { id: number } }> | undefined | null
+  if (!tenants?.[0]) return undefined
+  const t = tenants[0].tenant
+  return typeof t === 'object' && t !== null ? t.id : t
+}
+
+const strategy = multiTenantSessionStrategy({ extractTenantId: extractTenantLikeConsumer })
+
+const alice = { id: 42, tenants: [{ tenant: 1 }, { tenant: 2 }] }
+
+describe('multiTenantSessionStrategy — tenant-aware session ids', () => {
+  it('buildSessionId embeds the tenant from the cookie, not tenants[0]', async () => {
+    const req = makeReq(2)
+    const sessionId = await strategy.buildSessionId({
+      user: alice,
+      agentSlug: 'bastos',
+      payload: {} as Payload,
+      req
+    })
+    expect(sessionId.startsWith('bastos:2:42:')).toBe(true)
+  })
+
+  it('buildSessionId falls back to tenants[0] when no cookie is present', async () => {
+    const req = makeReq(null)
+    const sessionId = await strategy.buildSessionId({
+      user: alice,
+      agentSlug: 'bastos',
+      payload: {} as Payload,
+      req
+    })
+    expect(sessionId.startsWith('bastos:1:42:')).toBe(true)
+  })
+
+  it('buildSessionId passes through an existing chatId unchanged', async () => {
+    const sessionId = await strategy.buildSessionId({
+      user: alice,
+      agentSlug: 'bastos',
+      chatId: 'continuing-chat-abc',
+      payload: {} as Payload,
+      req: makeReq(2)
+    })
+    expect(sessionId).toBe('continuing-chat-abc')
+  })
+
+  it('validateSessionOwnership accepts sessions whose tenant matches the active cookie', async () => {
+    const ok = await strategy.validateSessionOwnership('bastos:2:42:some-uuid', {
+      user: alice,
+      payload: {} as Payload,
+      req: makeReq(2)
+    })
+    expect(ok).toBe(true)
+  })
+
+  it('validateSessionOwnership rejects sessions tagged with a different tenant than the active one', async () => {
+    const ok = await strategy.validateSessionOwnership('bastos:1:42:some-uuid', {
+      user: alice,
+      payload: {} as Payload,
+      req: makeReq(2)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('validateSessionOwnership rejects sessions for a different user even if the tenant matches', async () => {
+    const ok = await strategy.validateSessionOwnership('bastos:2:99:some-uuid', {
+      user: alice,
+      payload: {} as Payload,
+      req: makeReq(2)
+    })
+    expect(ok).toBe(false)
+  })
+
+  it('validateSessionOwnership rejects when the user has no id', async () => {
+    const ok = await strategy.validateSessionOwnership('bastos:2:42:some-uuid', {
+      user: { tenants: alice.tenants },
+      payload: {} as Payload,
+      req: makeReq(2)
+    })
+    expect(ok).toBe(false)
+  })
+})

--- a/packages/payload-agents-core/src/lib/multi-tenant.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.ts
@@ -11,16 +11,22 @@
  * such a plugin, add the filter yourself via `collectionOverrides`.
  */
 
+import type { PayloadRequest } from 'payload'
 import type { BuildSessionId, ValidateSessionOwnership } from '../types'
 
 export interface MultiTenantSessionStrategyOptions {
   /**
-   * Extract the tenant id from the authenticated Payload user.
+   * Resolve the tenant id for the current request.
+   *
+   * Receives the authenticated Payload user and the current `PayloadRequest`,
+   * so consumers can read the active tenant from whatever source their app
+   * uses (cookie, header, subdomain…) instead of being restricted to the
+   * user object.
    *
    * Return `undefined` (or a falsy value) for users without a tenant —
    * sessions will fall back to `'default'`.
    */
-  extractTenantId: (user: Record<string, unknown>) => string | number | undefined | null
+  extractTenantId: (user: Record<string, unknown>, req: PayloadRequest) => string | number | undefined | null
 }
 
 export interface MultiTenantSessionStrategy {
@@ -39,14 +45,12 @@ export interface MultiTenantSessionStrategy {
  * @example
  * ```ts
  * import { agentPlugin, multiTenantSessionStrategy } from '@zetesis/payload-agents-core'
+ * import { getTenantFromCookie } from '@payloadcms/plugin-multi-tenant/utilities'
  *
  * const { buildSessionId, validateSessionOwnership } = multiTenantSessionStrategy({
- *   extractTenantId: user => {
- *     const tenants = user.tenants as Array<{ tenant: number | { id: number } }> | undefined
- *     if (!tenants?.[0]) return undefined
- *     const t = tenants[0].tenant
- *     return typeof t === 'object' && t !== null ? t.id : t
- *   }
+ *   extractTenantId: (user, req) =>
+ *     getTenantFromCookie(req.headers, req.payload.db.defaultIDType) ??
+ *     (user.tenants as Array<{ tenant: number | { id: number } }> | undefined)?.[0]?.tenant
  * })
  *
  * agentPlugin({
@@ -57,20 +61,20 @@ export interface MultiTenantSessionStrategy {
  * ```
  */
 export function multiTenantSessionStrategy(options: MultiTenantSessionStrategyOptions): MultiTenantSessionStrategy {
-  const resolveTenant = (user: Record<string, unknown>): string => {
-    const value = options.extractTenantId(user)
+  const resolveTenant = (user: Record<string, unknown>, req: PayloadRequest): string => {
+    const value = options.extractTenantId(user, req)
     return value === undefined || value === null || value === '' ? 'default' : String(value)
   }
 
-  const buildSessionId: BuildSessionId = ({ user, agentSlug, chatId }) => {
+  const buildSessionId: BuildSessionId = ({ user, agentSlug, chatId, req }) => {
     if (chatId) return chatId
-    const tenantId = resolveTenant(user)
+    const tenantId = resolveTenant(user, req)
     const userId = String((user as { id?: string | number }).id ?? 'anonymous')
     return `${agentSlug}:${tenantId}:${userId}:${crypto.randomUUID()}`
   }
 
-  const validateSessionOwnership: ValidateSessionOwnership = (sessionId, { user }) => {
-    const tenantId = resolveTenant(user)
+  const validateSessionOwnership: ValidateSessionOwnership = (sessionId, { user, req }) => {
+    const tenantId = resolveTenant(user, req)
     const userId = String((user as { id?: string | number }).id ?? '')
     if (!userId) return false
     return sessionId.includes(`:${tenantId}:${userId}:`)

--- a/packages/payload-agents-core/src/lib/runtime-client.ts
+++ b/packages/payload-agents-core/src/lib/runtime-client.ts
@@ -4,16 +4,13 @@
  * All requests to the runtime include the `X-Internal-Secret` header
  * so the runtime can verify the caller is trusted.
  *
- * Note on reload semantics: the Agents collection hooks fan out via
- * Postgres `NOTIFY agent_reload` so every runtime replica refreshes its
- * registry. The HTTP reload below is a single-pod, manual/debug fallback
- * still useful for `curl` checks and the chat-endpoint self-heal retry
- * (which only needs *some* pod to refresh before retrying).
+ * Reloads are not pushed from here: the Agents collection hooks fan out
+ * via Postgres `NOTIFY agent_reload` and every runtime replica listens
+ * on that channel. The HTTP `/internal/agents/reload` endpoint on the
+ * runtime stays for manual `curl` debugging, but there's no TS client
+ * helper for it — the old one only reached a single replica via the K8s
+ * Service round-robin, which was the bug it was supposed to work around.
  */
-
-import type { ReloadResult } from '../types'
-
-const RELOAD_TIMEOUT_MS = 5_000
 
 /**
  * Authenticated fetch to the agent-runtime.
@@ -24,26 +21,4 @@ export function runtimeFetch(url: string, runtimeSecret: string, init?: RequestI
   const headers = new Headers(init?.headers)
   headers.set('X-Internal-Secret', runtimeSecret)
   return fetch(url, { ...init, headers })
-}
-
-export async function reloadAgents(runtimeUrl: string, runtimeSecret: string): Promise<ReloadResult | null> {
-  const url = `${runtimeUrl}/internal/agents/reload`
-
-  try {
-    const res = await runtimeFetch(url, runtimeSecret, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      signal: AbortSignal.timeout(RELOAD_TIMEOUT_MS)
-    })
-
-    if (!res.ok) {
-      console.warn(`[agent-runtime] reload failed: ${res.status} ${res.statusText}`)
-      return null
-    }
-
-    return (await res.json()) as ReloadResult
-  } catch (err) {
-    console.warn('[agent-runtime] reload request errored:', err)
-    return null
-  }
 }

--- a/packages/payload-agents-core/src/lib/runtime-client.ts
+++ b/packages/payload-agents-core/src/lib/runtime-client.ts
@@ -3,6 +3,12 @@
  *
  * All requests to the runtime include the `X-Internal-Secret` header
  * so the runtime can verify the caller is trusted.
+ *
+ * Note on reload semantics: the Agents collection hooks fan out via
+ * Postgres `NOTIFY agent_reload` so every runtime replica refreshes its
+ * registry. The HTTP reload below is a single-pod, manual/debug fallback
+ * still useful for `curl` checks and the chat-endpoint self-heal retry
+ * (which only needs *some* pod to refresh before retrying).
  */
 
 import type { ReloadResult } from '../types'

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -27,9 +27,18 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
     collectionSlug: userConfig.collectionSlug ?? 'agents',
     basePath: userConfig.basePath ?? '/agents',
     encryptionKey: userConfig.encryptionKey,
-    mediaCollectionSlug: userConfig.mediaCollectionSlug ?? 'media',
-    taxonomyCollectionSlug: userConfig.taxonomyCollectionSlug ?? 'taxonomy',
+    mediaCollectionSlug: userConfig.mediaCollectionSlug,
+    taxonomyCollectionSlug: userConfig.taxonomyCollectionSlug,
     collectionOverrides: userConfig.collectionOverrides
+  }
+}
+
+function assertCollectionExists(config: Config, slug: string, configField: string): void {
+  const exists = (config.collections ?? []).some(c => c.slug === slug)
+  if (!exists) {
+    throw new Error(
+      `[agent-plugin] collection "${slug}" referenced by ${configField} is not registered in payload config`
+    )
   }
 }
 
@@ -37,6 +46,9 @@ export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
   return (incomingConfig: Config): Config => {
     const config = resolveConfig(userConfig)
     const basePath = config.basePath
+
+    assertCollectionExists(incomingConfig, config.mediaCollectionSlug, 'mediaCollectionSlug')
+    assertCollectionExists(incomingConfig, config.taxonomyCollectionSlug, 'taxonomyCollectionSlug')
 
     // Create the agents collection
     const agentsCollection = createAgentsCollection(config)

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -145,13 +145,6 @@ export interface AgentPluginConfig {
   collectionOverrides?: CollectionOverrides
 }
 
-// ── Runtime client types ──────────────────────────────────────────────────
-
-export interface ReloadResult {
-  count: number
-  slugs: string[]
-}
-
 // ── Source types ───────────────────────────────────────────────────────────
 
 export interface Source {

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -110,16 +110,19 @@ export interface AgentPluginConfig {
   encryptionKey?: string
 
   /**
-   * Slug of the `media` collection for agent avatars.
-   * Default: `'media'`.
+   * Slug of the `media` collection for agent avatars. Required — the plugin
+   * no longer guesses; you must pass the slug you use in your config so a
+   * rename elsewhere fails at boot instead of silently breaking uploads.
    */
-  mediaCollectionSlug?: string
+  mediaCollectionSlug: string
 
   /**
-   * Slug of the taxonomy collection for RAG filtering.
-   * Default: `'taxonomy'`.
+   * Slug of the taxonomy collection for RAG filtering. Required — the plugin
+   * no longer guesses; you must pass the slug you use in your config so a
+   * rename elsewhere fails at boot instead of silently breaking the
+   * taxonomies relationship on agents.
    */
-  taxonomyCollectionSlug?: string
+  taxonomyCollectionSlug: string
 
   /**
    * Transform the Agents collection config before it is registered.

--- a/packages/payload-agents-core/vitest.config.ts
+++ b/packages/payload-agents-core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.spec.ts'],
+    restoreMocks: true
+  }
+})

--- a/packages/payload-indexer/src/sync-status/sync-status-service.ts
+++ b/packages/payload-indexer/src/sync-status/sync-status-service.ts
@@ -43,19 +43,34 @@ const extractSourceText = async (doc: PayloadDocument, tableConfig: TableConfig)
   return textParts.join('\n\n')
 }
 
+interface IndexedHashesLookup {
+  /** Hashes keyed by documentId. Missing key means "not indexed". */
+  hashes: Map<string, string | undefined>
+  /** Documents whose lookup raised — caller must surface as `'error'`, not `'not-indexed'`. */
+  errored: Map<string, string>
+  /** True when the adapter does not support filter-based search at all. */
+  adapterUnsupported: boolean
+}
+
 /**
- * Query the adapter for stored content hashes of one or more documents
+ * Query the adapter for stored content hashes of one or more documents.
+ *
+ * The returned shape distinguishes three states so callers can tell
+ * "really not indexed" apart from "we don't know because the lookup
+ * failed" — critical when Typesense is down and we would otherwise mark
+ * every document as `'not-indexed'`.
  */
 const getIndexedHashes = async (
   adapter: IndexerAdapter,
   tableName: string,
   docIds: string[],
   isChunked: boolean
-): Promise<Map<string, string | undefined>> => {
-  const result = new Map<string, string | undefined>()
+): Promise<IndexedHashesLookup> => {
+  const hashes = new Map<string, string | undefined>()
+  const errored = new Map<string, string>()
 
   if (!adapter.searchDocumentsByFilter) {
-    return result
+    return { hashes, errored, adapterUnsupported: true }
   }
 
   for (const docId of docIds) {
@@ -70,18 +85,20 @@ const getIndexedHashes = async (
 
       const firstDoc = docs[0]
       if (firstDoc) {
-        result.set(docId, firstDoc.content_hash)
+        hashes.set(docId, firstDoc.content_hash)
       }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
       logger.warn('Failed to fetch indexed hash', {
         documentId: docId,
         tableName,
-        error: error instanceof Error ? error.message : String(error)
+        error: message
       })
+      errored.set(docId, message)
     }
   }
 
-  return result
+  return { hashes, errored, adapterUnsupported: false }
 }
 
 /**
@@ -175,19 +192,26 @@ export const checkBatchSyncStatus = async (
 
   // 2. Batch fetch indexed hashes
   const docIds = docs.map(d => String(d.id))
-  const indexedHashes = await getIndexedHashes(adapter, tableName, docIds, isChunked)
+  const lookup = await getIndexedHashes(adapter, tableName, docIds, isChunked)
 
-  // 3. Compare
+  // 3. Compare — if the adapter can't search at all, every doc is an error.
   for (const doc of docs) {
     const docId = String(doc.id)
     const currentHash = currentHashes.get(docId)
-    const indexedHash = indexedHashes.get(docId)
+    const indexedHash = lookup.hashes.get(docId)
 
     let status: SyncStatusValue
+    let error: string | undefined
 
-    if (!currentHash) {
+    if (lookup.adapterUnsupported) {
+      status = 'error'
+      error = 'Adapter does not support searchDocumentsByFilter'
+    } else if (lookup.errored.has(docId)) {
+      status = 'error'
+      error = lookup.errored.get(docId)
+    } else if (!currentHash) {
       status = 'not-indexed'
-    } else if (!indexedHashes.has(docId)) {
+    } else if (!lookup.hashes.has(docId)) {
       status = 'not-indexed'
     } else if (!indexedHash) {
       status = 'outdated'
@@ -195,7 +219,7 @@ export const checkBatchSyncStatus = async (
       status = currentHash === indexedHash ? 'synced' : 'outdated'
     }
 
-    results.set(docId, { status, documentId: docId, currentHash, indexedHash })
+    results.set(docId, { status, documentId: docId, currentHash, indexedHash, error })
     counts[status]++
   }
 

--- a/services/agent-runtime/agent_runtime/exceptions.py
+++ b/services/agent-runtime/agent_runtime/exceptions.py
@@ -84,9 +84,7 @@ class AuthenticationError(AgentRuntimeError):
         )
 
 
-async def agent_runtime_exception_handler(
-    request: Request, exc: AgentRuntimeError
-) -> JSONResponse:
+async def agent_runtime_exception_handler(request: Request, exc: AgentRuntimeError) -> JSONResponse:
     """Global exception handler — consistent JSON error responses."""
     logger.warning(
         "Request error",

--- a/services/agent-runtime/agent_runtime/logging.py
+++ b/services/agent-runtime/agent_runtime/logging.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any
+from typing import Any, cast
 
 import structlog
 from structlog.stdlib import BoundLogger
@@ -45,9 +45,7 @@ def _format_processor(log_level: str) -> Any:
     return structlog.processors.JSONRenderer(ensure_ascii=False)
 
 
-def _add_request_id(
-    _logger: Any, _method_name: str, event_dict: dict[str, Any]
-) -> dict[str, Any]:
+def _add_request_id(_logger: Any, _method_name: str, event_dict: dict[str, Any]) -> dict[str, Any]:
     """Inject correlation ID from the request context if available."""
     from agent_runtime.middleware import request_id_var
 
@@ -59,4 +57,4 @@ def _add_request_id(
 
 def get_logger(name: str | None = None) -> BoundLogger:
     """Get a structured logger instance."""
-    return structlog.get_logger(name)  # type: ignore[return-value]
+    return cast(BoundLogger, structlog.get_logger(name))

--- a/services/agent-runtime/agent_runtime/main.py
+++ b/services/agent-runtime/agent_runtime/main.py
@@ -60,6 +60,11 @@ _BOOT_MAX_RETRIES = 10
 _BOOT_BACKOFF_BASE = 2.0
 _BOOT_BACKOFF_MAX = 30.0
 
+# Belt-and-braces full resync, independent of the LISTEN/NOTIFY channel.
+# Covers the gap where a reconnecting listener misses a NOTIFY: the next
+# tick picks the edit up at most this many seconds late.
+_RESYNC_INTERVAL_S = 300.0
+
 
 async def _reload_registry(_payload: str | None = None) -> None:
     """Callback handed to the listener; serialised with the lock used by
@@ -69,6 +74,22 @@ async def _reload_registry(_payload: str | None = None) -> None:
         await registry.reload()
         agent_os.agents = _agents_as_union(registry.all())
     logger.info("Registry reloaded via notify", count=len(registry.all()), slugs=registry.slugs())
+
+
+async def _periodic_resync() -> None:
+    """Unconditional full reload every `_RESYNC_INTERVAL_S` seconds.
+
+    Closes the durability gap of `LISTEN/NOTIFY`: if the listener connection
+    is dropped at the moment of a NOTIFY, the message is lost. This tick
+    guarantees bounded staleness — at worst `_RESYNC_INTERVAL_S` seconds
+    behind Payload.
+    """
+    while True:
+        await asyncio.sleep(_RESYNC_INTERVAL_S)
+        try:
+            await _reload_registry()
+        except Exception:
+            logger.exception("Periodic resync failed, will retry on next tick")
 
 
 @asynccontextmanager
@@ -101,10 +122,12 @@ async def lifespan(app: Any) -> AsyncIterator[None]:
                 )
 
     listener_task = asyncio.create_task(run_reload_listener(_reload_registry))
+    resync_task = asyncio.create_task(_periodic_resync())
     yield
-    listener_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await listener_task
+    for task in (listener_task, resync_task):
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
     logger.info("Shutting down — disposing shared DB engine")
     await dispose_shared_engine()

--- a/services/agent-runtime/agent_runtime/main.py
+++ b/services/agent-runtime/agent_runtime/main.py
@@ -17,6 +17,7 @@ Custom additions:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hmac
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -39,6 +40,7 @@ from agent_runtime.health import router as health_router
 from agent_runtime.logging import configure_logging, get_logger
 from agent_runtime.middleware import InternalAuthMiddleware, RequestIdMiddleware
 from agent_runtime.registry import AgentRegistry
+from agent_runtime.reload_listener import run_reload_listener
 from agent_runtime.schemas import ErrorResponse, ReloadResponse
 
 configure_logging(settings.log_level)
@@ -57,6 +59,16 @@ def _agents_as_union(agents: list[Agent]) -> list[Agent | RemoteAgent]:
 _BOOT_MAX_RETRIES = 10
 _BOOT_BACKOFF_BASE = 2.0
 _BOOT_BACKOFF_MAX = 30.0
+
+
+async def _reload_registry(_payload: str | None = None) -> None:
+    """Callback handed to the listener; serialised with the lock used by
+    the internal HTTP endpoint so we never mutate ``agent_os.agents`` twice
+    at the same time."""
+    async with _reload_lock:
+        await registry.reload()
+        agent_os.agents = _agents_as_union(registry.all())
+    logger.info("Registry reloaded via notify", count=len(registry.all()), slugs=registry.slugs())
 
 
 @asynccontextmanager
@@ -87,7 +99,12 @@ async def lifespan(app: Any) -> AsyncIterator[None]:
                     max_retries=_BOOT_MAX_RETRIES,
                     exc_info=True,
                 )
+
+    listener_task = asyncio.create_task(run_reload_listener(_reload_registry))
     yield
+    listener_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await listener_task
 
     logger.info("Shutting down — disposing shared DB engine")
     await dispose_shared_engine()

--- a/services/agent-runtime/agent_runtime/middleware.py
+++ b/services/agent-runtime/agent_runtime/middleware.py
@@ -89,4 +89,3 @@ async def _send_401(send: Send) -> None:
         }
     )
     await send({"type": "http.response.body", "body": b'{"error":"Unauthorized"}'})
-

--- a/services/agent-runtime/agent_runtime/reload_listener.py
+++ b/services/agent-runtime/agent_runtime/reload_listener.py
@@ -1,0 +1,79 @@
+"""Postgres LISTEN/NOTIFY bridge that triggers registry reloads on every pod.
+
+A dedicated async psycopg connection sits in autocommit mode LISTENing on the
+``agent_reload`` channel. When Payload's afterChange/afterDelete hook fires a
+``NOTIFY agent_reload`` every replica sees the notification and refreshes its
+in-memory registry — fixing the multi-replica bug where an HTTP reload only
+reached whichever pod the Service routed the request to.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+import psycopg
+
+from agent_runtime.config import settings
+from agent_runtime.db import normalize_pg_url
+from agent_runtime.logging import get_logger
+
+logger = get_logger(__name__)
+
+RELOAD_CHANNEL = "agent_reload"
+
+_RECONNECT_BACKOFF_BASE_S = 1.0
+_RECONNECT_BACKOFF_MAX_S = 30.0
+
+
+def _psycopg_url(url: str) -> str:
+    """psycopg3 accepts ``postgres://`` and ``postgresql://`` but not the
+    SQLAlchemy-flavoured ``postgresql+psycopg://`` prefix."""
+    normalized = normalize_pg_url(url)
+    return normalized.replace("postgresql+psycopg://", "postgresql://")
+
+
+async def _listen_once(
+    on_notify: Callable[[str | None], Coroutine[Any, Any, None]],
+) -> None:
+    url = _psycopg_url(settings.database_url)
+    async with await psycopg.AsyncConnection.connect(url, autocommit=True) as conn:
+        async with conn.cursor() as cur:
+            await cur.execute(f"LISTEN {RELOAD_CHANNEL}")
+        logger.info("Listening for reload notifications", channel=RELOAD_CHANNEL)
+        async for notify in conn.notifies():
+            logger.info(
+                "Reload notification received",
+                channel=notify.channel,
+                payload=notify.payload or None,
+            )
+            await on_notify(notify.payload or None)
+
+
+async def run_reload_listener(
+    on_notify: Callable[[str | None], Coroutine[Any, Any, None]],
+) -> None:
+    """Run the listen loop forever, reconnecting with exponential backoff on failure.
+
+    Meant to be spawned as a background task during the FastAPI lifespan.
+    """
+    attempt = 0
+    while True:
+        try:
+            await _listen_once(on_notify)
+        except asyncio.CancelledError:
+            logger.info("Reload listener cancelled")
+            raise
+        except Exception:
+            delay = min(_RECONNECT_BACKOFF_BASE_S * (2**attempt), _RECONNECT_BACKOFF_MAX_S)
+            attempt += 1
+            logger.warning(
+                "Reload listener crashed, reconnecting",
+                attempt=attempt,
+                delay_s=delay,
+                exc_info=True,
+            )
+            await asyncio.sleep(delay)
+        else:
+            attempt = 0

--- a/services/agent-runtime/agent_runtime/schemas.py
+++ b/services/agent-runtime/agent_runtime/schemas.py
@@ -16,7 +16,9 @@ class ReadyResponse(BaseModel):
 
 class ReloadResponse(BaseModel):
     count: int = Field(description="Number of agents after reload", examples=[3])
-    slugs: list[str] = Field(description="Slugs of loaded agents", examples=[["escohotado", "bastos"]])
+    slugs: list[str] = Field(
+        description="Slugs of loaded agents", examples=[["escohotado", "bastos"]]
+    )
 
 
 class ErrorDetail(BaseModel):

--- a/services/agent-runtime/tests/conftest.py
+++ b/services/agent-runtime/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Test bootstrap — set the required settings env vars *before* agent_runtime.config is imported.
+
+The Settings class validates `DATABASE_URL` and `INTERNAL_SECRET` at import
+time; without this shim every test module would fail to collect.
+"""
+
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost:5432/test")
+os.environ.setdefault("INTERNAL_SECRET", "test-secret")

--- a/services/agent-runtime/tests/test_builder.py
+++ b/services/agent-runtime/tests/test_builder.py
@@ -1,0 +1,37 @@
+"""Tests for `agent_runtime.builder.build_model` provider/model mapping."""
+
+from __future__ import annotations
+
+import pytest
+from agno.models.anthropic import Claude
+from agno.models.openai import OpenAIChat, OpenAIResponses
+
+from agent_runtime.builder import build_model
+from agent_runtime.exceptions import UnsupportedProviderError
+
+
+class TestBuildModel:
+    def test_anthropic_returns_claude(self) -> None:
+        model = build_model("anthropic", "claude-sonnet-4-5", "sk-test")
+        assert isinstance(model, Claude)
+        assert model.id == "claude-sonnet-4-5"
+
+    @pytest.mark.parametrize(
+        "model_id", ["o1-preview", "o3-mini", "o4-mini", "gpt-4.1", "gpt-5-turbo"]
+    )
+    def test_openai_reasoning_series_returns_responses(self, model_id: str) -> None:
+        model = build_model("openai", model_id, "sk-test")
+        assert isinstance(model, OpenAIResponses)
+        assert model.id == model_id
+
+    @pytest.mark.parametrize("model_id", ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"])
+    def test_openai_chat_series_returns_chat(self, model_id: str) -> None:
+        model = build_model("openai", model_id, "sk-test")
+        assert isinstance(model, OpenAIChat)
+        assert model.id == model_id
+
+    def test_unknown_provider_raises(self) -> None:
+        with pytest.raises(UnsupportedProviderError) as exc:
+            build_model("cohere", "command-r", "sk-test")
+        assert exc.value.details == {"provider": "cohere"}
+        assert exc.value.http_status == 422

--- a/services/agent-runtime/tests/test_db.py
+++ b/services/agent-runtime/tests/test_db.py
@@ -1,0 +1,26 @@
+"""Tests for `agent_runtime.db`."""
+
+from __future__ import annotations
+
+from agent_runtime.db import normalize_pg_url
+
+
+class TestNormalizePgUrl:
+    def test_rewrites_postgres_prefix(self) -> None:
+        assert (
+            normalize_pg_url("postgres://u:p@host:5432/db")
+            == "postgresql+psycopg://u:p@host:5432/db"
+        )
+
+    def test_rewrites_postgresql_prefix(self) -> None:
+        assert (
+            normalize_pg_url("postgresql://u:p@host:5432/db")
+            == "postgresql+psycopg://u:p@host:5432/db"
+        )
+
+    def test_passes_through_already_normalized(self) -> None:
+        url = "postgresql+psycopg://u:p@host:5432/db"
+        assert normalize_pg_url(url) == url
+
+    def test_passes_through_unknown_prefix(self) -> None:
+        assert normalize_pg_url("mysql://u:p@host/db") == "mysql://u:p@host/db"

--- a/services/agent-runtime/tests/test_exceptions.py
+++ b/services/agent-runtime/tests/test_exceptions.py
@@ -1,0 +1,88 @@
+"""Tests for `agent_runtime.exceptions` — exception shapes and HTTP handler."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+from agent_runtime.exceptions import (
+    AgentRuntimeError,
+    AuthenticationError,
+    InvalidModelError,
+    MissingApiKeyError,
+    UnsupportedProviderError,
+    agent_runtime_exception_handler,
+)
+
+
+class TestExceptionShapes:
+    def test_invalid_model_structured_payload(self) -> None:
+        exc = InvalidModelError(slug="bastos", llm_model="bad")
+        assert exc.code == "INVALID_LLM_MODEL"
+        assert exc.http_status == 422
+        assert exc.details == {"slug": "bastos", "llmModel": "bad"}
+
+    def test_missing_api_key(self) -> None:
+        exc = MissingApiKeyError(slug="bastos")
+        assert exc.code == "MISSING_API_KEY"
+        assert exc.http_status == 422
+        assert exc.details == {"slug": "bastos"}
+
+    def test_unsupported_provider(self) -> None:
+        exc = UnsupportedProviderError(provider="cohere")
+        assert exc.code == "UNSUPPORTED_PROVIDER"
+        assert exc.http_status == 422
+        assert exc.details == {"provider": "cohere"}
+
+    def test_authentication_error_is_401(self) -> None:
+        exc = AuthenticationError()
+        assert exc.code == "AUTH_INVALID_SECRET"
+        assert exc.http_status == 401
+
+
+def _make_request(path: str = "/test") -> Request:
+    """Build a minimal Request from an ASGI scope — enough for the handler."""
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+    }
+    return Request(scope)
+
+
+class TestExceptionHandler:
+    @pytest.mark.asyncio
+    async def test_returns_json_with_expected_envelope(self) -> None:
+        exc = InvalidModelError(slug="bastos", llm_model="bad")
+        request = _make_request()
+
+        response = await agent_runtime_exception_handler(request, exc)
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 422
+        body = json.loads(response.body)
+        assert body == {
+            "error": {
+                "code": "INVALID_LLM_MODEL",
+                "message": "Invalid llmModel 'bad'; expected 'provider/model-id'",
+                "details": {"slug": "bastos", "llmModel": "bad"},
+            }
+        }
+
+    @pytest.mark.asyncio
+    async def test_uses_exception_http_status(self) -> None:
+        exc = AuthenticationError()
+        response = await agent_runtime_exception_handler(_make_request(), exc)
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_default_base_error_is_500(self) -> None:
+        exc = AgentRuntimeError("boom")
+        response = await agent_runtime_exception_handler(_make_request(), exc)
+        assert response.status_code == 500

--- a/services/agent-runtime/tests/test_reload_listener.py
+++ b/services/agent-runtime/tests/test_reload_listener.py
@@ -1,0 +1,18 @@
+"""Tests for `agent_runtime.reload_listener` helpers."""
+
+from __future__ import annotations
+
+from agent_runtime.reload_listener import _psycopg_url
+
+
+class TestPsycopgUrl:
+    def test_strips_sqlalchemy_driver_prefix(self) -> None:
+        assert (
+            _psycopg_url("postgresql+psycopg://u:p@host:5432/db") == "postgresql://u:p@host:5432/db"
+        )
+
+    def test_accepts_plain_postgresql_url(self) -> None:
+        assert _psycopg_url("postgresql://u:p@host/db") == "postgresql://u:p@host/db"
+
+    def test_rewrites_postgres_short_prefix(self) -> None:
+        assert _psycopg_url("postgres://u:p@host/db") == "postgresql://u:p@host/db"

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,4 +1,5 @@
 export default [
+  'packages/payload-agents-core',
   'packages/payload-indexer',
   'packages/payload-typesense'
 ]


### PR DESCRIPTION
## Summary

- Replace the HTTP push at the agent-runtime Service (which the K8s round-robin delivered to a single pod) with `pg_notify('agent_reload', slug)` emitted from the Agents `afterChange`/`afterDelete` hooks via Payload's drizzle handle.
- New `agent_runtime/reload_listener.py` runs a dedicated psycopg3 async connection in autocommit mode LISTENing on the `agent_reload` channel; the FastAPI lifespan spawns it as a background task and cancels it on shutdown.
- Reload handler reuses the same `_reload_lock` as the HTTP endpoint, so two concurrent signals can't mutate `agent_os.agents` simultaneously.
- Reconnect-with-backoff when the listener connection drops.
- HTTP `/internal/agents/reload` endpoint and `reloadAgents` client helper stay untouched — still used by the chat endpoint self-heal retry and for `curl` debugging.

## Context

This is stacked on `fix/extract-tenant-id-with-req` (#20). When that merges, this branch rebases cleanly onto main.

Closes Zetesis-Labs/ZetesisPortal#181.

## Test plan

- [ ] `pnpm --filter @zetesis/payload-agents-core build` passes.
- [ ] `pnpm lint` and `pnpm tsc --noEmit` pass in the submodule.
- [ ] `uv run ruff check agent_runtime/` and `uv run mypy agent_runtime/reload_listener.py agent_runtime/main.py` pass.
- [ ] Manual — run two replicas locally, edit an agent in Payload, confirm both pods log `Registry reloaded via notify` and serve the updated model.
- [ ] Manual — kill the Postgres connection on one pod and verify the backoff loop reconnects and resumes listening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/21" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
