### PR TITLE
fix(core): self-heal agno_sessions.metadata.tenant_id

### DIFF
--- a/.changeset/multi-tenant-self-heal-metadata.md
+++ b/.changeset/multi-tenant-self-heal-metadata.md
@@ -1,0 +1,5 @@
+---
+'@zetesis/payload-agents-core': patch
+---
+
+Self-heal `agno_sessions.metadata.tenant_id` from `validateSessionOwnership`. Agno (>=2.5) only persists the agent's static `metadata` field on the session row and ignores the per-run `metadata=` kwarg, so the runtime's `X-Tenant-Id` forwarding never reached `agno_sessions.metadata` and every continuation/history/rename/delete on a multi-tenant deploy returned `Forbidden`. The strategy now back-fills `metadata.tenant_id` the first time it sees a session whose `user_id` matches but `metadata.tenant_id` is null. The UPDATE casts the bound parameter to `::text` (otherwise pg can't infer `jsonb_build_object`'s anyelement arg type) and normalizes `metadata` via `jsonb_typeof` before merging (otherwise `'null'::jsonb || object` wraps both into an array).

--- a/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
@@ -113,15 +113,23 @@ describe('multiTenantSessionStrategy — validateSessionOwnership', () => {
     expect(warn).toHaveBeenCalledOnce()
   })
 
-  it('returns false when metadata.tenant_id is missing (runtime not forwarding X-Tenant-Id)', async () => {
+  it('back-fills tenant_id and returns true when stored tenant_id is null but user_id matches', async () => {
     const strategy = multiTenantSessionStrategy({ extractTenantId: () => 1 })
-    const { payload, warn } = makePayload([{ user_id: '42', tenant_id: null }])
+    const { payload, execute, warn } = makePayload([{ user_id: '42', tenant_id: null }])
+    const ok = await strategy.validateSessionOwnership('s', { user: alice, payload, req: makeReq() })
+    expect(ok).toBe(true)
+    expect(warn).not.toHaveBeenCalled()
+    // Two queries: SELECT to read the row, UPDATE to back-fill metadata.tenant_id.
+    expect(execute).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not back-fill and returns false when stored tenant_id is null but user_id differs', async () => {
+    const strategy = multiTenantSessionStrategy({ extractTenantId: () => 1 })
+    const { payload, execute, warn } = makePayload([{ user_id: '99', tenant_id: null }])
     const ok = await strategy.validateSessionOwnership('s', { user: alice, payload, req: makeReq() })
     expect(ok).toBe(false)
     expect(warn).toHaveBeenCalledOnce()
-    // First arg is the log object; second is the message
-    const message = warn.mock.calls[0]?.[1] as string | undefined
-    expect(message).toContain('metadata.tenant_id missing')
+    expect(execute).toHaveBeenCalledOnce()
   })
 })
 

--- a/packages/payload-agents-core/src/lib/multi-tenant.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.ts
@@ -4,12 +4,16 @@
  * - `buildSessionId` returns an opaque UUID. The id carries no ownership data.
  * - `validateSessionOwnership` queries `agno.agno_sessions` to verify the
  *   current user owns the session. Ownership lives in Agno's session row —
- *   `user_id` (native column) and `metadata->>'tenant_id'` (the agent-runtime
- *   is expected to populate this on session create).
+ *   `user_id` (native column) and `metadata->>'tenant_id'` (back-filled by
+ *   this strategy on the first validate; see below).
  *
- * The `agent-runtime` must write `{tenant_id, user_id}` into the session
- * `metadata` JSONB when it creates a session. An expression index on
- * `(metadata->>'tenant_id')` is recommended for query performance.
+ * Tenant back-fill: Agno (>=2.5) only writes the agent's static `metadata`
+ * to the session row, ignoring the per-run `metadata=` kwarg the runtime
+ * forwards from `X-Tenant-Id`. To keep `metadata.tenant_id` accurate without
+ * patching Agno, `validateSessionOwnership` updates the column the first
+ * time it sees a row with `metadata.tenant_id IS NULL` and a matching
+ * `user_id`. An expression index on `(metadata->>'tenant_id')` is
+ * recommended for query performance.
  */
 
 import { sql } from 'drizzle-orm'
@@ -107,21 +111,41 @@ export function multiTenantSessionStrategy(options: MultiTenantSessionStrategyOp
     }
     const storedUserId = row.user_id as string | null
     const storedTenantId = row.tenant_id as string | null
-    if (storedUserId !== String(userId) || storedTenantId !== String(tenantId)) {
+
+    if (storedUserId !== String(userId)) {
       payload.logger.warn(
-        {
-          sessionId,
-          expectedUserId: String(userId),
-          expectedTenantId: String(tenantId),
-          storedUserId,
-          storedTenantId
-        },
-        storedTenantId === null
-          ? '[multi-tenant] session ownership denied: metadata.tenant_id missing — runtime may not be forwarding X-Tenant-Id'
-          : '[multi-tenant] session ownership denied: tenant/user mismatch'
+        { sessionId, expectedUserId: String(userId), storedUserId },
+        '[multi-tenant] session ownership denied: user mismatch'
       )
       return false
     }
+
+    if (storedTenantId === null) {
+      // Two pitfalls in this UPDATE:
+      //   1. pg can't infer the type of jsonb_build_object's anyelement arg, so
+      //      the parameter needs an explicit ::text cast (else 42P18).
+      //   2. Postgres's `||` on non-object operands wraps both into an array
+      //      (e.g. 'null'::jsonb || {} → [null, {}]). COALESCE only catches SQL
+      //      NULL, not JSONB null/scalars/arrays — so we normalize via
+      //      jsonb_typeof before merging.
+      await db.execute(sql`
+        UPDATE agno.agno_sessions
+        SET metadata = (
+          CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END
+        ) || jsonb_build_object('tenant_id', ${String(tenantId)}::text)
+        WHERE session_id = ${sessionId}
+      `)
+      return true
+    }
+
+    if (storedTenantId !== String(tenantId)) {
+      payload.logger.warn(
+        { sessionId, expectedTenantId: String(tenantId), storedTenantId },
+        '[multi-tenant] session ownership denied: tenant mismatch'
+      )
+      return false
+    }
+
     return true
   }
 


### PR DESCRIPTION
## Summary
- Agno (>=2.5) only persists the agent's static `metadata` on the session row and ignores the per-run `metadata=` kwarg — so the runtime's `X-Tenant-Id` forwarding never reached `agno_sessions.metadata` and every continuation, history load, rename and delete on a multi-tenant deploy returned 403.
- `validateSessionOwnership` now back-fills `metadata.tenant_id` the first time it sees a row whose `user_id` matches but `tenant_id` is null.
- UPDATE casts the bound parameter to `::text` (else pg can't infer `jsonb_build_object`'s anyelement arg → 42P18) and normalizes via `jsonb_typeof` before the `||` merge (else `'null'::jsonb || {}` wraps both into an array).

## Test plan
- [x] `pnpm exec vitest run` — 13 tests pass in `multi-tenant.spec.ts`, including new coverage for the self-heal path and the user-mismatch null-tenant path.
- [x] Manually verified end-to-end on a ZetesisPortal multi-tenant deploy: send M1 → open from history → send M2 → all green; corrupted `[null, {tenant_id}]` rows from a pre-fix attempt cleaned with `UPDATE ... SET metadata = metadata->1`.

## Next steps
- After merge, "Version Packages" PR will publish `@zetesis/payload-agents-core` patch.
- ZetesisPortal will bump the submodule pointer; nexus-template will bump the npm version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)