### PR TITLE
fix(metrics): batchFetchFirstMessages binds text[] correctly via IN list

### DIFF
--- a/.changeset/fix-batch-fetch-pg-array-param.md
+++ b/.changeset/fix-batch-fetch-pg-array-param.md
@@ -1,0 +1,7 @@
+---
+'@zetesis/payload-agents-metrics': patch
+---
+
+Fix `/llm-usage/sessions` 500 caused by a malformed `text[]` parameter.
+
+`batchFetchFirstMessages` was rewritten in 0.1.1 to use `session_id = ANY($1::text[])`. With drizzle-orm + node-postgres the JS array is bound as a single string parameter, so Postgres receives e.g. `"af571d36-..."` and fails the `::text[]` cast with "malformed array literal". Switched to `session_id IN (...)` expanded via `sql.join`, which emits one parameterised placeholder per id and uses the session_id index just as well as the original OR list.

--- a/packages/payload-agents-metrics/src/lib/sessions-query.ts
+++ b/packages/payload-agents-metrics/src/lib/sessions-query.ts
@@ -194,13 +194,19 @@ async function batchFetchFirstMessages(
   const result = new Map<string, string>()
   if (conversationIds.length === 0) return result
 
-  // session_id = ANY($1::text[]) is parameter-bound and uses the index on
-  // session_id — beats a chained OR list, which the planner expands into N
-  // separate predicates and degrades as PAGE_SIZE grows.
+  // session_id IN (...) emits one parameterised placeholder per id, which
+  // node-postgres binds correctly. ANY(${array}::text[]) looks cleaner but
+  // drizzle's sql template hands the JS array to pg as a single string
+  // ("uuid"), which Postgres can't cast to text[] (malformed array literal).
+  // sql.join with comma separators expands to ($1, $2, …) and uses the
+  // session_id index just as well as a chained OR list.
   const rows = await db.execute(sql`
     SELECT session_id, runs
     FROM ${sql.raw(agnoSessionsTable)}
-    WHERE session_id = ANY(${conversationIds}::text[])
+    WHERE session_id IN (${sql.join(
+      conversationIds.map(id => sql`${id}`),
+      sql`, `
+    )})
   `)
 
   for (const row of rows.rows) {


### PR DESCRIPTION
## Summary
- Reverts the `session_id = ANY($1::text[])` rewrite from 0.1.1. drizzle-orm + node-postgres binds the JS array as a single string parameter, Postgres rejects the cast with "malformed array literal" and the sessions endpoint returns 500.
- Switches to `session_id IN (...)` expanded via `sql.join` — one placeholder per id, identical index usage, no array-literal binding.

## Repro (nexus-template, fresh clone of metrics 0.1.2)

\`\`\`
Failed query:
  SELECT session_id, runs FROM agno.agno_sessions
  WHERE session_id = ANY(($1)::text[])
params: af571d36-d7b8-40a0-b4ee-3bda46eb6be8
caused by: error: malformed array literal: "af571d36-..."
\`\`\`

## Test plan
- [ ] CI green on this branch
- [ ] After merge + publish (0.1.3), nexus-template `/dashboard/llm-usage` loads sessions without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)