### PR TITLE
fix(security): timing-safe internal-secret compare + LlamaParse upload limits

### DIFF
--- a/backend/payload-documents-worker-builder/payload_documents_worker_builder/tasks/parse_document.py
+++ b/backend/payload-documents-worker-builder/payload_documents_worker_builder/tasks/parse_document.py
@@ -31,6 +31,27 @@ from payload_documents_worker_builder.config import RuntimeConfig
 PARSE_DOCUMENT_TASK_NAME = "documents.parse"
 DEFAULT_FILENAME = "upload.bin"
 
+# Defensive limits before we ship a file to LlamaParse. A single 1GB upload
+# in Payload (or many MB-sized files in a tight loop) can rack up significant
+# LlamaParse cost. Mirrors the limit in apps/server/src/collections/Documents
+# (kept conservative for now; raise via config if needed). Security audit: M6.
+MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024  # 100 MiB
+ALLOWED_MIME_PREFIXES = (
+    "application/pdf",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument",
+    "text/",
+    "image/",
+)
+
+
+class FileTooLargeError(Exception):
+    """Raised when a Payload upload exceeds MAX_FILE_SIZE_BYTES."""
+
+
+class UnsupportedMimeTypeError(Exception):
+    """Raised when the upload's MIME type isn't on the allowlist."""
+
 logger = structlog.get_logger("payload_documents_worker_builder.parse_document")
 
 
@@ -77,7 +98,12 @@ async def _run_parse_document(document_id: str, config: RuntimeConfig) -> None:
             markdown = await _poll_until_done(llama, job.id, config, log)
             await _writeback_success(payload, config, document_id, markdown, log)
             log.info("Parse document task succeeded")
-        except (LlamaParseError, PayloadError) as exc:
+        except (
+            LlamaParseError,
+            PayloadError,
+            FileTooLargeError,
+            UnsupportedMimeTypeError,
+        ) as exc:
             log.exception("Parse document task failed")
             await _stamp_error(payload, config, document_id, str(exc))
             raise
@@ -98,8 +124,32 @@ async def _fetch_inputs(
     log: structlog.stdlib.BoundLogger,
 ) -> tuple[ParseContext, bytes]:
     ctx = await payload.fetch_parse_context(config.documents_collection_slug, document_id)
+
+    # Validate MIME type before pulling bytes — a quota-abuse attempt with a
+    # huge non-document file can be rejected without ever downloading.
+    mime_type = ctx.get("mimeType") or ctx.get("mime_type")
+    if mime_type and not any(mime_type.startswith(p) for p in ALLOWED_MIME_PREFIXES):
+        log.warning("Rejecting upload with unsupported MIME", mime_type=mime_type)
+        raise UnsupportedMimeTypeError(
+            f"MIME type {mime_type!r} not in allowlist; refusing to send to LlamaParse"
+        )
+
     log.info("Downloading upload from Payload", filename=_resolve_filename(ctx))
     file_bytes = await payload.fetch_parse_file(config.documents_collection_slug, document_id)
+
+    # Size-cap after download so we have actual bytes (Payload may not always
+    # populate filesize in the metadata depending on storage adapter).
+    if len(file_bytes) > MAX_FILE_SIZE_BYTES:
+        log.warning(
+            "Rejecting upload over size limit",
+            size=len(file_bytes),
+            limit=MAX_FILE_SIZE_BYTES,
+        )
+        raise FileTooLargeError(
+            f"File size {len(file_bytes)} bytes exceeds limit {MAX_FILE_SIZE_BYTES}; "
+            "refusing to send to LlamaParse"
+        )
+
     return ctx, file_bytes
 
 

--- a/backend/payload-documents-worker-builder/payload_documents_worker_builder/tasks/parse_document.py
+++ b/backend/payload-documents-worker-builder/payload_documents_worker_builder/tasks/parse_document.py
@@ -52,6 +52,7 @@ class FileTooLargeError(Exception):
 class UnsupportedMimeTypeError(Exception):
     """Raised when the upload's MIME type isn't on the allowlist."""
 
+
 logger = structlog.get_logger("payload_documents_worker_builder.parse_document")
 
 

--- a/packages/payload-agents-core/src/endpoints/agents-internal-list.ts
+++ b/packages/payload-agents-core/src/endpoints/agents-internal-list.ts
@@ -10,17 +10,33 @@
  * agents and tenants collections to make depth=1 populate work.
  */
 
+import { timingSafeEqual } from 'node:crypto'
 import type { PayloadHandler, PayloadRequest, Where } from 'payload'
 import type { ResolvedPluginConfig } from '../types'
 
 const INTERNAL_SECRET_HEADER = 'x-internal-secret'
+
+/**
+ * Constant-time comparison. Falls back to a dummy compare on mismatched
+ * length so an attacker can't infer the secret length from the
+ * early-exit timing of a length check. (Security audit: H1.)
+ */
+const safeCompareSecrets = (a: string, b: string): boolean => {
+  const aBuf = Buffer.from(a, 'utf8')
+  const bBuf = Buffer.from(b, 'utf8')
+  if (aBuf.length !== bBuf.length) {
+    timingSafeEqual(aBuf, Buffer.alloc(aBuf.length, 0))
+    return false
+  }
+  return timingSafeEqual(aBuf, bBuf)
+}
 
 const requireInternalSecret = (req: PayloadRequest, internalSecret: string): Response | null => {
   if (!internalSecret) {
     return Response.json({ error: 'Internal endpoint not configured' }, { status: 503 })
   }
   const headerSecret = req.headers?.get?.(INTERNAL_SECRET_HEADER)
-  if (!headerSecret || headerSecret !== internalSecret) {
+  if (!headerSecret || !safeCompareSecrets(headerSecret, internalSecret)) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
   return null

--- a/packages/payload-agents-metrics/src/endpoints/ingest.ts
+++ b/packages/payload-agents-metrics/src/endpoints/ingest.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto'
 import type { PayloadHandler } from 'payload'
 import { z } from 'zod'
 import { calculateLlmCost, type LlmProvider } from '../lib/cost-calculator'
@@ -30,11 +31,25 @@ const EventSchema = z.object({
 type IngestEvent = z.infer<typeof EventSchema>
 const PayloadSchema = z.union([EventSchema, z.array(EventSchema).min(1).max(100)])
 
+/**
+ * Constant-time secret comparison. Prevents byte-by-byte timing attacks
+ * on the ingest secret. (Security audit: H1.)
+ */
+const safeCompareSecrets = (a: string, b: string): boolean => {
+  const aBuf = Buffer.from(a, 'utf8')
+  const bBuf = Buffer.from(b, 'utf8')
+  if (aBuf.length !== bBuf.length) {
+    timingSafeEqual(aBuf, Buffer.alloc(aBuf.length, 0))
+    return false
+  }
+  return timingSafeEqual(aBuf, bBuf)
+}
+
 export function createIngestHandler(config: ResolvedMetricsConfig): PayloadHandler {
   return async req => {
     const secret = config.ingestSecret
     const provided = req.headers?.get?.('x-internal-secret')
-    if (!provided || provided !== secret) {
+    if (!provided || !safeCompareSecrets(provided, secret)) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 })
     }
 


### PR DESCRIPTION
Addresses H1 + M6 from the cross-repo security audit ([ZP#264](https://github.com/Zetesis-Labs/ZetesisPortal/issues/264)). Pairs with the ZP-side PR.

## What

**H1 — Timing-safe compare on `X-Internal-Secret` (HIGH)**

`agents-internal-list` and `metrics/ingest` endpoints used `!== / !=` on the incoming `X-Internal-Secret` header. Now use `crypto.timingSafeEqual` with a dummy compare on length mismatch.

- `packages/payload-agents-core/src/endpoints/agents-internal-list.ts`
- `packages/payload-agents-metrics/src/endpoints/ingest.ts`

**M6 — File size + MIME validation in LlamaParse worker (MEDIUM)**

`_fetch_inputs` now rejects:
- Files outside the MIME allowlist (pdf/word/text/image/officedoc) — checked BEFORE download to avoid wasted bandwidth.
- Files over 100 MiB — checked after download (Payload's `mimeType` metadata isn't always populated).

Both errors stamp `parse_status: error` in Payload via the existing orchestrator catch.

- `backend/payload-documents-worker-builder/.../tasks/parse_document.py`

**H2 — Deferred**

Header re-validation in `mcp-typesense/auth/resolve.ts` left for a follow-up PR. The proxy in ZP already overrides `x-taxonomy-slugs` / `x-folder-slugs` from the token; the residual risk requires direct cluster-internal access. Documented in the audit issue.

## Test plan

- npm packages: `pnpm lint` clean, `pnpm tsc --noEmit` clean.
- Python: existing test suite + spot-check that the new errors raise correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)