### PR TITLE
fix(indexer): correct afterChange sync — transaction, populate depth, opt-in metadata-only

### DIFF
--- a/.changeset/payload-indexer-sync-depth.md
+++ b/.changeset/payload-indexer-sync-depth.md
@@ -1,0 +1,11 @@
+---
+'@zetesis/payload-indexer': patch
+---
+
+Three fixes that together make `afterChange` indexing correct out of the box:
+
+**Refetch through the request transaction.** The `afterChange` hook now passes `req` to `payload.findByID` when repopulating, so the read joins the same transaction as the save that triggered the hook. Without this, Payload opens a new connection and reads the pre-commit snapshot, returning stale field values (e.g. the title from before the user's edit).
+
+**Add `TableConfig.syncDepth`.** Payload calls `afterChange` with `depth=0`, so relationship fields arrive as IDs and any field `transform` that needs populated relations (e.g. extracting `slug` from a related taxonomy doc) silently produces empty output. Set `syncDepth: 1` (or higher) on a table config to make the hook refetch the doc with that depth before running transforms. Default `0` — existing consumers see no behavior change and no extra query. The hook picks the highest `syncDepth` across enabled tables for the collection so a single refetch covers all of them.
+
+**Make the metadata-only optimization opt-in** via `EmbeddingTableConfig.reuseEmbeddingsWhenContentUnchanged` (default `false`). Previously, on `update` operations the syncer compared the content hash and, when unchanged, performed a partial update of mapped fields instead of re-chunking + re-embedding. That partial-update path can leave non-content fields stale in subtle ways. Default behavior is now to always run a full re-sync on update; consumers who have validated the partial path for their adapter and field set can opt in for the embedding-cost saving.

--- a/apps/server/src/plugins/typesense/collections.ts
+++ b/apps/server/src/plugins/typesense/collections.ts
@@ -9,6 +9,7 @@ export const collections: IndexableCollectionConfig<TypesenseFieldMapping> = {
       enabled: true,
       tableName: 'posts_chunk',
       displayName: 'Posts (Chunked)',
+      syncDepth: 1,
       embedding: {
         fields: [{ field: 'content', transform: createDynamicContentTransform() }],
         chunking: { strategy: 'markdown', size: 2000, overlap: 300 }
@@ -31,6 +32,7 @@ export const collections: IndexableCollectionConfig<TypesenseFieldMapping> = {
       enabled: true,
       tableName: 'posts',
       displayName: 'Posts',
+      syncDepth: 1,
       fields: [
         { name: 'title', type: 'string' },
         { name: 'slug', type: 'string', index: true },

--- a/apps/server/src/plugins/typesense/transforms.ts
+++ b/apps/server/src/plugins/typesense/transforms.ts
@@ -2,24 +2,29 @@ import type { SerializedEditorState } from '@payloadcms/richtext-lexical/lexical
 import { transformLexicalToMarkdown } from '@zetesis/payload-indexer'
 import { composeTextTransforms } from './text-transforms'
 
-/**
- * Transform categories relationship to taxonomy slugs array.
- * Extracts the deepest slug from each category via its last breadcrumb.
- */
 export const transformCategories = async (categories?: (number | Record<string, unknown>)[]): Promise<string[]> => {
   if (!categories || categories.length === 0) return []
 
   const slugs: string[] = []
 
   for (const cat of categories) {
-    if (!cat || typeof cat !== 'object' || !Array.isArray((cat as Record<string, unknown>).breadcrumbs)) continue
-    const breadcrumbs = (cat as Record<string, unknown>).breadcrumbs as { url?: string }[]
-    const lastBreadcrumb = [...breadcrumbs]
-      .reverse()
-      .find(b => b && typeof b === 'object' && 'url' in b && typeof b.url === 'string')
-    if (!lastBreadcrumb || typeof lastBreadcrumb.url !== 'string') continue
-    const parts = lastBreadcrumb.url.split('/').filter(Boolean)
-    slugs.push(...parts)
+    if (!cat || typeof cat !== 'object') continue
+    const record = cat as Record<string, unknown>
+
+    if (Array.isArray(record.breadcrumbs)) {
+      const breadcrumbs = record.breadcrumbs as { url?: string }[]
+      const lastBreadcrumb = [...breadcrumbs]
+        .reverse()
+        .find(b => b && typeof b === 'object' && 'url' in b && typeof b.url === 'string')
+      if (lastBreadcrumb && typeof lastBreadcrumb.url === 'string') {
+        slugs.push(...lastBreadcrumb.url.split('/').filter(Boolean))
+        continue
+      }
+    }
+
+    if (typeof record.slug === 'string' && record.slug.length > 0) {
+      slugs.push(record.slug)
+    }
   }
 
   return [...new Set(slugs)]

--- a/packages/payload-indexer/src/document/types.ts
+++ b/packages/payload-indexer/src/document/types.ts
@@ -126,6 +126,22 @@ export interface EmbeddingTableConfig {
    * @default 'skip-chunk'
    */
   onEmbeddingFailure?: EmbeddingFailureBehavior
+
+  /**
+   * When true, on `update` operations the indexer compares the content hash
+   * against the stored one and, if unchanged, performs a partial metadata
+   * update instead of re-chunking and re-embedding. This saves embedding
+   * cost but its partial-update path can leave non-content fields stale in
+   * subtle ways (e.g. when a localized field is edited or when an updateable
+   * field's mapping changes).
+   *
+   * Default `false` — every update re-runs the full sync (re-chunk + re-embed).
+   * Opt in only when you have validated that all your mapped fields propagate
+   * correctly through the partial-update path for your adapter.
+   *
+   * @default false
+   */
+  reuseEmbeddingsWhenContentUnchanged?: boolean
 }
 
 /**
@@ -163,6 +179,18 @@ interface BaseTableConfig<TFieldMapping extends FieldMapping = FieldMapping> {
    * @returns boolean | Promise<boolean> - true to index, false to skip
    */
   shouldIndex?: (doc: Record<string, unknown>) => boolean | Promise<boolean>
+
+  /**
+   * Population depth for the document before running field transforms in the
+   * `afterChange` hook. Payload calls `afterChange` with depth=0 by default,
+   * so relationship fields arrive as IDs. Set this to >=1 when a transform
+   * needs access to populated relations (e.g. a slug from the related doc).
+   *
+   * Defaults to 0 (no refetch — preserves prior behavior).
+   *
+   * @default 0
+   */
+  syncDepth?: number
 }
 
 /**

--- a/packages/payload-indexer/src/plugin/sync/document-syncer.spec.ts
+++ b/packages/payload-indexer/src/plugin/sync/document-syncer.spec.ts
@@ -112,10 +112,10 @@ describe('DocumentSyncer', () => {
   })
 
   describe('syncDocument — content hash', () => {
-    it('skips re-embedding on update if content unchanged', async () => {
+    it('skips re-embedding on update if content unchanged (when opted in)', async () => {
       const doc = createMockDocument()
       const config = createMockTableConfig({
-        embedding: { fields: ['content'] }
+        embedding: { fields: ['content'], reuseEmbeddingsWhenContentUnchanged: true }
       })
 
       vi.mocked(
@@ -127,6 +127,22 @@ describe('DocumentSyncer', () => {
 
       expect(adapter.updateDocument).toHaveBeenCalledOnce()
       expect(adapter.upsertDocument).not.toHaveBeenCalled()
+    })
+
+    it('full re-syncs on update by default (no optimization opt-in)', async () => {
+      const doc = createMockDocument()
+      const config = createMockTableConfig({
+        embedding: { fields: ['content'] }
+      })
+
+      vi.mocked(
+        adapter.searchDocumentsByFilter as NonNullable<typeof adapter.searchDocumentsByFilter>
+      ).mockResolvedValue([{ content_hash: 'abc123hash' }])
+
+      await syncDocumentToIndex(adapter, 'posts', doc, 'update', config, embeddingService)
+
+      expect(adapter.upsertDocument).toHaveBeenCalledOnce()
+      expect(adapter.updateDocument).not.toHaveBeenCalled()
     })
 
     it('re-embeds on update if content changed', async () => {

--- a/packages/payload-indexer/src/plugin/sync/document-syncer.ts
+++ b/packages/payload-indexer/src/plugin/sync/document-syncer.ts
@@ -176,8 +176,13 @@ export class DocumentSyncer {
     const sourceText = this.config.embedding?.fields ? await this.extractSourceText(doc) : ''
     const contentHash = sourceText ? computeContentHash(sourceText) : undefined
 
-    // 3. Check if content is unchanged on update — skip re-embedding
-    if (contentHash && operation === 'update' && !this.options?.forceReindex) {
+    // 3. Check if content is unchanged on update — skip re-embedding (opt-in)
+    if (
+      contentHash &&
+      operation === 'update' &&
+      !this.options?.forceReindex &&
+      this.config.embedding?.reuseEmbeddingsWhenContentUnchanged
+    ) {
       const unchanged = await this.isContentUnchanged(contentHash, String(doc.id))
       if (unchanged) {
         const updated = await this.updateMetadataOnly(doc, contentHash)
@@ -220,7 +225,11 @@ export class DocumentSyncer {
     // 2. Compute content hash and check for changes
     const contentHash = computeContentHash(sourceText)
 
-    if (operation === 'update' && !this.options?.forceReindex) {
+    if (
+      operation === 'update' &&
+      !this.options?.forceReindex &&
+      this.config.embedding?.reuseEmbeddingsWhenContentUnchanged
+    ) {
       const unchanged = await this.isContentUnchanged(contentHash, String(doc.id))
       if (unchanged) {
         const updated = await this.updateMetadataOnly(doc, contentHash)

--- a/packages/payload-indexer/src/plugin/sync/hooks.spec.ts
+++ b/packages/payload-indexer/src/plugin/sync/hooks.spec.ts
@@ -153,6 +153,87 @@ describe('sync hooks', () => {
         })
       ).rejects.toThrow('sync failed')
     })
+
+    describe('syncDepth', () => {
+      it('does not refetch when no table config sets syncDepth', async () => {
+        const findByID = vi.fn()
+        const hook = getAfterChangeHook([createMockTableConfig()])
+
+        await hook?.({
+          doc: createMockDocument(),
+          operation: 'update',
+          req: { payload: { findByID } }
+        })
+
+        expect(findByID).not.toHaveBeenCalled()
+        expect(mockSyncDocumentToIndex).toHaveBeenCalledWith(
+          expect.anything(),
+          'posts',
+          expect.objectContaining({ id: 'doc-1' }),
+          'update',
+          expect.anything(),
+          undefined,
+          expect.anything()
+        )
+      })
+
+      it('refetches with the highest syncDepth and forwards the populated doc', async () => {
+        const populatedDoc = createMockDocument({ title: 'populated' })
+        const findByID = vi.fn().mockResolvedValue(populatedDoc)
+        const hook = getAfterChangeHook([
+          createMockTableConfig({ syncDepth: 1 }),
+          createMockTableConfig({ syncDepth: 2 })
+        ])
+
+        await hook?.({
+          doc: createMockDocument({ title: 'stale' }),
+          operation: 'update',
+          req: { payload: { findByID } }
+        })
+
+        expect(findByID).toHaveBeenCalledTimes(1)
+        expect(findByID).toHaveBeenCalledWith(
+          expect.objectContaining({
+            collection: 'posts',
+            id: 'doc-1',
+            depth: 2,
+            overrideAccess: true,
+            req: expect.anything()
+          })
+        )
+        expect(mockSyncDocumentToIndex).toHaveBeenCalledWith(
+          expect.anything(),
+          'posts',
+          expect.objectContaining({ title: 'populated' }),
+          'update',
+          expect.anything(),
+          undefined,
+          expect.anything()
+        )
+      })
+
+      it('falls back to the original doc when refetch throws', async () => {
+        const findByID = vi.fn().mockRejectedValue(new Error('not found'))
+        const hook = getAfterChangeHook([createMockTableConfig({ syncDepth: 1 })])
+
+        await hook?.({
+          doc: createMockDocument({ title: 'stale' }),
+          operation: 'update',
+          req: { payload: { findByID } }
+        })
+
+        expect(findByID).toHaveBeenCalledTimes(1)
+        expect(mockSyncDocumentToIndex).toHaveBeenCalledWith(
+          expect.anything(),
+          'posts',
+          expect.objectContaining({ title: 'stale' }),
+          'update',
+          expect.anything(),
+          undefined,
+          expect.anything()
+        )
+      })
+    })
   })
 
   describe('processTableConfigAfterChange', () => {

--- a/packages/payload-indexer/src/plugin/sync/hooks.ts
+++ b/packages/payload-indexer/src/plugin/sync/hooks.ts
@@ -38,6 +38,61 @@ const processTableConfigAfterChange = async (
 }
 
 /**
+ * Minimal Payload client surface needed by the hook to repopulate docs.
+ * Kept narrow so tests can stub it without importing Payload types.
+ */
+interface PayloadFindByIDClient {
+  findByID: (args: {
+    collection: string
+    id: number | string
+    depth?: number
+    overrideAccess?: boolean
+    req?: unknown
+  }) => Promise<unknown>
+}
+
+interface AfterChangeReq {
+  context?: Record<string, unknown>
+  payload?: PayloadFindByIDClient
+}
+
+const resolveSyncDepth = (tableConfigs: TableConfig[]): number =>
+  tableConfigs.reduce((max, tableConfig) => (tableConfig.enabled ? Math.max(max, tableConfig.syncDepth ?? 0) : max), 0)
+
+const repopulateDoc = async (
+  doc: PayloadDocument,
+  collectionSlug: string,
+  tableConfigs: TableConfig[],
+  req: AfterChangeReq
+): Promise<PayloadDocument> => {
+  const requestedDepth = resolveSyncDepth(tableConfigs)
+  if (requestedDepth === 0 || !req.payload?.findByID) return doc
+
+  try {
+    const fresh = await req.payload.findByID({
+      collection: collectionSlug,
+      id: doc.id,
+      depth: requestedDepth,
+      overrideAccess: true,
+      // Pass req so the read joins the same transaction as the save that
+      // triggered the hook. Without this, Payload opens a new connection
+      // and reads the pre-commit snapshot, returning stale field values
+      // (e.g. the title from before the user's edit).
+      req
+    })
+    return fresh && typeof fresh === 'object' ? (fresh as PayloadDocument) : doc
+  } catch (error) {
+    logger.warn('Failed to repopulate doc for indexing, using afterChange doc as-is', {
+      collection: collectionSlug,
+      docId: String(doc.id),
+      requestedDepth,
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return doc
+  }
+}
+
+/**
  * Creates the afterChange hook handler for a collection
  */
 const createAfterChangeHook = (
@@ -54,7 +109,7 @@ const createAfterChangeHook = (
   }: {
     doc: PayloadDocument
     operation: 'create' | 'update'
-    req: { context?: Record<string, unknown> }
+    req: AfterChangeReq
   }) => {
     if (req.context?.skipIndexSync) return
 
@@ -62,13 +117,15 @@ const createAfterChangeHook = (
       forceReindex: req.context?.forceReindex === true
     }
 
+    const populatedDoc = await repopulateDoc(doc, collectionSlug, tableConfigs, req)
+
     try {
       for (const tableConfig of tableConfigs) {
         await processTableConfigAfterChange(
           tableConfig,
           adapter,
           collectionSlug,
-          doc,
+          populatedDoc,
           operation,
           embeddingService,
           syncOptions


### PR DESCRIPTION
## Summary

Three coupled fixes that together make Payload's `afterChange` indexing correct out of the box:

- **Transaction-aware refetch.** Pass `req` to `payload.findByID` when the hook repopulates a doc, so the read joins the same transaction as the save that triggered the hook. Without this, Payload opens a new connection and reads the pre-commit snapshot, returning stale field values (concrete symptom: the just-edited title comes back as the previous value, so Typesense never receives the new title).
- **`TableConfig.syncDepth`** (default `0`). Payload calls `afterChange` with `depth=0`, so relationship fields arrive as IDs and any field `transform` that needs the populated relation silently produces empty output. Set `syncDepth >= 1` on the table config to refetch with that depth before running transforms. Default `0` preserves previous behavior and adds no extra query for consumers who don't need it.
- **Metadata-only optimization is now opt-in** via `EmbeddingTableConfig.reuseEmbeddingsWhenContentUnchanged` (default `false`). The previous default ran a content-hash comparison and, when unchanged, did a partial update of mapped fields instead of re-chunking + re-embedding. That partial path can leave non-content fields stale (observed: localized title edits not propagating into already-indexed chunks). New default is to always run a full re-sync on update. Consumers that have validated the partial path for their adapter can opt back in to keep the embedding-cost saving.

`apps/server` opts into `syncDepth: 1` so the `categories → taxonomy_slugs` transform works. The flat-taxonomy `transformCategories` was also adjusted to fall back to `cat.slug` when no `breadcrumbs` exist.

## Test plan

- [x] `pnpm --filter @zetesis/payload-indexer test` (53 / 53 pass, 3 new tests cover `syncDepth` opt-in, refetch failure fallback, and the new full-resync default)
- [x] `pnpm --filter @zetesis/payload-indexer build`
- [x] `pnpm tsc --noEmit` (clean)
- [x] `pnpm lint` (no new errors)
- [x] Manual verification on the playground: edit a Post title → save → Typesense `posts_chunk` and `posts` reflect the new title, taxonomy_slugs populated correctly, embedding regenerated (1536 dims, normalized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zetesis-labs/payloadagents/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
