### PR TITLE
feat(payload-agents-core): migrate agent-runtime fetch to internal endpoint

### DIFF
--- a/.changeset/agent-internal-list-endpoint.md
+++ b/.changeset/agent-internal-list-endpoint.md
@@ -1,0 +1,34 @@
+---
+'@zetesis/payload-agents-core': minor
+---
+
+Add the `internal/list` endpoint and migrate the apiKey decryption gate
+off the `X-Runtime-Secret` request header.
+
+**New endpoint** (registered on the agents collection):
+
+`GET /api/<collectionSlug>/internal/list` — gated by `X-Internal-Secret`,
+returns active agents with their tenant + taxonomies populated and the
+`apiKey` field decrypted. Calls Payload's local API with
+`overrideAccess: true` and `req.context.internalAgentRead = true` so the
+host's collection access (and any populated relations like `tenants`) can
+stay honestly user-scoped — the bypass branches that previously had to
+live in the host's access functions are no longer needed.
+
+**Hook change**: `createDecryptAfterReadHook` no longer checks for an
+`X-Runtime-Secret` request header. Decryption now keys off
+`req.context.internalAgentRead === true` (set by the new endpoint),
+plus the existing `payloadAPI === 'local'` and superadmin checks.
+
+**Migration for hosts**:
+
+1. Bump this package + the `agno-agent-builder` Python lib together. The
+   Python source class (`PayloadAgentSource`) now hits the new endpoint
+   automatically — no caller changes if you used keyword args.
+2. Drop the `X-Runtime-Secret` bypass branches from your `agents` and
+   `tenants` collection `read` access functions; they're no longer
+   reachable.
+
+The `runtimeSecret` plugin config field stays the same value (it's
+still the shared secret with the agent runtime); only the inbound
+header name and the decryption-gate mechanism change.

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -1,7 +1,11 @@
 """Payload CMS implementation of `AgentSource`.
 
-Adapts Payload's `/api/agents` REST response into the normalized
-`AgentConfig` shape expected by the rest of the runtime.
+Calls the dedicated internal endpoint on `@zetesis/payload-agents-core`
+(`GET /api/<agents>/internal/list`) authenticated by `X-Internal-Secret`.
+The endpoint runs Payload's local API with `overrideAccess: true` and
+returns the active agents with apiKey decrypted + tenant/taxonomies
+populated, so we don't depend on access-control bypasses in the host's
+collections.
 """
 
 from __future__ import annotations
@@ -17,46 +21,34 @@ from agno_agent_builder.sources.types import AgentConfig
 logger = get_logger(__name__)
 
 _DEFAULT_TIMEOUT_S = 10.0
-_DEFAULT_WHERE: dict[str, str | int] = {"where[isActive][equals]": "true"}
+_DEFAULT_COLLECTION_SLUG = "agents"
+INTERNAL_SECRET_HEADER = "X-Internal-Secret"  # noqa: S105 — header name, not a secret value
 
 
 class PayloadAgentSource:
-    """Fetches agent configs from Payload CMS via REST.
-
-    The `X-Runtime-Secret` header bypasses the `agents` collection's read
-    access control. `depth=1` is required so the `tenant` and `taxonomies`
-    relationships come populated; consumers that change those defaults must
-    also extend `Tenants.read` access for the runtime secret.
-    """
+    """Fetches agent configs from Payload CMS via the plugin's internal endpoint."""
 
     def __init__(
         self,
         *,
         base_url: str,
         internal_secret: str,
-        service_token: str | None = None,
-        depth: int = 1,
-        limit: int = 1000,
-        where: dict[str, str | int] | None = None,
+        collection_slug: str = _DEFAULT_COLLECTION_SLUG,
         timeout_s: float = _DEFAULT_TIMEOUT_S,
     ) -> None:
+        if not internal_secret:
+            raise ValueError("internal_secret is required")
         self._base_url = base_url.rstrip("/")
         self._internal_secret = internal_secret
-        self._service_token = service_token
-        self._depth = depth
-        self._limit = limit
-        self._where = where if where is not None else dict(_DEFAULT_WHERE)
+        self._collection_slug = collection_slug
         self._timeout_s = timeout_s
 
     async def fetch_agents(self) -> list[AgentConfig]:
-        url = f"{self._base_url}/api/agents"
-        params: dict[str, str | int] = {**self._where, "depth": self._depth, "limit": self._limit}
-        headers: dict[str, str] = {"X-Runtime-Secret": self._internal_secret}
-        if self._service_token:
-            headers["Authorization"] = f"Bearer {self._service_token}"
+        url = f"{self._base_url}/api/{self._collection_slug}/internal/list"
+        headers = {INTERNAL_SECRET_HEADER: self._internal_secret}
 
         async with httpx.AsyncClient(timeout=self._timeout_s) as client:
-            response = await client.get(url, params=params, headers=headers)
+            response = await client.get(url, headers=headers)
             response.raise_for_status()
             data: dict[str, list[dict[str, Any]]] = response.json()
 

--- a/backend/agno-agent/agno_agent/main.py
+++ b/backend/agno-agent/agno_agent/main.py
@@ -14,7 +14,6 @@ app = create_app(
         agent_source=PayloadAgentSource(
             base_url=settings.payload_url,
             internal_secret=settings.internal_secret.get_secret_value(),
-            service_token=settings.payload_service_token or None,
         ),
         mcp_url=settings.mcp_url,
         database_url=settings.database_url,

--- a/backend/agno-agent/agno_agent/settings.py
+++ b/backend/agno-agent/agno_agent/settings.py
@@ -16,7 +16,6 @@ class Settings(BaseSettings):
     )
 
     payload_url: str = "http://app:3000"
-    payload_service_token: str = ""
 
     mcp_url: str = "http://app:3030/mcp"
 

--- a/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.ts
+++ b/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.ts
@@ -23,17 +23,18 @@ export function createEncryptBeforeChangeHook(config: ResolvedPluginConfig): Col
 }
 
 export function createDecryptAfterReadHook(config: ResolvedPluginConfig): CollectionAfterReadHook {
-  return async ({ doc, req }) => {
+  return async ({ context, doc, req }) => {
     if (!config.encryptionKey) return doc
     if (!doc.apiKey || !isEncrypted(doc.apiKey)) return doc
 
     const isLocalAPI = req.payloadAPI === 'local'
-    const isRuntimeRequest =
-      config.runtimeSecret !== '' && req.headers?.get?.('x-runtime-secret') === config.runtimeSecret
+    // Set by the internal `agents/internal/list` endpoint — the only
+    // out-of-process caller that needs decrypted keys.
+    const isInternalRead = context?.internalAgentRead === true
     const userRoles = req.user && 'role' in req.user ? (req.user as unknown as { role: string[] }).role : []
     const isSuperAdminUser = Array.isArray(userRoles) && userRoles.includes('superadmin')
 
-    if (!isLocalAPI && !isRuntimeRequest && !isSuperAdminUser) {
+    if (!isLocalAPI && !isInternalRead && !isSuperAdminUser) {
       doc.apiKey = undefined
       return doc
     }

--- a/packages/payload-agents-core/src/endpoints/agents-internal-list.ts
+++ b/packages/payload-agents-core/src/endpoints/agents-internal-list.ts
@@ -1,0 +1,52 @@
+/**
+ * GET /api/{collectionSlug}/internal/list — internal endpoint the agent
+ * runtime calls to fetch all active agents (with decrypted apiKey + populated
+ * tenant + populated taxonomies). Authenticated by `X-Internal-Secret`,
+ * scoped to active agents, calls Payload's local API with `overrideAccess:
+ * true` so the host's collection access can stay honestly user-scoped.
+ *
+ * Replaces the previous flow where the runtime hit `GET /api/agents` with
+ * `X-Runtime-Secret` and the host had to bypass `read` access on both the
+ * agents and tenants collections to make depth=1 populate work.
+ */
+
+import type { PayloadHandler, PayloadRequest, Where } from 'payload'
+import type { ResolvedPluginConfig } from '../types'
+
+const INTERNAL_SECRET_HEADER = 'x-internal-secret'
+
+const requireInternalSecret = (req: PayloadRequest, internalSecret: string): Response | null => {
+  if (!internalSecret) {
+    return Response.json({ error: 'Internal endpoint not configured' }, { status: 503 })
+  }
+  const headerSecret = req.headers?.get?.(INTERNAL_SECRET_HEADER)
+  if (!headerSecret || headerSecret !== internalSecret) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return null
+}
+
+export function createAgentsInternalListHandler(config: ResolvedPluginConfig): PayloadHandler {
+  return async req => {
+    const authError = requireInternalSecret(req, config.runtimeSecret)
+    if (authError) return authError
+
+    const where: Where = { isActive: { equals: true } }
+
+    // `context.internalAgentRead` tells the apiKey afterRead hook to decrypt;
+    // `overrideAccess: true` skips the host's collection access (and the
+    // populated tenant/taxonomies relations) so we don't need bypass branches
+    // in the host's collection access functions.
+    const { docs } = await req.payload.find({
+      collection: config.collectionSlug,
+      where,
+      depth: 1,
+      limit: 1000,
+      overrideAccess: true,
+      req,
+      context: { internalAgentRead: true }
+    })
+
+    return Response.json({ docs })
+  }
+}

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -6,6 +6,7 @@
 
 import type { Config, Plugin } from 'payload'
 import { createAgentsCollection } from './collections/agents'
+import { createAgentsInternalListHandler } from './endpoints/agents-internal-list'
 import { createAgentsListHandler } from './endpoints/agents-list'
 import { createChatHandler } from './endpoints/chat'
 import { createSessionDeleteHandler, createSessionGetHandler, createSessionPatchHandler } from './endpoints/session'
@@ -58,8 +59,18 @@ export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
     assertCollectionExists(incomingConfig, config.mediaCollectionSlug, 'mediaCollectionSlug')
     assertCollectionExists(incomingConfig, config.taxonomyCollectionSlug, 'taxonomyCollectionSlug')
 
-    // Create the agents collection
+    // Create the agents collection + register the internal-list endpoint on
+    // it (X-Internal-Secret + overrideAccess; replaces the old runtime-secret
+    // bypass that lived in the host's collection access functions).
     const agentsCollection = createAgentsCollection(config)
+    agentsCollection.endpoints = [
+      ...(agentsCollection.endpoints ?? []),
+      {
+        path: '/internal/list',
+        method: 'get' as const,
+        handler: createAgentsInternalListHandler(config)
+      }
+    ]
 
     // Register endpoints on the collection
     const endpoints = [


### PR DESCRIPTION
Same architectural pattern we applied to documents-worker (#54): the
agent runtime no longer hits `GET /api/agents` with a request-header
bypass that the host had to add to its `agents` AND `tenants` collection
access. Instead the plugin exposes a dedicated internal endpoint that
runs Payload's local API with `overrideAccess: true`, and the runtime
calls that.

## Plugin (`@zetesis/payload-agents-core`)

- New `endpoints/agents-internal-list.ts` registered on the agents
  collection at `GET /api/<slug>/internal/list`. Gated by
  `X-Internal-Secret`; returns `{ docs: [...] }` with active agents +
  decrypted `apiKey` + populated `tenant`/`taxonomies`.
- `createDecryptAfterReadHook` (apiKey decryption) drops the
  `X-Runtime-Secret` request-header check in favour of
  `req.context.internalAgentRead`. The new endpoint sets that context;
  no other caller does.

## Worker library (`agno-agent-builder`)

- `PayloadAgentSource` now calls `/api/<slug>/internal/list` with the
  `X-Internal-Secret` header. Drops `service_token`, `where`, `depth`,
  `limit` (server-side hardcoded). Keyword-only call site in
  `agno-agent/main.py` cleans up the now-dead `payload_service_token`
  setting.

## Migration impact for hosts

- Bump `@zetesis/payload-agents-core` and the python lib together.
- Drop the `X-Runtime-Secret` bypass branches from `agents` and `tenants`
  collection `read` access functions — the corresponding ZP-side change
  is in Zetesis-Labs/ZetesisPortal#NEW (linked below).

## Validation

- `pnpm --filter @zetesis/payload-agents-core build` ✓
- `pnpm tsc --noEmit` ✓
- `pnpm lint` ✓ (preexisting warnings)
- `uv run ruff check ./agno-agent-builder ./agno-agent` ✓

Closes the chat-agent side of Zetesis-Labs/ZetesisPortal#239 (the
documents-worker side already shipped earlier).

Stacked on top of #54 (cleanup pass). Mergeable once that lands.

🤖 Generated with Claude Code
