### PR TITLE
feat(payload-agents-core,agno-agent-builder): Telegram bot interface per tenant

### DIFF
--- a/.changeset/agent-telegram-interface.md
+++ b/.changeset/agent-telegram-interface.md
@@ -1,0 +1,13 @@
+---
+'@zetesis/payload-agents-core': minor
+---
+
+Add `Agent.allowGuestAccess` checkbox so hosts can mark agents as
+guest-accessible from external channels (e.g. Telegram users not yet
+bound to a CMS user). Defaults to `false` — backwards compatible.
+
+Pairs with the Telegram bot wiring in `agno-agent-builder` (same release).
+Hosts that wire a per-tenant `TelegramBotInstallations` collection and the
+matching internal endpoints can expose any active agent through Telegram;
+the `allowGuestAccess` flag lets them limit which agents the bot will
+serve to anonymous Telegram chats.

--- a/backend/agno-agent-builder/agno_agent_builder/app.py
+++ b/backend/agno-agent-builder/agno_agent_builder/app.py
@@ -33,6 +33,8 @@ from agno_agent_builder.middleware import (
 from agno_agent_builder.registry import AgentRegistry
 from agno_agent_builder.reload_listener import run_reload_listener
 from agno_agent_builder.schemas import ErrorResponse, ReloadResponse
+from agno_agent_builder.telegram_bind_middleware import TelegramBindMiddleware, TelegramBindState
+from agno_agent_builder.telegram_loader import fetch_installations, mount_telegram_interfaces
 
 _AgentList = list[Agent | RemoteAgent | AgentProtocol | AgentFactory]
 
@@ -47,6 +49,7 @@ def create_app(config: RuntimeConfig) -> FastAPI:
     logger = get_logger(config.app_name)
 
     secret = config.internal_secret.get_secret_value()
+    telegram_bind_state = TelegramBindState()
     registry = AgentRegistry(
         source=config.agent_source,
         database_url=config.database_url,
@@ -103,6 +106,28 @@ def create_app(config: RuntimeConfig) -> FastAPI:
                         exc_info=True,
                     )
 
+        # Telegram bot installations: fetch from the host CMS and mount one
+        # agno Telegram interface per row. The bind interceptor middleware is
+        # registered up-front; we just populate its state here so it knows
+        # which webhook paths + bot tokens are live. Skipped when payload_url
+        # isn't configured (CMS-agnostic deployments don't use Telegram).
+        if config.payload_url:
+            try:
+                installations = await fetch_installations(
+                    payload_url=config.payload_url,
+                    internal_secret=secret,
+                )
+                webhook_paths = mount_telegram_interfaces(app, registry, installations)
+                if webhook_paths:
+                    telegram_bind_state.update(
+                        webhook_paths=webhook_paths,
+                        bot_tokens={i.bot_username: i.bot_token for i in installations},
+                        installation_ids={i.bot_username: i.id for i in installations},
+                    )
+                    logger.info("Telegram interfaces mounted", count=len(installations))
+            except Exception:
+                logger.exception("Telegram interface bootstrap failed — continuing without bots")
+
         listener_task = asyncio.create_task(
             run_reload_listener(
                 reload_registry,
@@ -138,6 +163,17 @@ def create_app(config: RuntimeConfig) -> FastAPI:
     app.add_middleware(SessionMetadataMiddleware)
     app.add_middleware(RequestIdMiddleware)
     app.add_middleware(InternalAuthMiddleware, secret=secret, public_paths=config.public_paths)
+    # Bind interceptor is the OUTERMOST middleware (added last → runs first
+    # in the chain) so it can short-circuit /start <token> on Telegram
+    # webhooks before InternalAuth touches them. Telegram itself validates
+    # X-Telegram-Bot-Api-Secret-Token via agno's interface for the
+    # passthrough path.
+    app.add_middleware(
+        TelegramBindMiddleware,
+        payload_url=config.payload_url or "",
+        internal_secret=secret,
+        state=telegram_bind_state,
+    )
     app.add_exception_handler(AgentRuntimeError, agno_agent_builder_exception_handler)
     app.include_router(health_router)
 

--- a/backend/agno-agent-builder/agno_agent_builder/config.py
+++ b/backend/agno-agent-builder/agno_agent_builder/config.py
@@ -13,7 +13,16 @@ from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 from agno_agent_builder.sources.base import AgentSource
 
-DEFAULT_PUBLIC_PATHS: tuple[str, ...] = ("/health", "/ready", "/docs", "/openapi.json")
+DEFAULT_PUBLIC_PATHS: tuple[str, ...] = (
+    "/health",
+    "/ready",
+    "/docs",
+    "/openapi.json",
+    # Trailing slash = prefix match. Each Telegram interface validates its own
+    # X-Telegram-Bot-Api-Secret-Token, so the global X-Internal-Secret is not
+    # required on incoming Telegram webhooks.
+    "/telegram/",
+)
 DEFAULT_RELOAD_CHANNEL = "agent_reload"
 DEFAULT_RESYNC_INTERVAL_S = 300.0
 DEFAULT_BOOT_MAX_RETRIES = 10
@@ -31,6 +40,7 @@ class RuntimeConfig(BaseModel):
     mcp_url: str
     database_url: str
     internal_secret: SecretStr
+    payload_url: str | None = None  # Required for Telegram bot loader; optional for CMS-agnostic deployments
     database_schema: str = "agno"
     log_level: str = "INFO"
     reload_channel: str = DEFAULT_RELOAD_CHANNEL

--- a/backend/agno-agent-builder/agno_agent_builder/middleware.py
+++ b/backend/agno-agent-builder/agno_agent_builder/middleware.py
@@ -45,12 +45,23 @@ class RequestIdMiddleware:
 
 
 class InternalAuthMiddleware:
-    """Reject requests without a valid ``X-Internal-Secret`` header."""
+    """Reject requests without a valid ``X-Internal-Secret`` header.
+
+    Public paths are matched two ways: exact match for full paths
+    (``/health``, ``/openapi.json``) and prefix match for entries ending in
+    ``/`` (``/telegram/`` lets every per-bot webhook through, since each
+    Telegram interface validates its own ``X-Telegram-Bot-Api-Secret-Token``).
+    """
 
     def __init__(self, app: ASGIApp, *, secret: str, public_paths: tuple[str, ...]) -> None:
         self.app = app
         self._secret = secret
-        self._public_paths = frozenset(public_paths)
+        exact: list[str] = []
+        prefixes: list[str] = []
+        for entry in public_paths:
+            (prefixes if entry.endswith("/") else exact).append(entry)
+        self._public_paths_exact = frozenset(exact)
+        self._public_path_prefixes = tuple(prefixes)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -58,7 +69,7 @@ class InternalAuthMiddleware:
             return
 
         path: str = scope.get("path", "")
-        if path in self._public_paths:
+        if path in self._public_paths_exact or any(path.startswith(p) for p in self._public_path_prefixes):
             await self.app(scope, receive, send)
             return
 

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -105,6 +105,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         taxonomy_slugs=taxonomy_slugs,
         search_collections=search_collections,
         tool_call_limit=tool_call_limit,
+        allow_guest_access=bool(doc.get("allowGuestAccess")),
     )
 
 

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -23,3 +23,4 @@ class AgentConfig(BaseModel):
     taxonomy_slugs: list[str] = []
     search_collections: list[str] = []
     tool_call_limit: int | None = None
+    allow_guest_access: bool = False

--- a/backend/agno-agent-builder/agno_agent_builder/telegram_bind_middleware.py
+++ b/backend/agno-agent-builder/agno_agent_builder/telegram_bind_middleware.py
@@ -1,0 +1,228 @@
+"""ASGI middleware that intercepts `/start <token>` Telegram updates on bot
+webhook paths and binds the Telegram user to a CMS user via the host's
+`POST /api/telegram-binding-tokens/bind` endpoint.
+
+Runs BEFORE agno's Telegram router on every Telegram webhook hit. If the
+update is `/start <token>` it short-circuits, calls the CMS to bind, and
+replies via the Bot API directly (no agent invocation). For every other
+update it transparently re-injects the request body and lets agno proceed.
+
+This is the cleanest place to intercept: agno's `Telegram` interface
+hardcodes `/start` to send a static welcome message and doesn't expose a
+hook for custom handlers. Subclassing the interface would force us to
+fork agno's 200+ line `attach_routes` closure; ASGI middleware avoids
+that at the cost of one extra body read.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import httpx
+import structlog
+
+logger = structlog.get_logger("agno_agent_builder.telegram_bind_middleware")
+
+INTERNAL_SECRET_HEADER = "X-Internal-Secret"  # noqa: S105
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+
+class TelegramBindState:
+    """Mutable holder populated by `app.py`'s lifespan once installations are
+    fetched. Lets us register the middleware unconditionally at app
+    construction (Starlette's middleware stack is built before lifespan
+    runs) and fill in the per-bot config afterwards.
+    """
+
+    def __init__(self) -> None:
+        self.webhook_paths: set[str] = set()
+        self.bot_tokens: dict[str, str] = {}
+        self.installation_ids: dict[str, str | int] = {}
+
+    def update(
+        self,
+        *,
+        webhook_paths: list[str],
+        bot_tokens: dict[str, str],
+        installation_ids: dict[str, str | int],
+    ) -> None:
+        self.webhook_paths = set(webhook_paths)
+        self.bot_tokens = bot_tokens
+        self.installation_ids = installation_ids
+
+
+class TelegramBindMiddleware:
+    """Intercepts `/start <token>` POSTs to any registered Telegram webhook path.
+
+    Reads its per-bot config from a `TelegramBindState` populated in lifespan
+    startup (so we can register the middleware up-front without knowing which
+    bots exist yet — the middleware passes through every request until state
+    is populated).
+    """
+
+    def __init__(
+        self,
+        app: Any,
+        *,
+        payload_url: str,
+        internal_secret: str,
+        state: TelegramBindState,
+    ) -> None:
+        self.app = app
+        self._payload_url = payload_url.rstrip("/")
+        self._internal_secret = internal_secret
+        self._state = state
+
+    async def __call__(
+        self, scope: dict[str, Any], receive: Callable[[], Awaitable[dict]], send: Callable
+    ) -> None:
+        if scope["type"] != "http" or scope.get("method") != "POST":
+            await self.app(scope, receive, send)
+            return
+        path = scope["path"]
+        if path not in self._state.webhook_paths:
+            await self.app(scope, receive, send)
+            return
+
+        # Buffer the body so we can both inspect it and replay it.
+        body = await _read_body(receive)
+
+        try:
+            update = json.loads(body)
+        except json.JSONDecodeError:
+            await self.app(scope, _replay(body), send)
+            return
+
+        token = _extract_start_token(update)
+        if token is None:
+            await self.app(scope, _replay(body), send)
+            return
+
+        bot_username = _bot_username_from_path(path)
+        if bot_username is None or bot_username not in self._state.bot_tokens:
+            await self.app(scope, _replay(body), send)
+            return
+
+        message = update.get("message") or {}
+        from_user = message.get("from") or {}
+        chat = message.get("chat") or {}
+        chat_id = chat.get("id")
+        telegram_user_id = from_user.get("id")
+        telegram_username = from_user.get("username")
+
+        if chat_id is None or telegram_user_id is None:
+            await self.app(scope, _replay(body), send)
+            return
+
+        bot_token = self._state.bot_tokens[bot_username]
+        installation_id = self._state.installation_ids[bot_username]
+
+        try:
+            reply = await self._bind_and_reply(
+                token=token,
+                telegram_id=telegram_user_id,
+                telegram_username=telegram_username,
+                bot_installation_id=installation_id,
+            )
+        except Exception:
+            logger.exception("Telegram bind interceptor failed", bot=bot_username)
+            reply = "Something went wrong while linking your account. Please try again."
+
+        await _send_telegram_message(bot_token, chat_id, reply)
+        await _respond_200(send)
+
+    async def _bind_and_reply(
+        self,
+        *,
+        token: str,
+        telegram_id: int,
+        telegram_username: str | None,
+        bot_installation_id: str | int,
+    ) -> str:
+        url = f"{self._payload_url}/api/telegram-binding-tokens/bind"
+        payload = {
+            "token": token,
+            "telegramId": telegram_id,
+            "botInstallationId": bot_installation_id,
+        }
+        if telegram_username:
+            payload["telegramUsername"] = telegram_username
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                url, headers={INTERNAL_SECRET_HEADER: self._internal_secret}, json=payload
+            )
+
+        if response.status_code == 200:
+            data = response.json().get("user", {})
+            display = (
+                data.get("telegramUsername") or data.get("email") or "your Zetesis account"
+            )
+            return f"Connected to {display}. You can now chat with the agent."
+        if response.status_code in (404, 410):
+            return "This binding link is invalid or has expired. Please generate a new one in /settings/telegram."
+        if response.status_code == 403:
+            return "This binding link doesn't match this bot. Please generate a new one."
+        return "Sorry — couldn't link your account right now. Please try again in a minute."
+
+
+def _extract_start_token(update: dict) -> str | None:
+    text = (update.get("message") or {}).get("text")
+    if not isinstance(text, str):
+        return None
+    parts = text.strip().split(maxsplit=1)
+    if len(parts) != 2:
+        return None
+    cmd = parts[0].split("@")[0]  # strip /start@BotName
+    if cmd != "/start":
+        return None
+    return parts[1].strip() or None
+
+
+def _bot_username_from_path(path: str) -> str | None:
+    # /telegram/<botUsername>/webhook
+    parts = path.strip("/").split("/")
+    if len(parts) != 3 or parts[0] != "telegram" or parts[2] != "webhook":
+        return None
+    return parts[1]
+
+
+async def _read_body(receive: Callable[[], Awaitable[dict]]) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        chunks.append(message.get("body", b""))
+        if not message.get("more_body", False):
+            break
+    return b"".join(chunks)
+
+
+def _replay(body: bytes) -> Callable[[], Awaitable[dict]]:
+    sent = False
+
+    async def receive() -> dict:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+async def _send_telegram_message(bot_token: str, chat_id: int, text: str) -> None:
+    url = f"{TELEGRAM_API_BASE}/bot{bot_token}/sendMessage"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        try:
+            await client.post(url, json={"chat_id": chat_id, "text": text})
+        except httpx.HTTPError:
+            logger.exception("Failed to send Telegram bind reply")
+
+
+async def _respond_200(send: Callable) -> None:
+    await send({"type": "http.response.start", "status": 200, "headers": [(b"content-type", b"application/json")]})
+    await send({"type": "http.response.body", "body": b'{"status":"ok"}', "more_body": False})

--- a/backend/agno-agent-builder/agno_agent_builder/telegram_loader.py
+++ b/backend/agno-agent-builder/agno_agent_builder/telegram_loader.py
@@ -1,0 +1,149 @@
+"""Loads Telegram bot installations from the host CMS and wires one
+agno `Telegram` interface per installation onto the FastAPI app.
+
+The host CMS (e.g. ZetesisPortal) exposes a tenant-aware collection of
+TelegramBotInstallations and an internal endpoint that the runtime calls
+at boot to enumerate them. Each installation pins a (bot, agent) pairing,
+so the same agno-agent process can host many tenants' bots in parallel.
+
+Webhook auth — agno's `validate_webhook_secret_token` reads a SINGLE env
+var (`TELEGRAM_WEBHOOK_SECRET_TOKEN`), so for v1 every installation shares
+the same webhook secret. Operators register each bot via Telegram's
+`setWebhook` with `secret_token=<global>`. Per-bot rotation requires
+upstream changes (tracked separately).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+import structlog
+
+from agno_agent_builder.registry import AgentRegistry
+
+logger = structlog.get_logger("agno_agent_builder.telegram_loader")
+
+INTERNAL_SECRET_HEADER = "X-Internal-Secret"  # noqa: S105
+
+
+@dataclass(slots=True)
+class TelegramInstallation:
+    """Subset of the CMS row the runtime needs to mount one Telegram interface."""
+
+    id: str | int
+    bot_username: str
+    bot_token: str
+    agent_slug: str
+    tenant_slug: str | None
+
+
+async def fetch_installations(
+    payload_url: str, internal_secret: str, timeout_s: float = 10.0
+) -> list[TelegramInstallation]:
+    """GET /api/telegram-bot-installations/internal/list."""
+    if not internal_secret:
+        logger.warning("Telegram loader skipped: internal_secret empty")
+        return []
+
+    url = f"{payload_url.rstrip('/')}/api/telegram-bot-installations/internal/list"
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        try:
+            response = await client.get(url, headers={INTERNAL_SECRET_HEADER: internal_secret})
+        except httpx.HTTPError:
+            logger.exception("Failed to fetch Telegram bot installations")
+            return []
+
+    if response.status_code == 404:
+        # Host doesn't expose the endpoint — Telegram support not provisioned.
+        return []
+    if not response.is_success:
+        logger.error(
+            "Telegram bot installations endpoint returned non-2xx",
+            status_code=response.status_code,
+            body=response.text[:200],
+        )
+        return []
+
+    docs = response.json().get("docs", [])
+    installations: list[TelegramInstallation] = []
+    for doc in docs:
+        try:
+            installations.append(_parse_installation(doc))
+        except (KeyError, TypeError, ValueError) as exc:
+            logger.warning("Skipping malformed Telegram bot installation", error=str(exc))
+    return installations
+
+
+def _parse_installation(doc: dict) -> TelegramInstallation:
+    bot_username = doc.get("botUsername")
+    bot_token = doc.get("botToken")
+    if not isinstance(bot_username, str) or not bot_username:
+        raise ValueError(f"installation {doc.get('id', '?')} has no botUsername")
+    if not isinstance(bot_token, str) or not bot_token:
+        raise ValueError(f"installation {bot_username!r} has no botToken")
+
+    agent = doc.get("agent")
+    agent_slug = agent.get("slug") if isinstance(agent, dict) else None
+    if not isinstance(agent_slug, str) or not agent_slug:
+        raise ValueError(f"installation {bot_username!r} has no agent.slug (depth=1 not honoured?)")
+
+    tenant = doc.get("tenant")
+    tenant_slug = tenant.get("slug") if isinstance(tenant, dict) else None
+
+    return TelegramInstallation(
+        id=doc["id"],
+        bot_username=bot_username,
+        bot_token=bot_token,
+        agent_slug=agent_slug,
+        tenant_slug=tenant_slug if isinstance(tenant_slug, str) else None,
+    )
+
+
+def mount_telegram_interfaces(
+    app, registry: AgentRegistry, installations: list[TelegramInstallation]
+) -> list[str]:
+    """Build one agno `Telegram` interface per installation, mount its router.
+
+    Returns the list of webhook paths registered, so the caller can extend
+    `InternalAuthMiddleware`'s public_paths to allow Telegram to hit them
+    directly (Telegram validates its own X-Telegram-Bot-Api-Secret-Token).
+    """
+    try:
+        from agno.os.interfaces.telegram import Telegram
+    except ImportError:
+        logger.warning(
+            "agno's Telegram interface not installed (install with `agno[telegram]`); "
+            "Telegram bots will not be loaded"
+        )
+        return []
+
+    registered_paths: list[str] = []
+    for install in installations:
+        agent = registry.get(install.agent_slug)
+        if agent is None:
+            logger.warning(
+                "Bot installation references missing agent",
+                bot=install.bot_username,
+                agent_slug=install.agent_slug,
+            )
+            continue
+
+        prefix = f"/telegram/{install.bot_username}"
+        telegram = Telegram(
+            agent=agent,
+            token=install.bot_token,
+            prefix=prefix,
+            register_commands=False,  # handled out-of-process at install time
+        )
+        app.include_router(telegram.get_router())
+        registered_paths.append(f"{prefix}/webhook")
+        registered_paths.append(f"{prefix}/status")
+        logger.info(
+            "Mounted Telegram interface",
+            bot=install.bot_username,
+            agent=install.agent_slug,
+            prefix=prefix,
+        )
+
+    return registered_paths

--- a/backend/agno-agent-builder/pyproject.toml
+++ b/backend/agno-agent-builder/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "agno[anthropic,mcp,openai,os,postgres]>=2.6.0",
+    "agno[anthropic,mcp,openai,os,postgres,telegram]>=2.6.0",
     "fastapi>=0.115",
     "httpx>=0.28",
     "psycopg[binary]>=3.2",

--- a/backend/agno-agent/agno_agent/main.py
+++ b/backend/agno-agent/agno_agent/main.py
@@ -19,6 +19,7 @@ app = create_app(
         database_url=settings.database_url,
         database_schema=settings.database_schema,
         internal_secret=settings.internal_secret,
+        payload_url=settings.payload_url,
         log_level=settings.log_level,
     )
 )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -64,6 +64,10 @@ os = [
 postgres = [
     { name = "psycopg-binary" },
 ]
+telegram = [
+    { name = "aiohttp" },
+    { name = "pytelegrambotapi" },
+]
 
 [[package]]
 name = "agno-agent"
@@ -85,7 +89,7 @@ name = "agno-agent-builder"
 version = "0.1.2"
 source = { editable = "agno-agent-builder" }
 dependencies = [
-    { name = "agno", extra = ["anthropic", "mcp", "openai", "os", "postgres"] },
+    { name = "agno", extra = ["anthropic", "mcp", "openai", "os", "postgres", "telegram"] },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
@@ -96,7 +100,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "agno", extras = ["anthropic", "mcp", "openai", "os", "postgres"], specifier = ">=2.6.0" },
+    { name = "agno", extras = ["anthropic", "mcp", "openai", "os", "postgres", "telegram"], specifier = ">=2.6.0" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
@@ -335,6 +339,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -1844,6 +1921,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytelegrambotapi"
+version = "4.33.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/3c/ab2936cb4ab75c59fab8343e34df2472c79f9f6d2f20b3cdf27e215231b4/pytelegrambotapi-4.33.0.tar.gz", hash = "sha256:df35be14d015d6ac874768db848d0c6d7864f586b242d4902efa2244efca6512", size = 1378027, upload-time = "2026-04-11T19:28:11.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/c6/383f0a951afeec0f6b44cba460ea651668ceb0a86d82f9c91ca696c52729/pytelegrambotapi-4.33.0-py3-none-any.whl", hash = "sha256:0c34ded8c6f7afe41b8d591ef102aeaa9ca158d97ec50309279d09a6603e0ffb", size = 308423, upload-time = "2026-04-11T19:28:08.961Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1994,6 +2083,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]

--- a/packages/payload-agents-core/src/collections/agents.ts
+++ b/packages/payload-agents-core/src/collections/agents.ts
@@ -56,6 +56,15 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
                 type: 'checkbox',
                 defaultValue: true,
                 admin: { description: 'Enable or disable this agent' }
+              },
+              {
+                name: 'allowGuestAccess',
+                type: 'checkbox',
+                defaultValue: false,
+                admin: {
+                  description:
+                    'When enabled, anonymous channel callers (e.g. Telegram users not yet bound to a ZP user) can chat with this agent. Leave off to require a bound user.'
+                }
               }
             ]
           },


### PR DESCRIPTION
Wires agno's native `Telegram` interface into the agno-agent runtime
backed by a per-tenant `TelegramBotInstallations` collection on the host
CMS. Each row pins one (bot, agent) pairing; the runtime fetches the
list at boot and mounts one Telegram interface per bot at
`/telegram/<botUsername>/webhook`. A binding flow lets web users link
their CMS account to their Telegram user via a one-time `/start <token>`
deep link.

## `@zetesis/payload-agents-core`

- New `Agent.allowGuestAccess` checkbox (default false) — tenants mark
  which agents anonymous channel callers can chat with. Surfaces via
  `AgentConfig.allow_guest_access` in the runtime.

## `agno-agent-builder`

- `agno[telegram]` added to required deps (pulls `pyTelegramBotAPI`).
- `RuntimeConfig.payload_url` (optional) — required for the Telegram
  loader to call back to the host CMS for installations and binds.
- `telegram_loader.py`:
  - `fetch_installations()` → `GET /api/telegram-bot-installations/internal/list`
    with `X-Internal-Secret`.
  - `mount_telegram_interfaces()` builds one `agno.os.interfaces.telegram.Telegram`
    per row, wired to the matching agent.
- `telegram_bind_middleware.py`:
  - ASGI middleware intercepts `/start <token>` POSTs on registered
    Telegram webhook paths, calls `POST /api/telegram-binding-tokens/bind`
    on the host, replies via the Bot API directly. Implementation is
    middleware (not subclass) to avoid forking agno's 200+ line
    `attach_routes` closure.
  - `TelegramBindState` mutable holder lets the middleware register at
    app construction and pick up live per-bot config from lifespan.
- `app.py`: lifespan startup, after agents load, fetches installations
  + populates bind state. Bind middleware is the OUTERMOST in the stack
  so it runs before `InternalAuthMiddleware` (Telegram doesn't present
  X-Internal-Secret).
- `middleware.InternalAuthMiddleware`: now supports prefix-match public
  paths (entries ending in `/`). `DEFAULT_PUBLIC_PATHS` adds `/telegram/`.

## `agno-agent` (consumer)

- `main.py` passes `payload_url=settings.payload_url`.

## Validation

- `pnpm --filter @zetesis/payload-agents-core build` ✓
- `pnpm tsc --noEmit` ✓ / `pnpm lint` ✓
- `uv run ruff check` ✓ / `uv run pyright` ✓ (only preexisting unrelated)
- `agno_agent.main:app` smoke-imports

## Stacked on

`feat/chat-agent-internal-endpoints` (#55). Mergeable after that.

## Pairs with

ZetesisPortal#NEW (host-side collections + UI + ingress).

🤖 Generated with Claude Code
