### PR TITLE
fix(payload-indexer): per-collection defaultColumns wins over global sync default

### DIFF
--- a/.changeset/indexer-default-columns-precedence.md
+++ b/.changeset/indexer-default-columns-precedence.md
@@ -1,0 +1,7 @@
+---
+'@zetesis/payload-indexer': patch
+---
+
+Fix `defaultColumns` precedence so the per-collection `admin.defaultColumns` wins over the global `syncConfig.defaultColumns` (the global is now a fallback for collections that haven't picked their own list).
+
+Previously the global default silently overrode every indexed collection — e.g. `@zetesis/payload-documents` ships `['filename', 'parse_status', 'parsed_at']` but the host's global `['title', '_syncStatus', 'slug', 'categorias']` was applied instead, leaving only `_syncStatus` rendered (the other columns don't exist on the documents schema).

--- a/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
+++ b/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
@@ -173,7 +173,11 @@ function injectSyncStatusField(
     const tableConfigs = indexedCollections[collection.slug]
     if (!tableConfigs) return collection
 
-    const defaultColumns = syncConfig?.defaultColumns ?? collection.admin?.defaultColumns
+    // Per-collection `admin.defaultColumns` wins over the global sync default
+    // — the global is a fallback for collections that haven't picked their
+    // own admin columns. Inverting this would silently override every
+    // collection's bespoke list (filename/parse_status for documents, etc).
+    const defaultColumns = collection.admin?.defaultColumns ?? syncConfig?.defaultColumns
 
     return {
       ...collection,


### PR DESCRIPTION
## Summary

`syncConfig.defaultColumns` was overriding `collection.admin.defaultColumns` for every indexed collection. With this PR the global is a *fallback* for collections that haven't picked their own list — host stays in control where it cares, the package's defaults work everywhere else.

## Repro

In ZetesisPortal we just wired `@zetesis/payload-documents` (which ships `defaultColumns: ['filename', 'parse_status', 'parsed_at']`) into the typesense indexer plugin (host global: `['title', '_syncStatus', 'slug', 'categorias']`). The admin list view rendered **only `_syncStatus`** — the global won, and `title`/`slug`/`categorias` don't exist on `documents`, so they silently dropped.

After this fix the documents list shows filename / parse_status / parsed_at as the package intended, while collections without an own `defaultColumns` (Posts, ResearchProjects in zp) still pick up the global.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm --filter @zetesis/payload-indexer build` clean
- [ ] Verify in zp that the documents list view shows filename first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
