### PR TITLE
fix(chat-agent): nested button hydration in ChatHistoryList

### DIFF
--- a/.changeset/chat-history-nested-button.md
+++ b/.changeset/chat-history-nested-button.md
@@ -1,0 +1,5 @@
+---
+'@zetesis/chat-agent': patch
+---
+
+Fix hydration error caused by nested `<button>` in the chat history list. Each session row was rendered as a `<button>` with rename/delete/options child buttons inside; the resulting markup is invalid HTML and React aborts hydration. Replaced the outer element with a `<div role="button" tabIndex={0}>` and added an Enter/Space `onKeyDown` handler so keyboard activation still works.

--- a/packages/chat-agent/src/components/ChatHistoryList.tsx
+++ b/packages/chat-agent/src/components/ChatHistoryList.tsx
@@ -109,14 +109,22 @@ export const ChatHistoryList = ({
   return (
     <div className="space-y-1">
       {sessions.map((session, _index) => (
-        <button
-          type="button"
+        <div
           key={session.conversation_id}
+          role="button"
+          tabIndex={0}
+          aria-pressed={activeSessionId === session.conversation_id}
           className={cn(
             'group relative flex items-center rounded-md px-2 py-2 text-sm transition-colors hover:bg-accent/50 cursor-pointer w-full text-left',
             activeSessionId === session.conversation_id ? 'bg-accent text-accent-foreground' : 'text-foreground'
           )}
           onClick={() => onSelectSession(session.conversation_id)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              onSelectSession(session.conversation_id)
+            }
+          }}
         >
           <MessageSquare className="mr-2 h-4 w-4 opacity-70 flex-shrink-0" />
 
@@ -238,7 +246,7 @@ export const ChatHistoryList = ({
               </div>
             </>
           )}
-        </button>
+        </div>
       ))}
     </div>
   )


### PR DESCRIPTION
## Summary
- Each session row in `ChatHistoryList` was a `<button>` with rename/delete/options child buttons inside, producing invalid HTML and aborting React hydration.
- Replaced the outer element with a `<div role="button" tabIndex={0}>` and added an `onKeyDown` handler for Enter/Space to preserve keyboard activation.

## Test plan
- [ ] Open the chat history sidebar on a multi-tenant ZP/nexus deploy and confirm no hydration error in the console.
- [ ] Click a session row → loads conversation.
- [ ] Tab to a row → press Enter / Space → loads conversation.
- [ ] Open the row's options menu → rename / delete still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)