### PR TITLE
feat(payload-documents): new plugin with LlamaParse-powered PDF parsing

### DIFF
--- a/.changeset/payload-documents-devin-review-fixes.md
+++ b/.changeset/payload-documents-devin-review-fixes.md
@@ -1,0 +1,9 @@
+---
+'@zetesis/payload-documents': patch
+---
+
+Address three issues raised in the Devin review of PR #24:
+
+- **Treat `CANCELED` LlamaParse jobs as terminal.** `resolveJob` in the parse-status endpoint previously fell through to `handleProcessing` for any status other than `SUCCESS`/`ERROR`, including `CANCELED`. Canceled jobs never transition to `SUCCESS` or `ERROR`, so the document stayed in `processing` and the client polled forever. Canceled jobs now surface as `parse_status='error'` with the message "LlamaParse job was canceled" (overridable by the API's own `error_message`).
+- **Fail-fast when the uploaded file URL cannot be resolved.** `fetchUploadedFile` used to fall back to an empty `serverURL`, which turned a relative upload URL into a path-only string and blew up Node's `fetch` with a cryptic `TypeError: Invalid URL`. It now returns a clear 500 (`"Payload serverURL is not configured and the uploaded file URL is relative"`) when the URL is relative and no `serverURL` is set.
+- **Clean up the polling interval on unmount.** `ParseButtonField` started a `setInterval` via `startPolling` but never cleared it when the component unmounted. If the user navigated away mid-parse, the interval kept firing, called `setState` on an unmounted component, and could trigger `window.location.reload()` after navigation. Added a `useEffect` cleanup that always clears the interval on unmount.

--- a/.changeset/payload-documents-initial.md
+++ b/.changeset/payload-documents-initial.md
@@ -1,0 +1,19 @@
+---
+'@zetesis/payload-documents': minor
+---
+
+Add new `@zetesis/payload-documents` package: a Payload CMS plugin that registers an upload-enabled `documents` collection and wires a LlamaParse (LlamaIndex Cloud) flow to parse uploaded PDFs into editable markdown.
+
+The plugin is configuration-driven — parsing parameters (`language`, `mode`, `parsing_instruction`) live on the document itself so each upload can be tuned independently. `result_type` is fixed to markdown so downstream consumers get a stable shape.
+
+- **Admin UX**: a `ParseButtonField` (client boundary at `@zetesis/payload-documents/client`) posts to the plugin's REST endpoints and polls until the job settles, then reloads so the parsed markdown appears in the document.
+- **Endpoints**: `POST /api/{slug}/:id/parse` kicks off a job and stores `parse_job_id`; `GET /api/{slug}/:id/parse-status` polls LlamaParse and writes the resulting markdown into a `parsed_text` code field when `SUCCESS`.
+- **Multitenancy & storage** are intentionally not hardcoded — host apps add the collection slug to their existing `@payloadcms/plugin-multi-tenant` and `@payloadcms/storage-s3` configurations.
+
+```ts
+import { createDocumentsPlugin } from '@zetesis/payload-documents'
+
+export default buildConfig({
+  plugins: [createDocumentsPlugin().plugin]
+})
+```

--- a/.changeset/payload-documents-parse-button-always-visible.md
+++ b/.changeset/payload-documents-parse-button-always-visible.md
@@ -1,0 +1,16 @@
+---
+'@zetesis/payload-documents': patch
+---
+
+Make the **Parse with LlamaParse** button always visible in the admin.
+
+Previously the button was declared as a UI field inside a `Parsing` tab and was conditionally hidden while the document had no `id` (i.e. before the first save). Users could not find the button after uploading a PDF because it only appeared if they remembered to click the `Parsing` tab *after* saving.
+
+Now:
+
+- The `parse_action` UI field is rendered at the top of the form, outside the tabs, so it shows up as soon as the document is opened.
+- The button is always rendered — when the document has not been saved yet, it is disabled with the hint "Upload a PDF and save the document to enable parsing." This makes the flow discoverable without relying on users knowing they need to save first.
+- Status, job id, parsed-at and the error textarea are still on the form but at top-level (status/job/date in the sidebar) so the remaining `tabs` (`Params`, `Output`) only group things that actually belong together.
+- `toast.info` is replaced with `toast.success` for the "Parsing started" notification to avoid a possible runtime mismatch with the subset of toast methods re-exported from `@payloadcms/ui`.
+
+No config or behavior changes on the server side — only how the admin surfaces the existing flow.

--- a/packages/payload-documents/package.json
+++ b/packages/payload-documents/package.json
@@ -1,0 +1,95 @@
+{
+  "name": "@zetesis/payload-documents",
+  "version": "0.1.0",
+  "description": "Payload CMS plugin that adds a documents collection with LlamaParse-powered PDF parsing into editable markdown.",
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./client": {
+      "types": "./dist/client/index.d.mts",
+      "import": "./src/client/index.ts",
+      "default": "./src/client/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "peerDependencies": {
+    "@payloadcms/ui": "^3.81.0",
+    "payload": "^3.81.0",
+    "react": "^19"
+  },
+  "peerDependenciesMeta": {
+    "@payloadcms/ui": {
+      "optional": true
+    },
+    "react": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.7",
+    "@types/react": "^19",
+    "rimraf": "3.0.2",
+    "tsdown": "^0.16.5",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "pnpm": "^9 || ^10"
+  },
+  "keywords": [
+    "payload",
+    "payloadcms",
+    "llamaparse",
+    "llamaindex",
+    "pdf",
+    "parsing",
+    "markdown"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Zetesis-Labs/PayloadAgents.git",
+    "directory": "packages/payload-documents"
+  },
+  "homepage": "https://github.com/Zetesis-Labs/PayloadAgents/tree/main/packages/payload-documents#readme",
+  "bugs": {
+    "url": "https://github.com/Zetesis-Labs/PayloadAgents/issues"
+  },
+  "author": {
+    "name": "Zetesis - Rubén Garcia",
+    "email": "ruben@zetesis.xyz",
+    "url": "https://zetesis.xyz"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      },
+      "./client": {
+        "types": "./dist/client/index.d.mts",
+        "import": "./dist/client/index.mjs",
+        "default": "./dist/client/index.mjs"
+      }
+    },
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
+}

--- a/packages/payload-documents/src/client/components/ParseButtonField.tsx
+++ b/packages/payload-documents/src/client/components/ParseButtonField.tsx
@@ -110,7 +110,7 @@ export const ParseButtonField: UIFieldClientComponent = () => {
         toast.error(data.error ?? 'Failed to start parsing')
         return
       }
-      toast.info('Parsing started')
+      toast.success('Parsing started')
       startPolling()
     } catch (error) {
       setLocalStatus('error')
@@ -120,6 +120,7 @@ export const ParseButtonField: UIFieldClientComponent = () => {
   }, [id, collectionSlug, startPolling])
 
   const description = useMemo(() => {
+    if (!id) return 'Upload a PDF and save the document to enable parsing.'
     switch (status) {
       case 'idle':
         return 'Click to parse the uploaded PDF with LlamaParse.'
@@ -132,7 +133,7 @@ export const ParseButtonField: UIFieldClientComponent = () => {
       case 'error':
         return 'Parsing failed. See the error details below.'
     }
-  }, [status])
+  }, [id, status])
 
   return (
     <div style={containerStyle}>
@@ -143,13 +144,11 @@ export const ParseButtonField: UIFieldClientComponent = () => {
         </Pill>
       </div>
       <span style={descStyle}>{description}</span>
-      {id && (
-        <div>
-          <Button buttonStyle="primary" size="small" onClick={handleStart} disabled={isRunning}>
-            {isRunning ? 'Parsing…' : 'Parse with LlamaParse'}
-          </Button>
-        </div>
-      )}
+      <div>
+        <Button buttonStyle="primary" size="small" onClick={handleStart} disabled={isRunning || !id}>
+          {isRunning ? 'Parsing…' : 'Parse with LlamaParse'}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/packages/payload-documents/src/client/components/ParseButtonField.tsx
+++ b/packages/payload-documents/src/client/components/ParseButtonField.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Pill, toast, useFormFields } from '@payloadcms/ui'
 import type { UIFieldClientComponent } from 'payload'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 type ParseStatus = 'idle' | 'pending' | 'processing' | 'done' | 'error'
 
@@ -51,6 +51,18 @@ export const ParseButtonField: UIFieldClientComponent = () => {
       pollingRef.current = null
     }
     setBusy(false)
+  }, [])
+
+  // Ensure the polling interval is cleared if the user navigates away
+  // while a job is in flight — otherwise setInterval would keep running,
+  // setting state on an unmounted component and potentially reloading the page.
+  useEffect(() => {
+    return () => {
+      if (pollingRef.current !== null) {
+        window.clearInterval(pollingRef.current)
+        pollingRef.current = null
+      }
+    }
   }, [])
 
   const startPolling = useCallback(

--- a/packages/payload-documents/src/client/components/ParseButtonField.tsx
+++ b/packages/payload-documents/src/client/components/ParseButtonField.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { Button, Pill, toast, useDocumentInfo, useFormFields } from '@payloadcms/ui'
+import type { UIFieldClientComponent } from 'payload'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+type ParseStatus = 'idle' | 'pending' | 'processing' | 'done' | 'error'
+
+const pillStyle: Record<ParseStatus, 'success' | 'error' | 'warning' | undefined> = {
+  idle: undefined,
+  pending: 'warning',
+  processing: 'warning',
+  done: 'success',
+  error: 'error'
+}
+
+const labels: Record<ParseStatus, string> = {
+  idle: 'Idle',
+  pending: 'Pending',
+  processing: 'Processing',
+  done: 'Done',
+  error: 'Error'
+}
+
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  padding: '16px 0'
+}
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px'
+}
+
+const descStyle: React.CSSProperties = {
+  fontSize: '13px',
+  opacity: 0.7
+}
+
+const POLL_INTERVAL_MS = 3000
+
+export const ParseButtonField: UIFieldClientComponent = () => {
+  const { id, collectionSlug } = useDocumentInfo()
+  const persistedStatus = useFormFields(([fields]) => {
+    const raw = fields?.parse_status?.value
+    return typeof raw === 'string' ? (raw as ParseStatus) : 'idle'
+  })
+
+  const [localStatus, setLocalStatus] = useState<ParseStatus | null>(null)
+  const pollingRef = useRef<number | null>(null)
+
+  const status: ParseStatus = localStatus ?? persistedStatus ?? 'idle'
+  const isRunning = status === 'pending' || status === 'processing'
+
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current !== null) {
+      window.clearInterval(pollingRef.current)
+      pollingRef.current = null
+    }
+  }, [])
+
+  const pollOnce = useCallback(async () => {
+    if (!id || !collectionSlug) return
+    try {
+      const res = await fetch(`/api/${collectionSlug}/${id}/parse-status`)
+      const data = (await res.json()) as { status?: ParseStatus; error?: string }
+      const next = data.status ?? 'processing'
+      setLocalStatus(next)
+      if (next === 'done') {
+        stopPolling()
+        toast.success('Document parsed')
+        window.location.reload()
+      } else if (next === 'error') {
+        stopPolling()
+        toast.error(data.error ?? 'Parse failed')
+        window.location.reload()
+      }
+    } catch {
+      // keep polling; transient errors are fine
+    }
+  }, [id, collectionSlug, stopPolling])
+
+  useEffect(() => stopPolling, [stopPolling])
+
+  const startPolling = useCallback(() => {
+    stopPolling()
+    pollingRef.current = window.setInterval(() => {
+      void pollOnce()
+    }, POLL_INTERVAL_MS)
+  }, [pollOnce, stopPolling])
+
+  // If the document was already in-flight when the user opened it, resume polling.
+  useEffect(() => {
+    if (persistedStatus === 'pending' || persistedStatus === 'processing') {
+      startPolling()
+    }
+  }, [persistedStatus, startPolling])
+
+  const handleStart = useCallback(async () => {
+    if (!id || !collectionSlug) return
+    setLocalStatus('pending')
+    try {
+      const res = await fetch(`/api/${collectionSlug}/${id}/parse`, { method: 'POST' })
+      const data = (await res.json().catch(() => ({}))) as { error?: string }
+      if (!res.ok) {
+        setLocalStatus('error')
+        toast.error(data.error ?? 'Failed to start parsing')
+        return
+      }
+      toast.info('Parsing started')
+      startPolling()
+    } catch (error) {
+      setLocalStatus('error')
+      const message = error instanceof Error ? error.message : 'Failed to start parsing'
+      toast.error(message)
+    }
+  }, [id, collectionSlug, startPolling])
+
+  const description = useMemo(() => {
+    switch (status) {
+      case 'idle':
+        return 'Click to parse the uploaded PDF with LlamaParse.'
+      case 'pending':
+        return 'Job accepted by LlamaParse. Waiting to start…'
+      case 'processing':
+        return 'LlamaParse is processing the document.'
+      case 'done':
+        return 'Parsed markdown is available in the Output tab.'
+      case 'error':
+        return 'Parsing failed. See the error details below.'
+    }
+  }, [status])
+
+  return (
+    <div style={containerStyle}>
+      <div style={headerStyle}>
+        <strong>LlamaParse</strong>
+        <Pill pillStyle={pillStyle[status]} size="small">
+          {labels[status]}
+        </Pill>
+      </div>
+      <span style={descStyle}>{description}</span>
+      {id && (
+        <div>
+          <Button buttonStyle="primary" size="small" onClick={handleStart} disabled={isRunning}>
+            {isRunning ? 'Parsing…' : 'Parse with LlamaParse'}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/payload-documents/src/client/components/ParseButtonField.tsx
+++ b/packages/payload-documents/src/client/components/ParseButtonField.tsx
@@ -1,18 +1,10 @@
 'use client'
 
-import { Button, Pill, toast, useDocumentInfo, useFormFields } from '@payloadcms/ui'
+import { Button, Pill, toast, useFormFields } from '@payloadcms/ui'
 import type { UIFieldClientComponent } from 'payload'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 type ParseStatus = 'idle' | 'pending' | 'processing' | 'done' | 'error'
-
-const pillStyle: Record<ParseStatus, 'success' | 'error' | 'warning' | undefined> = {
-  idle: undefined,
-  pending: 'warning',
-  processing: 'warning',
-  done: 'success',
-  error: 'error'
-}
 
 const labels: Record<ParseStatus, string> = {
   idle: 'Idle',
@@ -22,131 +14,109 @@ const labels: Record<ParseStatus, string> = {
   error: 'Error'
 }
 
-const containerStyle: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: '8px',
-  padding: '16px 0'
-}
-
-const headerStyle: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '8px'
-}
-
-const descStyle: React.CSSProperties = {
-  fontSize: '13px',
-  opacity: 0.7
+const pillStyle: Record<ParseStatus, 'success' | 'error' | 'warning' | undefined> = {
+  idle: undefined,
+  pending: 'warning',
+  processing: 'warning',
+  done: 'success',
+  error: 'error'
 }
 
 const POLL_INTERVAL_MS = 3000
 
+const parseUrlContext = (): { slug?: string; id?: string } => {
+  if (typeof window === 'undefined') return {}
+  const match = window.location.pathname.match(/\/admin\/collections\/([^/]+)\/([^/?#]+)/)
+  if (!match) return {}
+  const [, slug, id] = match
+  if (!id || id === 'create') return { slug }
+  return { slug, id }
+}
+
 export const ParseButtonField: UIFieldClientComponent = () => {
-  const { id, collectionSlug } = useDocumentInfo()
   const persistedStatus = useFormFields(([fields]) => {
     const raw = fields?.parse_status?.value
     return typeof raw === 'string' ? (raw as ParseStatus) : 'idle'
   })
 
+  const [busy, setBusy] = useState(false)
   const [localStatus, setLocalStatus] = useState<ParseStatus | null>(null)
   const pollingRef = useRef<number | null>(null)
 
   const status: ParseStatus = localStatus ?? persistedStatus ?? 'idle'
-  const isRunning = status === 'pending' || status === 'processing'
 
   const stopPolling = useCallback(() => {
     if (pollingRef.current !== null) {
       window.clearInterval(pollingRef.current)
       pollingRef.current = null
     }
+    setBusy(false)
   }, [])
 
-  const pollOnce = useCallback(async () => {
-    if (!id || !collectionSlug) return
-    try {
-      const res = await fetch(`/api/${collectionSlug}/${id}/parse-status`)
-      const data = (await res.json()) as { status?: ParseStatus; error?: string }
-      const next = data.status ?? 'processing'
-      setLocalStatus(next)
-      if (next === 'done') {
-        stopPolling()
-        toast.success('Document parsed')
-        window.location.reload()
-      } else if (next === 'error') {
-        stopPolling()
-        toast.error(data.error ?? 'Parse failed')
-        window.location.reload()
-      }
-    } catch {
-      // keep polling; transient errors are fine
+  const startPolling = useCallback(
+    (slug: string, id: string) => {
+      stopPolling()
+      setBusy(true)
+      pollingRef.current = window.setInterval(async () => {
+        try {
+          const res = await fetch(`/api/${slug}/${id}/parse-status`)
+          const data = (await res.json()) as { status?: ParseStatus; error?: string }
+          const next = data.status ?? 'processing'
+          setLocalStatus(next)
+          if (next === 'done') {
+            stopPolling()
+            toast.success('Document parsed')
+            window.location.reload()
+          } else if (next === 'error') {
+            stopPolling()
+            toast.error(data.error ?? 'Parse failed')
+          }
+        } catch {
+          // keep polling on transient errors
+        }
+      }, POLL_INTERVAL_MS)
+    },
+    [stopPolling]
+  )
+
+  const handleClick = useCallback(async () => {
+    const { slug, id } = parseUrlContext()
+    if (!slug || !id) {
+      toast.error('Save the document before parsing.')
+      return
     }
-  }, [id, collectionSlug, stopPolling])
 
-  useEffect(() => stopPolling, [stopPolling])
-
-  const startPolling = useCallback(() => {
-    stopPolling()
-    pollingRef.current = window.setInterval(() => {
-      void pollOnce()
-    }, POLL_INTERVAL_MS)
-  }, [pollOnce, stopPolling])
-
-  // If the document was already in-flight when the user opened it, resume polling.
-  useEffect(() => {
-    if (persistedStatus === 'pending' || persistedStatus === 'processing') {
-      startPolling()
-    }
-  }, [persistedStatus, startPolling])
-
-  const handleStart = useCallback(async () => {
-    if (!id || !collectionSlug) return
+    setBusy(true)
     setLocalStatus('pending')
     try {
-      const res = await fetch(`/api/${collectionSlug}/${id}/parse`, { method: 'POST' })
+      const res = await fetch(`/api/${slug}/${id}/parse`, { method: 'POST' })
       const data = (await res.json().catch(() => ({}))) as { error?: string }
       if (!res.ok) {
+        setBusy(false)
         setLocalStatus('error')
-        toast.error(data.error ?? 'Failed to start parsing')
+        toast.error(data.error ?? `Parse failed (HTTP ${res.status})`)
         return
       }
       toast.success('Parsing started')
-      startPolling()
+      startPolling(slug, id)
     } catch (error) {
+      setBusy(false)
       setLocalStatus('error')
-      const message = error instanceof Error ? error.message : 'Failed to start parsing'
-      toast.error(message)
+      toast.error(error instanceof Error ? error.message : 'Network error')
     }
-  }, [id, collectionSlug, startPolling])
-
-  const description = useMemo(() => {
-    if (!id) return 'Upload a PDF and save the document to enable parsing.'
-    switch (status) {
-      case 'idle':
-        return 'Click to parse the uploaded PDF with LlamaParse.'
-      case 'pending':
-        return 'Job accepted by LlamaParse. Waiting to start…'
-      case 'processing':
-        return 'LlamaParse is processing the document.'
-      case 'done':
-        return 'Parsed markdown is available in the Output tab.'
-      case 'error':
-        return 'Parsing failed. See the error details below.'
-    }
-  }, [id, status])
+  }, [startPolling])
 
   return (
-    <div style={containerStyle}>
-      <div style={headerStyle}>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', padding: '16px 0' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
         <strong>LlamaParse</strong>
         <Pill pillStyle={pillStyle[status]} size="small">
           {labels[status]}
         </Pill>
       </div>
-      <span style={descStyle}>{description}</span>
       <div>
-        <Button buttonStyle="primary" size="small" onClick={handleStart} disabled={isRunning || !id}>
-          {isRunning ? 'Parsing…' : 'Parse with LlamaParse'}
+        <Button buttonStyle="primary" size="small" onClick={handleClick} disabled={busy}>
+          {busy ? 'Parsing…' : 'Parse with LlamaParse'}
         </Button>
       </div>
     </div>

--- a/packages/payload-documents/src/client/index.ts
+++ b/packages/payload-documents/src/client/index.ts
@@ -1,0 +1,3 @@
+'use client'
+
+export { ParseButtonField } from './components/ParseButtonField'

--- a/packages/payload-documents/src/endpoints/parse-endpoint.ts
+++ b/packages/payload-documents/src/endpoints/parse-endpoint.ts
@@ -10,7 +10,7 @@ import {
 } from './shared'
 
 export const createParseEndpoint = (config: EndpointConfig): Endpoint => ({
-  path: `/${config.collectionSlug}/:id/parse`,
+  path: '/:id/parse',
   method: 'post',
   handler: async (req: PayloadRequest) => {
     const authError = requireAuth(req)

--- a/packages/payload-documents/src/endpoints/parse-endpoint.ts
+++ b/packages/payload-documents/src/endpoints/parse-endpoint.ts
@@ -1,0 +1,58 @@
+import type { Endpoint, PayloadRequest } from 'payload'
+import {
+  type EndpointConfig,
+  fetchDocument,
+  fetchUploadedFile,
+  getLlamaParseClient,
+  getRouteId,
+  requireAuth,
+  updateDocument
+} from './shared'
+
+export const createParseEndpoint = (config: EndpointConfig): Endpoint => ({
+  path: `/${config.collectionSlug}/:id/parse`,
+  method: 'post',
+  handler: async (req: PayloadRequest) => {
+    const authError = requireAuth(req)
+    if (authError) return authError
+
+    const idOrError = getRouteId(req)
+    if (idOrError instanceof Response) return idOrError
+    const id = idOrError
+
+    const clientOrError = getLlamaParseClient(config)
+    if (clientOrError instanceof Response) return clientOrError
+    const client = clientOrError
+
+    const docOrError = await fetchDocument(req, config.collectionSlug, id)
+    if (docOrError instanceof Response) return docOrError
+    const doc = docOrError
+
+    const fileOrError = await fetchUploadedFile(req, doc)
+    if (fileOrError instanceof Response) return fileOrError
+    const { blob, filename } = fileOrError
+
+    try {
+      const job = await client.upload(blob, filename, {
+        language: doc.language ?? undefined,
+        parsingInstruction: doc.parsing_instruction ?? undefined,
+        mode: doc.mode ?? 'default'
+      })
+
+      await updateDocument(req, config.collectionSlug, id, {
+        parse_job_id: job.id,
+        parse_status: 'pending',
+        parse_error: null
+      })
+
+      return Response.json({ job_id: job.id, status: 'pending' })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'LlamaParse upload failed'
+      await updateDocument(req, config.collectionSlug, id, {
+        parse_status: 'error',
+        parse_error: message
+      })
+      return Response.json({ error: message }, { status: 500 })
+    }
+  }
+})

--- a/packages/payload-documents/src/endpoints/parse-status-endpoint.ts
+++ b/packages/payload-documents/src/endpoints/parse-status-endpoint.ts
@@ -57,6 +57,7 @@ const resolveJob = async (
 ): Promise<Response> => {
   if (jobStatus === 'SUCCESS') return handleSuccess(args)
   if (jobStatus === 'ERROR') return handleError(args, errorMessage)
+  if (jobStatus === 'CANCELED') return handleError(args, errorMessage ?? 'LlamaParse job was canceled')
   return handleProcessing(args)
 }
 

--- a/packages/payload-documents/src/endpoints/parse-status-endpoint.ts
+++ b/packages/payload-documents/src/endpoints/parse-status-endpoint.ts
@@ -61,7 +61,7 @@ const resolveJob = async (
 }
 
 export const createParseStatusEndpoint = (config: EndpointConfig): Endpoint => ({
-  path: `/${config.collectionSlug}/:id/parse-status`,
+  path: '/:id/parse-status',
   method: 'get',
   handler: async (req: PayloadRequest) => {
     const authError = requireAuth(req)

--- a/packages/payload-documents/src/endpoints/parse-status-endpoint.ts
+++ b/packages/payload-documents/src/endpoints/parse-status-endpoint.ts
@@ -1,0 +1,109 @@
+import type { Endpoint, PayloadRequest } from 'payload'
+import type { LlamaParseClient } from '../llama-parse/client'
+import type { LlamaParseJobStatus } from '../llama-parse/types'
+import {
+  type DocumentRecord,
+  type EndpointConfig,
+  fetchDocument,
+  getLlamaParseClient,
+  getRouteId,
+  requireAuth,
+  updateDocument
+} from './shared'
+
+const isTerminal = (status: DocumentRecord['parse_status']): boolean =>
+  !status || status === 'idle' || status === 'done' || status === 'error'
+
+interface ResolveArgs {
+  req: PayloadRequest
+  client: LlamaParseClient
+  config: EndpointConfig
+  id: string
+  jobId: string
+  currentStatus: DocumentRecord['parse_status']
+}
+
+const handleProcessing = async ({ req, config, id, currentStatus }: ResolveArgs): Promise<Response> => {
+  if (currentStatus !== 'processing') {
+    await updateDocument(req, config.collectionSlug, id, { parse_status: 'processing' })
+  }
+  return Response.json({ status: 'processing' })
+}
+
+const handleError = async ({ req, config, id }: ResolveArgs, errorMessage: string | undefined): Promise<Response> => {
+  const message = errorMessage ?? 'LlamaParse job failed'
+  await updateDocument(req, config.collectionSlug, id, {
+    parse_status: 'error',
+    parse_error: message
+  })
+  return Response.json({ status: 'error', error: message })
+}
+
+const handleSuccess = async ({ req, client, config, id, jobId }: ResolveArgs): Promise<Response> => {
+  const markdown = await client.getMarkdown(jobId)
+  await updateDocument(req, config.collectionSlug, id, {
+    parse_status: 'done',
+    parse_error: null,
+    parsed_at: new Date().toISOString(),
+    parsed_text: markdown
+  })
+  return Response.json({ status: 'done' })
+}
+
+const resolveJob = async (
+  args: ResolveArgs,
+  jobStatus: LlamaParseJobStatus,
+  errorMessage: string | undefined
+): Promise<Response> => {
+  if (jobStatus === 'SUCCESS') return handleSuccess(args)
+  if (jobStatus === 'ERROR') return handleError(args, errorMessage)
+  return handleProcessing(args)
+}
+
+export const createParseStatusEndpoint = (config: EndpointConfig): Endpoint => ({
+  path: `/${config.collectionSlug}/:id/parse-status`,
+  method: 'get',
+  handler: async (req: PayloadRequest) => {
+    const authError = requireAuth(req)
+    if (authError) return authError
+
+    const idOrError = getRouteId(req)
+    if (idOrError instanceof Response) return idOrError
+    const id = idOrError
+
+    const clientOrError = getLlamaParseClient(config)
+    if (clientOrError instanceof Response) return clientOrError
+    const client = clientOrError
+
+    const docOrError = await fetchDocument(req, config.collectionSlug, id)
+    if (docOrError instanceof Response) return docOrError
+    const doc = docOrError
+
+    const currentStatus = doc.parse_status ?? 'idle'
+
+    if (!doc.parse_job_id || isTerminal(currentStatus)) {
+      return Response.json({ status: currentStatus })
+    }
+
+    const args: ResolveArgs = {
+      req,
+      client,
+      config,
+      id,
+      jobId: doc.parse_job_id,
+      currentStatus
+    }
+
+    try {
+      const job = await client.getJobStatus(doc.parse_job_id)
+      return await resolveJob(args, job.status, job.error_message)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'LlamaParse status check failed'
+      await updateDocument(req, config.collectionSlug, id, {
+        parse_status: 'error',
+        parse_error: message
+      })
+      return Response.json({ status: 'error', error: message }, { status: 500 })
+    }
+  }
+})

--- a/packages/payload-documents/src/endpoints/shared.ts
+++ b/packages/payload-documents/src/endpoints/shared.ts
@@ -75,8 +75,18 @@ export const fetchUploadedFile = async (
     return Response.json({ error: 'Document has no uploaded file yet.' }, { status: 400 })
   }
 
-  const serverURL = req.payload.config.serverURL ?? ''
-  const absoluteUrl = doc.url.startsWith('http') ? doc.url : `${serverURL}${doc.url}`
+  const serverURL = req.payload.config.serverURL
+  const isAbsolute = doc.url.startsWith('http')
+  if (!isAbsolute && !serverURL) {
+    return Response.json(
+      {
+        error:
+          'Cannot resolve file URL: Payload `serverURL` is not configured and the uploaded file URL is relative. Set `serverURL` in payload.config or use a storage adapter that returns absolute URLs.'
+      },
+      { status: 500 }
+    )
+  }
+  const absoluteUrl = isAbsolute ? doc.url : `${serverURL}${doc.url}`
   const cookieHeader = req.headers.get('cookie') ?? ''
 
   try {

--- a/packages/payload-documents/src/endpoints/shared.ts
+++ b/packages/payload-documents/src/endpoints/shared.ts
@@ -1,0 +1,114 @@
+import type { PayloadRequest } from 'payload'
+import { LlamaParseClient } from '../llama-parse/client'
+
+export interface EndpointConfig {
+  collectionSlug: string
+  apiKey: string | undefined
+  baseUrl: string
+}
+
+export interface DocumentRecord {
+  id: string | number
+  filename?: string | null
+  url?: string | null
+  mimeType?: string | null
+  language?: string | null
+  parsing_instruction?: string | null
+  mode?: 'fast' | 'default' | 'premium' | null
+  parse_status?: 'idle' | 'pending' | 'processing' | 'done' | 'error' | null
+  parse_job_id?: string | null
+  parse_error?: string | null
+  parsed_at?: string | null
+  parsed_text?: string | null
+}
+
+export const getLlamaParseClient = (config: EndpointConfig): LlamaParseClient | Response => {
+  if (!config.apiKey) {
+    return Response.json(
+      { error: 'LlamaParse API key is not configured (set LLAMA_CLOUD_API_KEY or pass llamaParseApiKey).' },
+      { status: 500 }
+    )
+  }
+  return new LlamaParseClient({ apiKey: config.apiKey, baseUrl: config.baseUrl })
+}
+
+export const requireAuth = (req: PayloadRequest): Response | null => {
+  if (!req.user) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return null
+}
+
+export const getRouteId = (req: PayloadRequest): string | Response => {
+  const id = req.routeParams?.id
+  if (typeof id !== 'string' || id.length === 0) {
+    return Response.json({ error: 'Missing id' }, { status: 400 })
+  }
+  return id
+}
+
+export const fetchDocument = async (
+  req: PayloadRequest,
+  collectionSlug: string,
+  id: string
+): Promise<DocumentRecord | Response> => {
+  try {
+    const doc = await req.payload.findByID({
+      collection: collectionSlug,
+      id,
+      depth: 0,
+      overrideAccess: false,
+      req
+    })
+    return doc as unknown as DocumentRecord
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Document not found'
+    return Response.json({ error: message }, { status: 404 })
+  }
+}
+
+export const fetchUploadedFile = async (
+  req: PayloadRequest,
+  doc: DocumentRecord
+): Promise<{ blob: Blob; filename: string } | Response> => {
+  if (!doc.url || !doc.filename) {
+    return Response.json({ error: 'Document has no uploaded file yet.' }, { status: 400 })
+  }
+
+  const serverURL = req.payload.config.serverURL ?? ''
+  const absoluteUrl = doc.url.startsWith('http') ? doc.url : `${serverURL}${doc.url}`
+  const cookieHeader = req.headers.get('cookie') ?? ''
+
+  try {
+    const res = await fetch(absoluteUrl, {
+      headers: cookieHeader ? { cookie: cookieHeader } : undefined
+    })
+    if (!res.ok) {
+      return Response.json(
+        { error: `Failed to download uploaded file (${res.status} ${res.statusText})` },
+        { status: 502 }
+      )
+    }
+    const blob = await res.blob()
+    return { blob, filename: doc.filename }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to download uploaded file'
+    return Response.json({ error: message }, { status: 502 })
+  }
+}
+
+export const updateDocument = async (
+  req: PayloadRequest,
+  collectionSlug: string,
+  id: string,
+  data: Partial<DocumentRecord>
+): Promise<void> => {
+  await req.payload.update({
+    collection: collectionSlug,
+    id,
+    data: data as Record<string, unknown>,
+    depth: 0,
+    overrideAccess: true,
+    req
+  })
+}

--- a/packages/payload-documents/src/index.ts
+++ b/packages/payload-documents/src/index.ts
@@ -1,0 +1,20 @@
+export {
+  DEFAULT_LLAMA_PARSE_BASE_URL,
+  LlamaParseClient,
+  type LlamaParseClientConfig
+} from './llama-parse/client'
+export type {
+  LlamaParseJob,
+  LlamaParseJobDetails,
+  LlamaParseJobStatus,
+  LlamaParseMode,
+  LlamaParseUploadOptions
+} from './llama-parse/types'
+export {
+  buildDocumentsCollection,
+  createDocumentsPlugin,
+  DEFAULT_COLLECTION_SLUG,
+  type DocumentsPluginConfig,
+  type DocumentsPluginOverrides,
+  type DocumentsPluginResult
+} from './plugin'

--- a/packages/payload-documents/src/llama-parse/client.ts
+++ b/packages/payload-documents/src/llama-parse/client.ts
@@ -1,0 +1,83 @@
+import type { LlamaParseJob, LlamaParseJobDetails, LlamaParseUploadOptions } from './types'
+
+export const DEFAULT_LLAMA_PARSE_BASE_URL = 'https://api.cloud.llamaindex.ai/api/v1'
+
+export interface LlamaParseClientConfig {
+  apiKey: string
+  baseUrl?: string
+}
+
+export class LlamaParseClient {
+  private readonly apiKey: string
+  private readonly baseUrl: string
+
+  constructor(config: LlamaParseClientConfig) {
+    if (!config.apiKey) {
+      throw new Error('LlamaParse API key is required')
+    }
+    this.apiKey = config.apiKey
+    this.baseUrl = (config.baseUrl ?? DEFAULT_LLAMA_PARSE_BASE_URL).replace(/\/$/, '')
+  }
+
+  private authHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${this.apiKey}` }
+  }
+
+  async upload(file: Blob, filename: string, opts: LlamaParseUploadOptions = {}): Promise<LlamaParseJob> {
+    const form = new FormData()
+    form.append('file', file, filename)
+    form.append('result_type', 'markdown')
+    if (opts.language) form.append('language', opts.language)
+    if (opts.parsingInstruction) form.append('parsing_instruction', opts.parsingInstruction)
+    const mode = opts.mode ?? 'default'
+    if (mode === 'fast') form.append('fast_mode', 'true')
+    if (mode === 'premium') form.append('premium_mode', 'true')
+
+    const res = await fetch(`${this.baseUrl}/parsing/upload`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: form
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`LlamaParse upload failed (${res.status}): ${body || res.statusText}`)
+    }
+
+    const data = (await res.json()) as LlamaParseJob
+    return data
+  }
+
+  async getJobStatus(id: string): Promise<LlamaParseJobDetails> {
+    const res = await fetch(`${this.baseUrl}/parsing/job/${encodeURIComponent(id)}`, {
+      method: 'GET',
+      headers: this.authHeaders()
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`LlamaParse job status failed (${res.status}): ${body || res.statusText}`)
+    }
+
+    const data = (await res.json()) as LlamaParseJobDetails
+    return data
+  }
+
+  async getMarkdown(id: string): Promise<string> {
+    const res = await fetch(`${this.baseUrl}/parsing/job/${encodeURIComponent(id)}/result/markdown`, {
+      method: 'GET',
+      headers: this.authHeaders()
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      throw new Error(`LlamaParse markdown fetch failed (${res.status}): ${body || res.statusText}`)
+    }
+
+    const data = (await res.json()) as { markdown?: string }
+    if (typeof data.markdown !== 'string') {
+      throw new Error('LlamaParse markdown response missing `markdown` field')
+    }
+    return data.markdown
+  }
+}

--- a/packages/payload-documents/src/llama-parse/types.ts
+++ b/packages/payload-documents/src/llama-parse/types.ts
@@ -1,0 +1,18 @@
+export type LlamaParseMode = 'fast' | 'default' | 'premium'
+
+export type LlamaParseJobStatus = 'PENDING' | 'SUCCESS' | 'ERROR' | 'CANCELED'
+
+export interface LlamaParseUploadOptions {
+  language?: string
+  parsingInstruction?: string
+  mode?: LlamaParseMode
+}
+
+export interface LlamaParseJob {
+  id: string
+  status: LlamaParseJobStatus
+}
+
+export interface LlamaParseJobDetails extends LlamaParseJob {
+  error_message?: string
+}

--- a/packages/payload-documents/src/plugin/build-collection.ts
+++ b/packages/payload-documents/src/plugin/build-collection.ts
@@ -5,7 +5,8 @@ export const buildDocumentsCollection = (slug: string): CollectionConfig => ({
   admin: {
     useAsTitle: 'filename',
     group: 'Content',
-    description: 'Documents parsed to markdown via LlamaParse.'
+    description: 'Documents parsed to markdown via LlamaParse.',
+    defaultColumns: ['filename', 'parse_status', 'parsed_at']
   },
   upload: {
     staticDir: slug,
@@ -13,65 +14,60 @@ export const buildDocumentsCollection = (slug: string): CollectionConfig => ({
   },
   fields: [
     {
+      name: 'parse_action',
+      type: 'ui',
+      admin: {
+        components: {
+          Field: '@zetesis/payload-documents/client#ParseButtonField'
+        }
+      }
+    },
+    {
+      name: 'parse_status',
+      type: 'select',
+      defaultValue: 'idle',
+      options: [
+        { label: 'Idle', value: 'idle' },
+        { label: 'Pending', value: 'pending' },
+        { label: 'Processing', value: 'processing' },
+        { label: 'Done', value: 'done' },
+        { label: 'Error', value: 'error' }
+      ],
+      admin: {
+        readOnly: true,
+        position: 'sidebar'
+      }
+    },
+    {
+      name: 'parse_job_id',
+      type: 'text',
+      admin: {
+        readOnly: true,
+        position: 'sidebar'
+      }
+    },
+    {
+      name: 'parsed_at',
+      type: 'date',
+      admin: {
+        readOnly: true,
+        position: 'sidebar',
+        date: {
+          pickerAppearance: 'dayAndTime'
+        }
+      }
+    },
+    {
+      name: 'parse_error',
+      type: 'textarea',
+      admin: {
+        readOnly: true,
+        condition: (data: Record<string, unknown> | undefined) => data?.parse_status === 'error'
+      }
+    },
+    {
       type: 'tabs',
       tabs: [
-        {
-          label: 'Parsing',
-          fields: [
-            {
-              name: 'parse_action',
-              type: 'ui',
-              admin: {
-                components: {
-                  Field: '@zetesis/payload-documents/client#ParseButtonField'
-                }
-              }
-            },
-            {
-              name: 'parse_status',
-              type: 'select',
-              defaultValue: 'idle',
-              options: [
-                { label: 'Idle', value: 'idle' },
-                { label: 'Pending', value: 'pending' },
-                { label: 'Processing', value: 'processing' },
-                { label: 'Done', value: 'done' },
-                { label: 'Error', value: 'error' }
-              ],
-              admin: {
-                readOnly: true,
-                position: 'sidebar'
-              }
-            },
-            {
-              name: 'parse_job_id',
-              type: 'text',
-              admin: {
-                readOnly: true,
-                position: 'sidebar'
-              }
-            },
-            {
-              name: 'parsed_at',
-              type: 'date',
-              admin: {
-                readOnly: true,
-                position: 'sidebar',
-                date: {
-                  pickerAppearance: 'dayAndTime'
-                }
-              }
-            },
-            {
-              name: 'parse_error',
-              type: 'textarea',
-              admin: {
-                readOnly: true,
-                condition: (data: Record<string, unknown> | undefined) => data?.parse_status === 'error'
-              }
-            }
-          ]
-        },
         {
           label: 'Params',
           fields: [

--- a/packages/payload-documents/src/plugin/build-collection.ts
+++ b/packages/payload-documents/src/plugin/build-collection.ts
@@ -1,0 +1,123 @@
+import type { CollectionConfig } from 'payload'
+
+export const buildDocumentsCollection = (slug: string): CollectionConfig => ({
+  slug,
+  admin: {
+    useAsTitle: 'filename',
+    group: 'Content',
+    description: 'Documents parsed to markdown via LlamaParse.'
+  },
+  upload: {
+    staticDir: slug,
+    mimeTypes: ['application/pdf']
+  },
+  fields: [
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Parsing',
+          fields: [
+            {
+              name: 'parse_action',
+              type: 'ui',
+              admin: {
+                components: {
+                  Field: '@zetesis/payload-documents/client#ParseButtonField'
+                }
+              }
+            },
+            {
+              name: 'parse_status',
+              type: 'select',
+              defaultValue: 'idle',
+              options: [
+                { label: 'Idle', value: 'idle' },
+                { label: 'Pending', value: 'pending' },
+                { label: 'Processing', value: 'processing' },
+                { label: 'Done', value: 'done' },
+                { label: 'Error', value: 'error' }
+              ],
+              admin: {
+                readOnly: true,
+                position: 'sidebar'
+              }
+            },
+            {
+              name: 'parse_job_id',
+              type: 'text',
+              admin: {
+                readOnly: true,
+                position: 'sidebar'
+              }
+            },
+            {
+              name: 'parsed_at',
+              type: 'date',
+              admin: {
+                readOnly: true,
+                position: 'sidebar',
+                date: {
+                  pickerAppearance: 'dayAndTime'
+                }
+              }
+            },
+            {
+              name: 'parse_error',
+              type: 'textarea',
+              admin: {
+                readOnly: true,
+                condition: (data: Record<string, unknown> | undefined) => data?.parse_status === 'error'
+              }
+            }
+          ]
+        },
+        {
+          label: 'Params',
+          fields: [
+            {
+              name: 'language',
+              type: 'text',
+              admin: {
+                description: 'Optional language hint for OCR (e.g. "es", "en").'
+              }
+            },
+            {
+              name: 'mode',
+              type: 'select',
+              defaultValue: 'default',
+              options: [
+                { label: 'Fast', value: 'fast' },
+                { label: 'Default', value: 'default' },
+                { label: 'Premium', value: 'premium' }
+              ],
+              admin: {
+                description: 'Speed vs. quality. Premium enables enhanced OCR.'
+              }
+            },
+            {
+              name: 'parsing_instruction',
+              type: 'textarea',
+              admin: {
+                description: 'Free-form instruction to guide LlamaParse (e.g. "preserve tables").'
+              }
+            }
+          ]
+        },
+        {
+          label: 'Output',
+          fields: [
+            {
+              name: 'parsed_text',
+              type: 'code',
+              admin: {
+                language: 'markdown',
+                description: 'Markdown returned by LlamaParse. Editable.'
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+})

--- a/packages/payload-documents/src/plugin/create-documents-plugin.ts
+++ b/packages/payload-documents/src/plugin/create-documents-plugin.ts
@@ -1,0 +1,33 @@
+import type { Config } from 'payload'
+import { createParseEndpoint } from '../endpoints/parse-endpoint'
+import { createParseStatusEndpoint } from '../endpoints/parse-status-endpoint'
+import { DEFAULT_LLAMA_PARSE_BASE_URL } from '../llama-parse/client'
+import { buildDocumentsCollection } from './build-collection'
+import { DEFAULT_COLLECTION_SLUG, type DocumentsPluginConfig, type DocumentsPluginResult } from './types'
+
+export const createDocumentsPlugin = (options: DocumentsPluginConfig = {}): DocumentsPluginResult => {
+  const slug = options.collectionSlug ?? DEFAULT_COLLECTION_SLUG
+  const baseUrl = options.llamaParseBaseUrl ?? DEFAULT_LLAMA_PARSE_BASE_URL
+
+  const plugin = (payloadConfig: Config): Config => {
+    const apiKey = options.llamaParseApiKey ?? process.env.LLAMA_CLOUD_API_KEY
+
+    let collection = buildDocumentsCollection(slug)
+    if (options.overrides?.collection) {
+      collection = options.overrides.collection(collection)
+    }
+
+    payloadConfig.collections = [...(payloadConfig.collections ?? []), collection]
+
+    const endpointConfig = { collectionSlug: slug, apiKey, baseUrl }
+    payloadConfig.endpoints = [
+      ...(payloadConfig.endpoints ?? []),
+      createParseEndpoint(endpointConfig),
+      createParseStatusEndpoint(endpointConfig)
+    ]
+
+    return payloadConfig
+  }
+
+  return { plugin }
+}

--- a/packages/payload-documents/src/plugin/create-documents-plugin.ts
+++ b/packages/payload-documents/src/plugin/create-documents-plugin.ts
@@ -12,19 +12,22 @@ export const createDocumentsPlugin = (options: DocumentsPluginConfig = {}): Docu
   const plugin = (payloadConfig: Config): Config => {
     const apiKey = options.llamaParseApiKey ?? process.env.LLAMA_CLOUD_API_KEY
 
+    const endpointConfig = { collectionSlug: slug, apiKey, baseUrl }
+
     let collection = buildDocumentsCollection(slug)
+    collection = {
+      ...collection,
+      endpoints: [
+        ...(collection.endpoints ? collection.endpoints : []),
+        createParseEndpoint(endpointConfig),
+        createParseStatusEndpoint(endpointConfig)
+      ]
+    }
     if (options.overrides?.collection) {
       collection = options.overrides.collection(collection)
     }
 
     payloadConfig.collections = [...(payloadConfig.collections ?? []), collection]
-
-    const endpointConfig = { collectionSlug: slug, apiKey, baseUrl }
-    payloadConfig.endpoints = [
-      ...(payloadConfig.endpoints ?? []),
-      createParseEndpoint(endpointConfig),
-      createParseStatusEndpoint(endpointConfig)
-    ]
 
     return payloadConfig
   }

--- a/packages/payload-documents/src/plugin/index.ts
+++ b/packages/payload-documents/src/plugin/index.ts
@@ -1,0 +1,8 @@
+export { buildDocumentsCollection } from './build-collection'
+export { createDocumentsPlugin } from './create-documents-plugin'
+export {
+  DEFAULT_COLLECTION_SLUG,
+  type DocumentsPluginConfig,
+  type DocumentsPluginOverrides,
+  type DocumentsPluginResult
+} from './types'

--- a/packages/payload-documents/src/plugin/types.ts
+++ b/packages/payload-documents/src/plugin/types.ts
@@ -1,0 +1,31 @@
+import type { CollectionConfig } from 'payload'
+
+export interface DocumentsPluginOverrides {
+  collection?: (collection: CollectionConfig) => CollectionConfig
+}
+
+export interface DocumentsPluginConfig {
+  /**
+   * Slug of the collection to register. Defaults to `documents`.
+   */
+  collectionSlug?: string
+  /**
+   * LlamaParse (LlamaIndex Cloud) API key. Defaults to `process.env.LLAMA_CLOUD_API_KEY`.
+   */
+  llamaParseApiKey?: string
+  /**
+   * Override the base URL of the LlamaParse API. Defaults to the public LlamaIndex Cloud endpoint.
+   */
+  llamaParseBaseUrl?: string
+  /**
+   * Hooks to let host apps customize the generated collection
+   * (access, admin group, tenant wiring, etc.) without forking the plugin.
+   */
+  overrides?: DocumentsPluginOverrides
+}
+
+export interface DocumentsPluginResult {
+  plugin: (config: import('payload').Config) => import('payload').Config
+}
+
+export const DEFAULT_COLLECTION_SLUG = 'documents'

--- a/packages/payload-documents/tsconfig.json
+++ b/packages/payload-documents/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/payload-documents/tsdown.config.ts
+++ b/packages/payload-documents/tsdown.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/client/index.ts'],
+  format: ['esm'],
+  dts: {
+    resolve: true
+  },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  outDir: 'dist',
+  tsconfig: './tsconfig.json',
+  inputOptions: {
+    transform: {
+      jsx: { runtime: 'automatic' }
+    }
+  },
+  external: ['payload', '@payloadcms/ui', 'next', 'react', 'react-dom']
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,34 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
 
+  packages/payload-documents:
+    dependencies:
+      '@payloadcms/ui':
+        specifier: ^3.81.0
+        version: 3.81.0(@types/react@19.1.8)(monaco-editor@0.55.1)(next@16.1.6(@playwright/test@1.58.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.77.4))(payload@3.81.0(graphql@16.13.1)(typescript@5.7.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.7.3)
+      payload:
+        specifier: ^3.81.0
+        version: 3.81.0(graphql@16.13.1)(typescript@5.7.3)
+      react:
+        specifier: ^19
+        version: 19.2.4
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.7
+        version: 22.19.13
+      '@types/react':
+        specifier: ^19
+        version: 19.1.8
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+      tsdown:
+        specifier: ^0.16.5
+        version: 0.16.8(typescript@5.7.3)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   packages/payload-indexer:
     dependencies:
       '@google/generative-ai':


### PR DESCRIPTION
## Summary

Adds a new `@zetesis/payload-documents` OSS package: a Payload CMS plugin that registers an upload-enabled `documents` collection and wires a LlamaParse (LlamaIndex Cloud) flow so uploaded PDFs can be parsed into editable markdown directly from the admin UI.

The design mirrors `payload-indexer`: dual dev/npm exports, tsdown multi-entry build, `.client` boundary for the admin component, and a factory `createDocumentsPlugin({ overrides, ... })` that does not hardcode multitenancy or storage decisions — host apps wire those via the existing `plugin-multi-tenant` and `storage-s3` plugins.

## What it does

- **Upload + config in one record.** The `documents` collection is upload-enabled (PDFs). Per-document parameters are saved on the record itself: `language`, `mode` (`fast` / `default` / `premium`), `parsing_instruction`. `result_type` is fixed to `markdown` so downstream consumers get a stable shape.
- **Async job model.** `POST /api/{slug}/:id/parse` uploads the PDF to LlamaParse, stores `parse_job_id`, and returns. `GET /api/{slug}/:id/parse-status` polls LlamaParse and — on `SUCCESS` — writes the markdown into the `parsed_text` `code` field (editable by the user afterwards).
- **Admin UX.** `ParseButtonField` (exported from `@zetesis/payload-documents/client`) renders a button with a live status pill, polls every 3s while running, and reloads the form once the job settles so the parsed markdown appears in the Output tab.
- **Errors surface instead of being swallowed.** API failures set `parse_status='error'` and write the message into the read-only `parse_error` textarea.

## Package shape

```
packages/payload-documents/
├── src/
│   ├── index.ts, client/{index.ts,components/ParseButtonField.tsx}
│   ├── plugin/{create-documents-plugin.ts,build-collection.ts,types.ts,index.ts}
│   ├── endpoints/{parse-endpoint.ts,parse-status-endpoint.ts,shared.ts}
│   └── llama-parse/{client.ts,types.ts}
├── package.json  # dual exports ".", "./client" + publishConfig to dist
├── tsconfig.json # extends tsconfig.base.json
└── tsdown.config.ts
```

## Usage

```ts
import { createDocumentsPlugin } from '@zetesis/payload-documents'

export default buildConfig({
  plugins: [
    createDocumentsPlugin({
      overrides: {
        collection: current => ({ ...current, access: myAccessMap })
      }
    }).plugin,
  ],
})
```

Host apps additionally:
- add `documents` to `@payloadcms/plugin-multi-tenant` `collections` if they want per-tenant documents
- add `documents: true` to `@payloadcms/storage-s3` `collections` to send PDFs to S3/R2 instead of the local filesystem
- expose `LLAMA_CLOUD_API_KEY` in the runtime environment

## Test plan

- [x] `pnpm --filter @zetesis/payload-documents build` — tsdown build produces `dist/index.mjs`, `dist/client/index.mjs`, and self-contained `.d.mts` declarations.
- [x] `pnpm tsc --noEmit` at the monorepo root — clean.
- [x] Biome check on `packages/payload-documents/src` — clean (no ignores, no `as any`).
- [ ] End-to-end in the consumer app: upload a PDF, click **Parse with LlamaParse**, observe status transitions `idle → pending → processing → done`, see markdown populated and editable.
- [ ] Error path: unset `LLAMA_CLOUD_API_KEY`, click Parse, confirm `parse_status='error'` and `parse_error` populated.

Companion wiring PR in zetesis-portal (Zetesis-Labs/ZetesisPortal `feat/documents-collection`) will bump this submodule and register the collection for the portal tenants.

---

Changeset included: minor bump for the new package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
