### PR TITLE
ci(release): chain PyPI publish from release-please outputs

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,9 +1,16 @@
 name: Publish Python Package
 
 on:
-  push:
-    tags:
-      - "agno-agent-builder-v*"
+  workflow_call:
+    inputs:
+      package:
+        description: "Workspace package to publish"
+        required: true
+        type: string
+      ref:
+        description: "Git ref (tag or sha) to checkout and build from"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       package:
@@ -13,6 +20,10 @@ on:
         type: choice
         options:
           - agno-agent-builder
+      ref:
+        description: "Git ref (tag or sha) to publish (defaults to current branch)"
+        required: false
+        type: string
 
 jobs:
   publish:
@@ -20,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/agno-agent-builder
+      url: https://pypi.org/p/${{ inputs.package }}
     permissions:
       id-token: write
       contents: read
@@ -29,24 +40,16 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
 
-      - name: Resolve target package
-        id: target
-        run: |
-          if [ -n "${{ inputs.package }}" ]; then
-            echo "package=${{ inputs.package }}" >> "$GITHUB_OUTPUT"
-          else
-            ref="${GITHUB_REF##refs/tags/}"
-            echo "package=${ref%-v*}" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Build distribution
-        run: uv build --package "${{ steps.target.outputs.package }}"
+        run: uv build --package "${{ inputs.package }}"
 
       - name: Publish to PyPI (trusted publisher / OIDC)
         run: uv publish

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,9 +12,24 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      agno_agent_builder_released: ${{ steps.release.outputs['backend/agno-agent-builder--release_created'] }}
+      agno_agent_builder_tag: ${{ steps.release.outputs['backend/agno-agent-builder--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - id: release
+        uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish-agno-agent-builder:
+    needs: release-please
+    if: needs.release-please.outputs.agno_agent_builder_released == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/publish-python.yml
+    with:
+      package: agno-agent-builder
+      ref: ${{ needs.release-please.outputs.agno_agent_builder_tag }}


### PR DESCRIPTION
## Summary

Eliminates the manual \`gh workflow run publish-python.yml\` step after every release.

GitHub Actions does not chain workflows when a tag is pushed using \`GITHUB_TOKEN\` (anti-loop safeguard), so the previous \`on: push: tags:\` trigger on \`publish-python.yml\` never fired after release-please created the tag.

This PR converts \`publish-python.yml\` into a reusable workflow (\`workflow_call\`) that \`release-please.yml\` invokes as a downstream job, gated by the per-package \`<path>--release_created\` output. The publish runs as part of the same actor (the workflow run that just merged the release PR), no manual trigger needed.

\`publish-python.yml\` keeps \`workflow_dispatch\` for retries / manual republishes. Inputs are parametric (\`package\`, \`ref\`), so adding a second PyPI package later means just another job in \`release-please.yml\` that calls it with the matching tag output.

## Test plan

- [ ] Next release-please PR that merges to main → publish job runs automatically and uploads to PyPI without human intervention.
- [ ] Manual republish via \`gh workflow run publish-python.yml -f package=agno-agent-builder -f ref=agno-agent-builder-v0.1.1\` still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)