### PR TITLE
fix(metrics): re-export MetricsPluginResult (lost in 0.1.0 rebase)

### DIFF
--- a/.changeset/export-metrics-plugin-result.md
+++ b/.changeset/export-metrics-plugin-result.md
@@ -1,0 +1,5 @@
+---
+'@zetesis/payload-agents-metrics': patch
+---
+
+Re-export `MetricsPluginResult` (the inferred return type of `metricsPlugin()`) from the package root. Without it, downstream packages that re-export `metricsPlugin(...)` fail with TS4023 ("Exported variable has or is using name from external module but cannot be named"). Same fix that landed in `76a92c1` and was lost in a rebase before the 0.1.0 release.

--- a/packages/payload-agents-metrics/src/index.ts
+++ b/packages/payload-agents-metrics/src/index.ts
@@ -6,7 +6,7 @@ export type { AggregateFilters, BucketRow, GroupBy, SeriesRow, Totals } from './
 export { calculateLlmCost, type LlmProvider, normalizeProvider } from './lib/cost-calculator'
 export { createOnRunCompleted } from './lib/on-run-completed'
 export type { SessionFilters, SessionRow, SessionsResult, SessionTotals } from './lib/sessions-query'
-export { metricsPlugin, type MetricsPluginResult } from './plugin'
+export { type MetricsPluginResult, metricsPlugin } from './plugin'
 // Types
 export type {
   AccessResult,

--- a/packages/payload-agents-metrics/src/index.ts
+++ b/packages/payload-agents-metrics/src/index.ts
@@ -6,7 +6,7 @@ export type { AggregateFilters, BucketRow, GroupBy, SeriesRow, Totals } from './
 export { calculateLlmCost, type LlmProvider, normalizeProvider } from './lib/cost-calculator'
 export { createOnRunCompleted } from './lib/on-run-completed'
 export type { SessionFilters, SessionRow, SessionsResult, SessionTotals } from './lib/sessions-query'
-export { metricsPlugin } from './plugin'
+export { metricsPlugin, type MetricsPluginResult } from './plugin'
 // Types
 export type {
   AccessResult,

--- a/packages/payload-agents-metrics/src/plugin.ts
+++ b/packages/payload-agents-metrics/src/plugin.ts
@@ -41,7 +41,11 @@ function resolveConfig(userConfig: MetricsPluginConfig): ResolvedMetricsConfig {
   }
 }
 
-interface MetricsPluginResult extends Plugin {
+/**
+ * Return type of `metricsPlugin()`. Exported so downstream packages that
+ * re-export the wrapped plugin can name it; otherwise TS bails with TS4023.
+ */
+export interface MetricsPluginResult extends Plugin {
   /** Callback for `agentPlugin({ onRunCompleted })`. */
   onRunCompleted: ReturnType<typeof createOnRunCompleted>
 }


### PR DESCRIPTION
## Summary
- Re-export the `MetricsPluginResult` interface that `metricsPlugin()` returns. Without it, downstream packages that wrap and re-export the plugin fail with TS4023.

## Why
Landed once in [76a92c1](https://github.com/Zetesis-Labs/PayloadAgents/commit/76a92c1) but disappeared in a rebase before `@zetesis/payload-agents-metrics@0.1.0` was published. The consumer in `Zetesis-Labs/ZetesisPortal#222` is failing CI on this exact error:

\`\`\`
src/payload/plugins/metrics/index.ts(9,14): error TS4023: Exported variable 'metricsPlugin' has or is using name 'MetricsPluginResult' from external module ".../@zetesis/payload-agents-metrics/dist/index" but cannot be named.
\`\`\`

## Test plan
- [ ] CI green on this branch
- [ ] After merge + npm publish (0.1.2), ZetesisPortal#222 type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)