### PR TITLE
feat(mcp-typesense,payload-agents-core): scope MCP search by folder

### DIFF
--- a/.changeset/mcp-typesense-folder-filter.md
+++ b/.changeset/mcp-typesense-folder-filter.md
@@ -13,6 +13,10 @@ Mirrors the existing `x-taxonomy-slugs` plumbing:
 - `searchCollections` injects `folder_slugs:[…]` into `scopedFilters`
   when `auth.folderSlugs` is non-empty and the caller hasn't already
   set the filter explicitly.
+- `getPostSummaries` mirrors the same auto-scoping for both
+  `taxonomy_slugs` (when not already narrowed via `author_slug` /
+  `topic_slug`) and `folder_slugs`. A token-scoped client now sees a
+  consistent corpus across listing and search.
 
 The slug chain is expected to mirror the folder breadcrumb (root →
 leaf), so a token scoped to "Proyectos" matches every doc nested below

--- a/.changeset/mcp-typesense-folder-filter.md
+++ b/.changeset/mcp-typesense-folder-filter.md
@@ -1,0 +1,20 @@
+---
+"@zetesis/mcp-typesense": minor
+---
+
+**Folder-scoped MCP search**: parse the new `x-folder-slugs` header and
+auto-apply it as the `folder_slugs` filter on every search.
+
+Mirrors the existing `x-taxonomy-slugs` plumbing:
+
+- `McpAuthContext` gains an optional `folderSlugs?: string[]` field.
+- The default `header` auth strategy parses comma-separated values from
+  the `x-folder-slugs` request header.
+- `searchCollections` injects `folder_slugs:[…]` into `scopedFilters`
+  when `auth.folderSlugs` is non-empty and the caller hasn't already
+  set the filter explicitly.
+
+The slug chain is expected to mirror the folder breadcrumb (root →
+leaf), so a token scoped to "Proyectos" matches every doc nested below
+it. Documentation in `defaults.ts` (DEFAULT_INSTRUCTIONS / DEFAULT_GUIDE)
+mentions the new filter alongside `taxonomy_slugs`.

--- a/.changeset/payload-agents-core-folder-relationship.md
+++ b/.changeset/payload-agents-core-folder-relationship.md
@@ -1,0 +1,19 @@
+---
+"@zetesis/payload-agents-core": minor
+---
+
+**Folder-scoped agents**: the auto-generated `agents` collection gets a
+new `folders` `relationship[hasMany]` field next to `taxonomies`.
+
+- `AgentPluginConfig` gains an optional `foldersCollectionSlug` (default
+  `'payload-folders'`, matching Payload's auto-injected folders slug).
+  Override it only if your `buildConfig({ folders: { slug } })` uses a
+  different slug.
+- The `RAG Configuration` group on the agents admin form now exposes
+  `Folders` so admins can scope an agent to one or more folders. Empty
+  by default — the agent searches all available content unless a folder
+  is selected.
+
+The agno-agent-builder runtime reads the new field and forwards each
+folder's breadcrumb slug chain via the `x-folder-slugs` header (handled
+by `@zetesis/mcp-typesense ≥ 0.4`).

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -46,7 +46,7 @@ const mcp = createMcpServer({
       chunkCollection: 'posts_chunk',
       parentCollection: 'posts',
       chunkSearchFields: ['chunk_text', 'title'],
-      chunkFacetFields: ['tenant', 'taxonomy_slugs', 'parent_doc_id', 'headers'],
+      chunkFacetFields: ['tenant', 'taxonomy_slugs', 'folder_slugs', 'parent_doc_id', 'headers'],
       kind: 'document',
     },
     {
@@ -55,7 +55,7 @@ const mcp = createMcpServer({
       chunkCollection: 'books_chunk',
       parentCollection: 'books',
       chunkSearchFields: ['chunk_text', 'title'],
-      chunkFacetFields: ['tenant', 'taxonomy_slugs', 'parent_doc_id', 'headers'],
+      chunkFacetFields: ['tenant', 'taxonomy_slugs', 'folder_slugs', 'parent_doc_id', 'headers'],
       kind: 'book',
     },
   ],

--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -41,7 +41,7 @@ def build_agent(
             cfg, tool_protocol=tool_protocol, output_format=output_format
         ),
         db=db,
-        tools=[build_mcp_tools(mcp_url, cfg.tenant_slug, cfg.taxonomy_slugs)],
+        tools=[build_mcp_tools(mcp_url, cfg.tenant_slug, cfg.taxonomy_slugs, cfg.folder_slugs)],
         add_history_to_context=True,
         num_history_runs=5,
         reasoning=not is_native_reasoner,
@@ -65,13 +65,16 @@ def build_mcp_tools(
     mcp_url: str,
     tenant_slug: str | None = None,
     taxonomy_slugs: list[str] | None = None,
+    folder_slugs: list[str] | None = None,
 ) -> MCPTools:
-    """Build an MCPTools instance with tenant/taxonomy headers."""
+    """Build an MCPTools instance with tenant/taxonomy/folder headers."""
     headers: dict[str, str] = {}
     if tenant_slug:
         headers["x-tenant-slug"] = tenant_slug
     if taxonomy_slugs:
         headers["x-taxonomy-slugs"] = ",".join(taxonomy_slugs)
+    if folder_slugs:
+        headers["x-folder-slugs"] = ",".join(folder_slugs)
     if headers:
         params = StreamableHTTPClientParams(url=mcp_url, headers=headers)
         return MCPTools(server_params=params, transport="streamable-http")

--- a/backend/agno-agent-builder/agno_agent_builder/instructions.py
+++ b/backend/agno-agent-builder/agno_agent_builder/instructions.py
@@ -19,7 +19,8 @@ ARGUMENT SHAPE (read this before every call):
   Example: `["posts_chunk", "books_chunk"]`.
 - `filters` (object): facet filters. Keys are field names, values are
   strings or string arrays. The supported keys are `taxonomy_slugs`,
-  `tenant` and `headers`. Example: `{ "taxonomy_slugs": "<slug>" }`.
+  `folder_slugs`, `tenant` and `headers`. Example:
+  `{ "taxonomy_slugs": "<slug>" }` or `{ "folder_slugs": "<slug>" }`.
 - COMMON MISTAKE: do NOT pass `filters: "posts_chunk"`. That is a
   collection name and belongs in `collections: ["posts_chunk"]`.
 
@@ -90,6 +91,8 @@ def compose_instructions(
     rag_parts: list[str] = []
     if cfg.taxonomy_slugs:
         rag_parts.append(f"taxonomy_slugs: {','.join(cfg.taxonomy_slugs)}")
+    if cfg.folder_slugs:
+        rag_parts.append(f"folder_slugs: {','.join(cfg.folder_slugs)}")
     if cfg.search_collections:
         rag_parts.append(f"collections: {','.join(cfg.search_collections)}")
     if rag_parts:

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -79,6 +79,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
     tenant_slug = tenant.get("slug") if isinstance(tenant, dict) else None
 
     taxonomy_slugs = _extract_taxonomy_slugs(doc.get("taxonomies"))
+    folder_slugs = _extract_folder_slugs(doc.get("folders"))
 
     search_collections = doc.get("searchCollections")
     if not isinstance(search_collections, list):
@@ -103,6 +104,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         else None,
         tenant_slug=tenant_slug,
         taxonomy_slugs=taxonomy_slugs,
+        folder_slugs=folder_slugs,
         search_collections=search_collections,
         tool_call_limit=tool_call_limit,
         allow_guest_access=bool(doc.get("allowGuestAccess")),
@@ -119,3 +121,37 @@ def _extract_taxonomy_slugs(taxonomies: Any) -> list[str]:
         elif isinstance(item, str):
             slugs.append(item)
     return slugs
+
+
+def _extract_folder_slugs(folders: Any) -> list[str]:
+    """Pull the slug chain from each folder's breadcrumbs.
+
+    A folder filed under ``Proyectos / 2026 / Q1`` indexes its docs with
+    ``folder_slugs = ['proyectos', '2026', 'q1']``. To filter "everything
+    under Q1" we forward the leaf slug (``q1``); Typesense matches all docs
+    whose ``folder_slugs`` array contains it. We collect every slug in the
+    breadcrumb so a user picking ``Proyectos`` selects the whole subtree.
+    """
+    if not isinstance(folders, list):
+        return []
+    slugs: list[str] = []
+    for item in folders:
+        if not isinstance(item, dict):
+            continue
+        breadcrumbs = item.get("breadcrumbs")
+        if isinstance(breadcrumbs, list):
+            for crumb in breadcrumbs:
+                if not isinstance(crumb, dict):
+                    continue
+                url = crumb.get("url")
+                if isinstance(url, str) and url:
+                    slug = url.lstrip("/")
+                    if slug:
+                        slugs.append(slug)
+        else:
+            # Fallback: depth=0 may give us only the slug column
+            fallback_slug = item.get("slug")
+            if isinstance(fallback_slug, str) and fallback_slug:
+                slugs.append(fallback_slug)
+    # Dedupe preserving order
+    return list(dict.fromkeys(slugs))

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -21,6 +21,7 @@ class AgentConfig(BaseModel):
     instructions_extra: str | None = None
     tenant_slug: str | None = None
     taxonomy_slugs: list[str] = []
+    folder_slugs: list[str] = []
     search_collections: list[str] = []
     tool_call_limit: int | None = None
     allow_guest_access: bool = False

--- a/packages/mcp-typesense/src/auth/resolve.ts
+++ b/packages/mcp-typesense/src/auth/resolve.ts
@@ -12,6 +12,17 @@ import type { McpAuthContext, McpAuthStrategy } from '../types'
 
 const DEFAULT_HEADER_NAME = 'x-tenant-slug'
 const TAXONOMY_HEADER_NAME = 'x-taxonomy-slugs'
+const FOLDER_HEADER_NAME = 'x-folder-slugs'
+
+const parseSlugList = (raw: string | string[] | undefined): string[] | undefined => {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  if (!value) return undefined
+  const slugs = value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+  return slugs.length > 0 ? slugs : undefined
+}
 
 export function resolveAuth(req: IncomingMessage, strategy: McpAuthStrategy | undefined): McpAuthContext | null {
   // Default strategy: header with default header name.
@@ -22,22 +33,17 @@ export function resolveAuth(req: IncomingMessage, strategy: McpAuthStrategy | un
     const raw = req.headers[headerName]
     const tenantSlug = Array.isArray(raw) ? raw[0] : raw
 
-    // Optional: taxonomy slugs for server-enforced content scoping
-    const taxonomyRaw = req.headers[TAXONOMY_HEADER_NAME]
-    const taxonomyStr = Array.isArray(taxonomyRaw) ? taxonomyRaw[0] : taxonomyRaw
-    const taxonomySlugs = taxonomyStr
-      ? taxonomyStr
-          .split(',')
-          .map(s => s.trim())
-          .filter(Boolean)
-      : undefined
+    // Optional content-scoping headers — set when the proxy resolves the
+    // owning token/agent's `taxonomies` or `folders` relationship.
+    const taxonomySlugs = parseSlugList(req.headers[TAXONOMY_HEADER_NAME])
+    const folderSlugs = parseSlugList(req.headers[FOLDER_HEADER_NAME])
 
-    // Single-tenant deploys (no tenant header) can still send taxonomy
-    // filters. Return a context whenever at least one of the two is present;
+    // Single-tenant deploys (no tenant header) can still send taxonomy or
+    // folder filters. Return a context whenever at least one is present;
     // null means "no auth headers at all" → no auto-scoping.
-    if (!tenantSlug && !taxonomySlugs?.length) return null
+    if (!tenantSlug && !taxonomySlugs?.length && !folderSlugs?.length) return null
 
-    return { tenantSlug: tenantSlug || undefined, taxonomySlugs }
+    return { tenantSlug: tenantSlug || undefined, taxonomySlugs, folderSlugs }
   }
 
   // Exhaustive guard. When new variants are added, TypeScript will force

--- a/packages/mcp-typesense/src/defaults.ts
+++ b/packages/mcp-typesense/src/defaults.ts
@@ -16,13 +16,14 @@ WORKFLOW:
 
 SEARCH RULES:
 - Query by CONCEPT. Do NOT put author names or meta-words in the query — scope them via \`filters.taxonomy_slugs\` instead.
+- Use \`filters.folder_slugs\` to scope by folder. Slugs follow the breadcrumb chain (root → leaf), so filtering by an ancestor's slug selects everything below it.
 - Lexical mode AND-joins terms. 1-2 concept words yield the best recall. Shorter query = more results.
 - In semantic/hybrid, vector recall is fixed (top 100 neighbors); \`per_page\` only paginates the page you see.
 - \`total_found\` is only reliable in \`mode: "lexical"\`.
 
 PARAMETER TYPES:
 - \`filters\` MUST be a JSON object, not a stringified JSON.
-- \`taxonomy_slugs\` accepts a string OR a string array.
+- \`taxonomy_slugs\` and \`folder_slugs\` accept a string OR a string array.
 - \`per_page\`, \`page\`, \`snippet_length\` are numbers, not strings.
 
 Read \`guide://search\` for deeper guidance.`
@@ -34,6 +35,7 @@ export const DEFAULT_GUIDE = `# MCP Search Server — Agent Guide
 - Search by **CONCEPT**, not by author name or meta-words. Indexed content is direct text — authors don't name themselves.
 - Use \`taxonomy_slugs\` **FILTERS** to scope by author/topic instead of putting the name in the query:
   \`{ "filters": { "taxonomy_slugs": "some-slug" }, "query": "core concept" }\`
+- Use \`folder_slugs\` **FILTERS** to scope by folder. The slug chain mirrors the folder breadcrumb (root → leaf), so filtering by an ancestor folder's slug selects everything below it.
 - Use the \`headers\` filter to search within a specific book section.
 - Do NOT add meta-words like "opinion", "thinks", "says", "believes" — they are not in the content.
 
@@ -71,7 +73,7 @@ If a search returns suspiciously few results:
 Some MCP clients silently coerce structured parameters into strings. Always pass:
 
 - \`filters\` as a **JSON object**, never as a stringified JSON.
-- \`taxonomy_slugs\` as a string OR string array.
+- \`taxonomy_slugs\` and \`folder_slugs\` as a string OR string array.
 - \`per_page\`, \`page\`, \`snippet_length\` as **numbers**, not strings.
 - \`collections\` as a string array.
 

--- a/packages/mcp-typesense/src/tools/get-post-summaries.ts
+++ b/packages/mcp-typesense/src/tools/get-post-summaries.ts
@@ -88,11 +88,32 @@ function resolveTargetCollection(input: GetPostSummariesInput, ctx: ToolContext)
   return { collection: first }
 }
 
-function buildFilters(input: GetPostSummariesInput, tenantSlug: string | null): string[] {
+/**
+ * Format a Typesense facet equality clause for one or many values.
+ * Single value → `field:=value`. Many values → `field:[v1,v2,…]`.
+ */
+const formatFacetClause = (field: string, values: string[]): string =>
+  values.length === 1 ? `${field}:=${values[0]}` : `${field}:[${values.join(',')}]`
+
+function buildFilters(
+  input: GetPostSummariesInput,
+  tenantSlug: string | null,
+  authTaxonomySlugs?: string[],
+  authFolderSlugs?: string[]
+): string[] {
   const filters: string[] = []
   if (tenantSlug) filters.push(`tenant:=${tenantSlug}`)
   if (input.author_slug) filters.push(`taxonomy_slugs:=${input.author_slug}`)
   if (input.topic_slug) filters.push(`taxonomy_slugs:=${input.topic_slug}`)
+  // Auto-scope by taxonomy/folder slugs from the auth context — mirrors the
+  // behavior of `search_collections`. Skipped when the explicit input already
+  // narrows by author/topic to avoid double-AND-ing the same field.
+  if (authTaxonomySlugs?.length && !input.author_slug && !input.topic_slug) {
+    filters.push(formatFacetClause('taxonomy_slugs', authTaxonomySlugs))
+  }
+  if (authFolderSlugs?.length) {
+    filters.push(formatFacetClause('folder_slugs', authFolderSlugs))
+  }
   return filters
 }
 
@@ -128,7 +149,7 @@ export async function getPostSummaries(input: GetPostSummariesInput, ctx: ToolCo
   const perPage = Math.min(input.per_page ?? 50, 100)
   const page = input.page ?? 1
 
-  const filters = buildFilters(input, tenantSlug)
+  const filters = buildFilters(input, tenantSlug, auth?.taxonomySlugs, auth?.folderSlugs)
 
   // Strategy: search chunks with * query, group by parent_doc_id to dedupe
   // into one entry per parent post. The first chunk of each group carries

--- a/packages/mcp-typesense/src/tools/search-collections.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.ts
@@ -37,7 +37,7 @@ export const searchCollectionsSchema = z.object({
     .record(z.union([z.string(), z.array(z.string())]))
     .optional()
     .describe(
-      'Facet filters to apply. Keys are field names (tenant, taxonomy_slugs, headers), values are strings or arrays.'
+      'Facet filters to apply. Keys are field names (tenant, taxonomy_slugs, folder_slugs, headers), values are strings or arrays.'
     ),
   per_page: z
     .number()
@@ -364,7 +364,7 @@ export async function searchCollections(
   ctx: ToolContext,
   auth: McpAuthContext | null
 ): Promise<SearchResult> {
-  // Auto-scope by tenant and taxonomy when auth provides them.
+  // Auto-scope by tenant, taxonomy, and folder when auth provides them.
   let scopedFilters = input.filters
   if (auth?.tenantSlug && !scopedFilters?.tenant) {
     scopedFilters = { ...scopedFilters, tenant: auth.tenantSlug }
@@ -373,6 +373,12 @@ export async function searchCollections(
     scopedFilters = {
       ...scopedFilters,
       taxonomy_slugs: auth.taxonomySlugs.length === 1 ? auth.taxonomySlugs[0] : auth.taxonomySlugs
+    }
+  }
+  if (auth?.folderSlugs?.length && !scopedFilters?.folder_slugs) {
+    scopedFilters = {
+      ...scopedFilters,
+      folder_slugs: auth.folderSlugs.length === 1 ? auth.folderSlugs[0] : auth.folderSlugs
     }
   }
 

--- a/packages/mcp-typesense/src/types.ts
+++ b/packages/mcp-typesense/src/types.ts
@@ -169,6 +169,12 @@ export interface McpAuthContext {
   tenantSlug?: string
   /** Taxonomy slugs — if present, searches are auto-scoped by `taxonomy_slugs`. */
   taxonomySlugs?: string[]
+  /**
+   * Folder slugs — if present, searches are auto-scoped by `folder_slugs`.
+   * The slug chain mirrors the folder breadcrumb (root → leaf), so
+   * filtering by any ancestor's slug selects everything below it.
+   */
+  folderSlugs?: string[]
   /** User identifier, for logging/auditing. */
   userId?: string
   /** Arbitrary metadata the auth strategy wants to propagate. */

--- a/packages/payload-agents-core/src/collections/agents.ts
+++ b/packages/payload-agents-core/src/collections/agents.ts
@@ -134,6 +134,16 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
                       description:
                         'Taxonomies that filter the RAG content. REQUIRED: if empty, agent will not search any content.'
                     }
+                  },
+                  {
+                    name: 'folders',
+                    type: 'relationship',
+                    relationTo: config.foldersCollectionSlug,
+                    hasMany: true,
+                    admin: {
+                      description:
+                        'Folders that scope the RAG content. Optional: if set, the agent only sees documents inside these folders (and their descendants, since the slug chain mirrors the breadcrumb).'
+                    }
                   }
                 ]
               },

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -37,6 +37,7 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
     encryptionKey: userConfig.encryptionKey,
     mediaCollectionSlug: userConfig.mediaCollectionSlug,
     taxonomyCollectionSlug: userConfig.taxonomyCollectionSlug,
+    foldersCollectionSlug: userConfig.foldersCollectionSlug ?? 'payload-folders',
     searchCollectionOptions: userConfig.searchCollectionOptions,
     collectionOverrides: userConfig.collectionOverrides,
     onRunCompleted: userConfig.onRunCompleted

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -137,6 +137,14 @@ export interface AgentPluginConfig {
    */
   taxonomyCollectionSlug: string
 
+  /**
+   * Slug of the folders collection for RAG filtering. Optional — defaults
+   * to `'payload-folders'`, which is Payload's default for the auto-injected
+   * folders collection. Override only if your `buildConfig({ folders: { slug } })`
+   * uses a different name.
+   */
+  foldersCollectionSlug?: string
+
   /** Options for the agent's `searchCollections` field. Empty arrays are rejected at boot. */
   searchCollectionOptions: ReadonlyArray<{ label: string; value: string }>
 
@@ -252,6 +260,7 @@ export interface ResolvedPluginConfig {
   encryptionKey: string | undefined
   mediaCollectionSlug: string
   taxonomyCollectionSlug: string
+  foldersCollectionSlug: string
   searchCollectionOptions: ReadonlyArray<{ label: string; value: string }>
   collectionOverrides: CollectionOverrides | undefined
   onRunCompleted: OnRunCompleted | undefined


### PR DESCRIPTION
## Summary

Mirror the existing `taxonomy_slugs` plumbing for folders so an MCP token or an Agno agent can scope search to one or more folders. The slug chain walks each folder's breadcrumbs (root → leaf), so a scope of "Proyectos" matches every doc nested below it via `folder_slugs:[proyectos-tenant]`.

## What changes

**`@zetesis/mcp-typesense`** (minor)
- `McpAuthContext.folderSlugs?: string[]` added to the type.
- Default `header` auth strategy parses the new `x-folder-slugs` header (comma-separated).
- `searchCollections` injects `folder_slugs:[…]` into the scoped filters when the auth context provides them and the caller hasn't already set the filter explicitly.
- `DEFAULT_INSTRUCTIONS` / `DEFAULT_GUIDE` document the new filter alongside `taxonomy_slugs`.
- Example MCP app (`apps/mcp`) registers `folder_slugs` as a chunk facet field.

**`@zetesis/payload-agents-core`** (minor)
- New optional `foldersCollectionSlug` config (default `'payload-folders'`, the auto-injected folders slug). Override only if `buildConfig({ folders: { slug } })` uses a different name.
- The auto-generated `agents` collection now exposes a `folders` `relationship[hasMany]` field in the **RAG Configuration** group, next to `taxonomies`.

**`agno-agent-builder`** (minor)
- `AgentConfig` gains `folder_slugs: list[str]`.
- `_extract_folder_slugs` walks each `folders[]` entry's breadcrumbs (depth=1) and falls back to the folder's own slug when breadcrumbs are missing.
- `build_mcp_tools` forwards them via the `x-folder-slugs` header.
- `instructions.py` documents the new filter so the agent uses it correctly.

## Out of scope

The consumer side (token UI, McpSearchTokens collection, proxy header forwarding, migration) lives in `Zetesis-Labs/ZetesisPortal` — companion PR follows.

## Test plan

- [x] `pnpm tsc --noEmit` — green
- [x] `pnpm lint` — green (submodule)
- [x] `uv run ruff check .`, `ruff format --check .` — green
- [x] `uv run mypy agno-agent-builder/agno_agent_builder` — green
- [x] `pnpm --filter @zetesis/mcp-typesense build` — green (~90 KB → 25 KB gzipped)
- [x] `pnpm --filter @zetesis/payload-agents-core build` — green
- [ ] Smoke in preview env: bind a folder to an agent, observe `x-folder-slugs` header arrives at the MCP server, every search applies `folder_slugs:[…]`
- [ ] Same for an MCP token created via `/settings/api-tokens` (consumer-side PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)