### PR TITLE
feat(core)!: require searchCollectionOptions on agentPlugin

### DIFF
--- a/.changeset/required-search-collection-options.md
+++ b/.changeset/required-search-collection-options.md
@@ -1,0 +1,38 @@
+---
+'@zetesis/payload-agents-core': minor
+---
+
+**BREAKING**: `agentPlugin({...})` now requires `searchCollectionOptions` in its config.
+
+The agent's `searchCollections` field used to ship with the options hardcoded to `posts_chunk` and `books_chunk`. That silently broke any consumer indexing additional collections (e.g. `documents_chunk` once the documents plugin is wired up): chunks were indexed but the agent had no way to query them.
+
+The plugin now demands an explicit list and refuses to boot without one — same stance as `mediaCollectionSlug` and `taxonomyCollectionSlug`. Each consumer's set of indexed collections is project-specific, so silently defaulting would mask wiring mistakes.
+
+Migration:
+
+```ts
+// Before (0.3.x)
+agentPlugin({
+  runtimeUrl: '...',
+  mediaCollectionSlug: 'media',
+  taxonomyCollectionSlug: 'taxonomy',
+  // ...
+})
+
+// After (0.4.x)
+agentPlugin({
+  runtimeUrl: '...',
+  mediaCollectionSlug: 'media',
+  taxonomyCollectionSlug: 'taxonomy',
+  searchCollectionOptions: [
+    { label: 'Posts', value: 'posts_chunk' },
+    { label: 'Books', value: 'books_chunk' }
+    // add { label: 'Documents', value: 'documents_chunk' } if you index documents
+  ],
+  // ...
+})
+```
+
+Empty arrays are rejected at boot: `agentPlugin` throws if the list has zero entries — an agent that can't search anything is almost certainly a misconfiguration.
+
+Existing agents in the database keep whatever was saved at creation. The new `defaultValue` (= every option you declare) only applies to brand-new agents.

--- a/packages/payload-agents-core/src/collections/agents.ts
+++ b/packages/payload-agents-core/src/collections/agents.ts
@@ -112,11 +112,8 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
                     name: 'searchCollections',
                     type: 'select',
                     hasMany: true,
-                    defaultValue: ['posts_chunk', 'books_chunk'],
-                    options: [
-                      { label: 'Posts', value: 'posts_chunk' },
-                      { label: 'Books', value: 'books_chunk' }
-                    ],
+                    defaultValue: config.searchCollectionOptions.map(opt => opt.value),
+                    options: config.searchCollectionOptions.map(opt => ({ label: opt.label, value: opt.value })),
                     admin: { description: 'Collections to search for RAG context' }
                   },
                   {

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -18,6 +18,11 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
   if (!runtimeSecret) {
     console.warn('[agent-plugin] runtimeSecret is empty — all runtime requests will be unauthenticated')
   }
+  if (userConfig.searchCollectionOptions.length === 0) {
+    throw new Error(
+      '[agent-plugin] searchCollectionOptions cannot be empty — pass at least one chunked collection your agents are allowed to query'
+    )
+  }
   return {
     runtimeUrl: userConfig.runtimeUrl,
     runtimeSecret,
@@ -30,6 +35,7 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
     encryptionKey: userConfig.encryptionKey,
     mediaCollectionSlug: userConfig.mediaCollectionSlug,
     taxonomyCollectionSlug: userConfig.taxonomyCollectionSlug,
+    searchCollectionOptions: userConfig.searchCollectionOptions,
     collectionOverrides: userConfig.collectionOverrides,
     onRunCompleted: userConfig.onRunCompleted
   }

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -137,6 +137,9 @@ export interface AgentPluginConfig {
    */
   taxonomyCollectionSlug: string
 
+  /** Options for the agent's `searchCollections` field. Empty arrays are rejected at boot. */
+  searchCollectionOptions: ReadonlyArray<{ label: string; value: string }>
+
   /**
    * Transform the Agents collection config before it is registered.
    *
@@ -249,6 +252,7 @@ export interface ResolvedPluginConfig {
   encryptionKey: string | undefined
   mediaCollectionSlug: string
   taxonomyCollectionSlug: string
+  searchCollectionOptions: ReadonlyArray<{ label: string; value: string }>
   collectionOverrides: CollectionOverrides | undefined
   onRunCompleted: OnRunCompleted | undefined
 }


### PR DESCRIPTION
## Summary
- Removes the hardcoded `[posts_chunk, books_chunk]` options on the agent's `searchCollections` field.
- `agentPlugin({...})` now requires `searchCollectionOptions` and refuses to boot on an empty list.
- Existing agents keep whatever was saved at creation; `defaultValue` for new agents = whatever the consumer declares.

## Why
Each consumer indexes a different set of chunked collections (some only posts/books, some also `documents_chunk`). Silently defaulting masked wiring mistakes — chunks were indexed, agents had no UI option to query them.

## Migration
\`\`\`ts
// 0.4.x
agentPlugin({
  // ...
  searchCollectionOptions: [
    { label: 'Posts', value: 'posts_chunk' },
    { label: 'Books', value: 'books_chunk' }
    // { label: 'Documents', value: 'documents_chunk' } when applicable
  ]
})
\`\`\`

## Downstream impact
- ZetesisPortal (workspace) and nexus-template (npm) both call `agentPlugin` without this field. ZP will break TS as soon as the change lands; nexus only on next bump.

## Test plan
- [ ] CI green
- [ ] After merge + publish (0.4.0), update ZP + nexus to pass the new prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)