### PR TITLE
feat(agno-microsoft-teams): add typing indicators and adaptive cards

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/channels/teams/outbound_media.py
+++ b/backend/agno-agent-builder/agno_agent_builder/channels/teams/outbound_media.py
@@ -1,9 +1,13 @@
 from agno_microsoft_teams.outbound_media import (
+    ADAPTIVE_CARD_CONTENT_TYPE,
     MAX_INLINE_ATTACHMENT_BYTES,
+    adaptive_card_attachment,
     build_attachments,
 )
 
 __all__ = [
+    "ADAPTIVE_CARD_CONTENT_TYPE",
     "MAX_INLINE_ATTACHMENT_BYTES",
+    "adaptive_card_attachment",
     "build_attachments",
 ]

--- a/backend/agno-microsoft-teams/README.md
+++ b/backend/agno-microsoft-teams/README.md
@@ -27,4 +27,21 @@ https://<runtime-host>/teams/<app-id>/messages
 
 The interface validates inbound Bot Framework JWTs, strips Teams bot
 mentions, downloads supported incoming attachments into Agno media, and
-replies through the Bot Connector API.
+replies through the Bot Connector API. Slow agent runs emit Teams `typing`
+activities before the final reply.
+
+Structured Teams cards can be returned by exposing `adaptive_cards` or
+`teams_cards` on the Agno response or on a structured `response.content` dict:
+
+```python
+response.adaptive_cards = [
+    {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [{"type": "TextBlock", "text": "Card result"}],
+    }
+]
+```
+
+The interface sends those as Bot Framework Adaptive Card attachments. It does
+not parse text into cards or handle card actions yet.

--- a/backend/agno-microsoft-teams/agno_microsoft_teams/__init__.py
+++ b/backend/agno-microsoft-teams/agno_microsoft_teams/__init__.py
@@ -5,13 +5,17 @@ from agno_microsoft_teams.attachments import (
 )
 from agno_microsoft_teams.interface import (
     TEAMS_AGENT_RUN_TIMEOUT_S,
+    TEAMS_TYPING_INITIAL_DELAY_S,
+    TEAMS_TYPING_INTERVAL_S,
     Teams,
     TeamsInterface,
     acquire_bot_token,
     build_msal_client,
 )
 from agno_microsoft_teams.outbound_media import (
+    ADAPTIVE_CARD_CONTENT_TYPE,
     MAX_INLINE_ATTACHMENT_BYTES,
+    adaptive_card_attachment,
     build_attachments,
 )
 from agno_microsoft_teams.verification import (
@@ -22,14 +26,18 @@ from agno_microsoft_teams.verification import (
 )
 
 __all__ = [
+    "ADAPTIVE_CARD_CONTENT_TYPE",
     "MAX_ATTACHMENT_BYTES",
     "MAX_INLINE_ATTACHMENT_BYTES",
     "TEAMS_AGENT_RUN_TIMEOUT_S",
     "TEAMS_FILE_DOWNLOAD_INFO",
+    "TEAMS_TYPING_INITIAL_DELAY_S",
+    "TEAMS_TYPING_INTERVAL_S",
     "Teams",
     "TeamsInterface",
     "VerifiedClaims",
     "acquire_bot_token",
+    "adaptive_card_attachment",
     "build_attachments",
     "build_msal_client",
     "download_attachments",

--- a/backend/agno-microsoft-teams/agno_microsoft_teams/interface.py
+++ b/backend/agno-microsoft-teams/agno_microsoft_teams/interface.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Mapping
+from contextlib import suppress
 from typing import Any, cast
 
 import httpx
@@ -48,6 +50,8 @@ from agno_microsoft_teams.verification import verify_teams_jwt
 # until we POST back. Cap the agent run at 14m so a slow run produces an
 # error follow-up rather than a hung conversation.
 TEAMS_AGENT_RUN_TIMEOUT_S = 14 * 60
+TEAMS_TYPING_INITIAL_DELAY_S = 1.5
+TEAMS_TYPING_INTERVAL_S = 5.0
 
 logger = structlog.get_logger("agno_microsoft_teams.interface")
 
@@ -199,6 +203,14 @@ class Teams(BaseInterface):
             return
 
         outbound_attachments: list[dict[str, Any]] = []
+        typing_task = asyncio.create_task(
+            self._send_typing_until_done(
+                service_url=service_url,
+                conversation_id=conversation_id,
+                recipient=recipient,
+                from_=from_,
+            )
+        )
         try:
             response = await asyncio.wait_for(
                 self._entity.arun(prompt, **media_kwargs), timeout=TEAMS_AGENT_RUN_TIMEOUT_S
@@ -211,6 +223,10 @@ class Teams(BaseInterface):
         except Exception:
             logger.exception("Teams agent invocation failed")
             content = "Sorry, something went wrong while processing your message."
+        finally:
+            typing_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await typing_task
 
         await self._send_reply(
             service_url=service_url,
@@ -221,6 +237,57 @@ class Teams(BaseInterface):
             from_=from_,
             attachments=outbound_attachments,
         )
+
+    async def _send_typing_until_done(
+        self,
+        *,
+        service_url: str,
+        conversation_id: str,
+        recipient: dict[str, Any],
+        from_: dict[str, Any],
+    ) -> None:
+        await asyncio.sleep(TEAMS_TYPING_INITIAL_DELAY_S)
+        while True:
+            try:
+                await self._send_typing(
+                    service_url=service_url,
+                    conversation_id=conversation_id,
+                    recipient=recipient,
+                    from_=from_,
+                )
+            except Exception:
+                logger.warning("Teams typing indicator failed", exc_info=True)
+            await asyncio.sleep(TEAMS_TYPING_INTERVAL_S)
+
+    async def _send_typing(
+        self,
+        *,
+        service_url: str,
+        conversation_id: str,
+        recipient: dict[str, Any],
+        from_: dict[str, Any],
+    ) -> None:
+        token = await acquire_bot_token(self._msal)
+        if token is None:
+            return
+
+        url = f"{service_url.rstrip('/')}/v3/conversations/{conversation_id}/activities"
+        payload: dict[str, Any] = {
+            "type": "typing",
+            "from": from_,
+            "recipient": recipient,
+            "conversation": {"id": conversation_id},
+        }
+
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            try:
+                await client.post(
+                    url,
+                    headers={"Authorization": f"Bearer {token}"},
+                    json=payload,
+                )
+            except httpx.HTTPError:
+                logger.warning("Failed to deliver Teams typing indicator")
 
     async def _send_reply(
         self,
@@ -302,6 +369,13 @@ def _stringify_agent_response(response: Any) -> str:
     content = getattr(response, "content", None)
     if isinstance(content, str) and content:
         return content
+    if isinstance(content, Mapping):
+        for key in ("text", "message", "content"):
+            value = content.get(key)
+            if isinstance(value, str):
+                return value
+        if any(key in content for key in ("adaptive_cards", "teams_cards", "teams_attachments")):
+            return ""
     return str(response)
 
 

--- a/backend/agno-microsoft-teams/agno_microsoft_teams/outbound_media.py
+++ b/backend/agno-microsoft-teams/agno_microsoft_teams/outbound_media.py
@@ -1,7 +1,7 @@
 """Outbound media for Teams: turn agno ``RunOutput`` media (``response.images``,
-``response.videos``, ``response.audio``, ``response.files``) into Bot Framework
-``attachments[]`` so the agent can deliver pictures, PDFs, audio, etc. through
-the channel.
+``response.videos``, ``response.audio``, ``response.files``) and explicit Teams
+cards into Bot Framework ``attachments[]`` so the agent can deliver pictures,
+PDFs, audio, Adaptive Cards, etc. through the channel.
 
 We use ``data:`` URIs (RFC 2397) for in-memory bytes — Teams renders them
 fine and it skips the upload-then-attach round trip entirely. URL-only media
@@ -17,13 +17,15 @@ which we punt to a future iteration when a use case demands it.
 from __future__ import annotations
 
 import base64
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from typing import Any
 
 import structlog
 from agno.media import Audio, File, Image, Video
 
 logger = structlog.get_logger("agno_microsoft_teams.outbound_media")
+
+ADAPTIVE_CARD_CONTENT_TYPE = "application/vnd.microsoft.card.adaptive"
 
 # 220 KB for the final data URI — leaves room under the documented 256 KB
 # activity limit for the JSON envelope, mentions, text body, etc.
@@ -38,11 +40,67 @@ def build_attachments(response: Any) -> list[dict[str, Any]]:
     against partial responses); same for items above the inline size budget.
     """
     out: list[dict[str, Any]] = []
+    for source in _iter_response_attachment_sources(response):
+        out.extend(_iter_response_card_attachments(source))
     for media, default_mime in _iter_response_media(response):
         attachment = _to_attachment(media, default_mime=default_mime)
         if attachment is not None:
             out.append(attachment)
     return out
+
+
+def adaptive_card_attachment(card: Mapping[str, Any]) -> dict[str, Any]:
+    return {"contentType": ADAPTIVE_CARD_CONTENT_TYPE, "content": dict(card)}
+
+
+def _iter_response_card_attachments(response: Any) -> Iterable[dict[str, Any]]:
+    for card in _iter_structured_items(response, "adaptive_cards", "teams_cards"):
+        if _is_adaptive_card(card):
+            yield adaptive_card_attachment(card)
+        else:
+            logger.warning("Skipping malformed Teams Adaptive Card")
+
+    for attachment in _iter_structured_items(response, "teams_attachments"):
+        if _is_bot_framework_attachment(attachment):
+            yield dict(attachment)
+        else:
+            logger.warning("Skipping malformed Teams attachment")
+
+
+def _iter_response_attachment_sources(response: Any) -> Iterable[Any]:
+    yield response
+    content = getattr(response, "content", None)
+    if content is not None and content is not response and not isinstance(content, (str, bytes)):
+        yield content
+
+
+def _iter_structured_items(response: Any, *attrs: str) -> Iterable[Mapping[str, Any]]:
+    for attr in attrs:
+        value = (
+            response.get(attr) if isinstance(response, Mapping) else getattr(response, attr, None)
+        )
+        if value is None:
+            continue
+        if isinstance(value, Mapping):
+            yield value
+            continue
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+            for item in value:
+                if isinstance(item, Mapping):
+                    yield item
+
+
+def _is_adaptive_card(card: Mapping[str, Any]) -> bool:
+    return (
+        card.get("type") == "AdaptiveCard"
+        and isinstance(card.get("version"), str)
+        and isinstance(card.get("body"), list)
+    )
+
+
+def _is_bot_framework_attachment(attachment: Mapping[str, Any]) -> bool:
+    content_type = attachment.get("contentType")
+    return isinstance(content_type, str) and bool(content_type)
 
 
 def _iter_response_media(response: Any) -> Iterable[tuple[Any, str]]:

--- a/backend/agno-microsoft-teams/tests/test_interface_http.py
+++ b/backend/agno-microsoft-teams/tests/test_interface_http.py
@@ -276,6 +276,121 @@ def test_message_runs_agent_and_posts_reply_to_bot_connector(
     assert reply["json"]["replyToId"] == ACTIVITY_ID
 
 
+def test_slow_message_sends_typing_before_final_reply(
+    monkeypatch: pytest.MonkeyPatch, stub_outbound: type[_StubAsyncClient]
+) -> None:
+    pem, kid, jwk = _generate_signing_key()
+    _prime_cache_with(jwk)
+    token = _issue_token(private_pem=pem, kid=kid, audience=APP_ID, service_url=SERVICE_URL)
+    monkeypatch.setattr(interface_module, "TEAMS_TYPING_INITIAL_DELAY_S", 0.01)
+    monkeypatch.setattr(interface_module, "TEAMS_TYPING_INTERVAL_S", 60.0)
+
+    agent_response = MagicMock()
+    agent_response.content = "done"
+    agent_response.images = None
+    agent_response.videos = None
+    agent_response.audio = None
+    agent_response.files = None
+
+    async def _slow(*_args: Any, **_kwargs: Any) -> Any:
+        await interface_module.asyncio.sleep(0.03)
+        return agent_response
+
+    agent = MagicMock()
+    agent.arun = _slow
+
+    with TestClient(_make_app(agent)) as client:
+        resp = client.post(
+            f"/teams/{APP_ID}/messages",
+            json=_message_activity(text="slow"),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 202
+    activity_types = [item["json"]["type"] for item in stub_outbound.captured]
+    assert activity_types == ["typing", "message"]
+    assert stub_outbound.captured[-1]["json"]["text"] == "done"
+
+
+def test_message_can_send_adaptive_card_attachment(
+    stub_outbound: type[_StubAsyncClient],
+) -> None:
+    pem, kid, jwk = _generate_signing_key()
+    _prime_cache_with(jwk)
+    token = _issue_token(private_pem=pem, kid=kid, audience=APP_ID, service_url=SERVICE_URL)
+    card = {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [{"type": "TextBlock", "text": "Card result"}],
+    }
+
+    agent_response = MagicMock()
+    agent_response.content = "see card"
+    agent_response.images = None
+    agent_response.videos = None
+    agent_response.audio = None
+    agent_response.files = None
+    agent_response.adaptive_cards = [card]
+    agent = MagicMock()
+    agent.arun = AsyncMock(return_value=agent_response)
+
+    with TestClient(_make_app(agent)) as client:
+        resp = client.post(
+            f"/teams/{APP_ID}/messages",
+            json=_message_activity(text="card"),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 202
+    reply = stub_outbound.captured[0]
+    assert reply["json"]["text"] == "see card"
+    assert reply["json"]["attachments"] == [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": card,
+        }
+    ]
+
+
+def test_message_can_send_adaptive_card_from_structured_content(
+    stub_outbound: type[_StubAsyncClient],
+) -> None:
+    pem, kid, jwk = _generate_signing_key()
+    _prime_cache_with(jwk)
+    token = _issue_token(private_pem=pem, kid=kid, audience=APP_ID, service_url=SERVICE_URL)
+    card = {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [{"type": "TextBlock", "text": "Structured card"}],
+    }
+
+    agent_response = MagicMock()
+    agent_response.content = {"text": "structured", "adaptive_cards": [card]}
+    agent_response.images = None
+    agent_response.videos = None
+    agent_response.audio = None
+    agent_response.files = None
+    agent = MagicMock()
+    agent.arun = AsyncMock(return_value=agent_response)
+
+    with TestClient(_make_app(agent)) as client:
+        resp = client.post(
+            f"/teams/{APP_ID}/messages",
+            json=_message_activity(text="card"),
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 202
+    reply = stub_outbound.captured[0]
+    assert reply["json"]["text"] == "structured"
+    assert reply["json"]["attachments"] == [
+        {
+            "contentType": "application/vnd.microsoft.card.adaptive",
+            "content": card,
+        }
+    ]
+
+
 def test_message_with_bot_mention_strips_mention_before_calling_agent(
     stub_outbound: type[_StubAsyncClient],
 ) -> None:

--- a/backend/agno-microsoft-teams/tests/test_outbound_media.py
+++ b/backend/agno-microsoft-teams/tests/test_outbound_media.py
@@ -8,7 +8,9 @@ from typing import Any
 
 from agno.media import File, Image
 from agno_microsoft_teams.outbound_media import (
+    ADAPTIVE_CARD_CONTENT_TYPE,
     MAX_INLINE_ATTACHMENT_BYTES,
+    adaptive_card_attachment,
     build_attachments,
 )
 
@@ -19,6 +21,9 @@ class _FakeResponse:
     videos: list[Any] = field(default_factory=list)
     audio: list[Any] = field(default_factory=list)
     files: list[Any] = field(default_factory=list)
+    adaptive_cards: list[dict[str, Any]] = field(default_factory=list)
+    teams_cards: list[dict[str, Any]] = field(default_factory=list)
+    teams_attachments: list[dict[str, Any]] = field(default_factory=list)
 
 
 def test_build_attachments_inlines_image_bytes_as_data_uri() -> None:
@@ -28,6 +33,65 @@ def test_build_attachments_inlines_image_bytes_as_data_uri() -> None:
     expected_b64 = base64.b64encode(b"PNGDATA").decode()
     assert attachments[0]["contentType"] == "image/png"
     assert attachments[0]["contentUrl"] == f"data:image/png;base64,{expected_b64}"
+
+
+def test_build_attachments_handles_adaptive_cards() -> None:
+    card = {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [{"type": "TextBlock", "text": "Result"}],
+    }
+    response = _FakeResponse(adaptive_cards=[card])
+
+    attachments = build_attachments(response)
+
+    assert attachments == [adaptive_card_attachment(card)]
+    assert attachments[0]["contentType"] == ADAPTIVE_CARD_CONTENT_TYPE
+    assert attachments[0]["content"] == card
+
+
+def test_build_attachments_handles_teams_cards_alias() -> None:
+    card = {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [{"type": "TextBlock", "text": "Alias"}],
+    }
+    response = _FakeResponse(teams_cards=[card])
+
+    attachments = build_attachments(response)
+
+    assert attachments == [adaptive_card_attachment(card)]
+
+
+def test_build_attachments_handles_adaptive_cards_in_response_content() -> None:
+    card = {
+        "type": "AdaptiveCard",
+        "version": "1.5",
+        "body": [{"type": "TextBlock", "text": "Nested"}],
+    }
+
+    class Response:
+        def __init__(self) -> None:
+            self.content = {"adaptive_cards": [card]}
+
+    attachments = build_attachments(Response())
+
+    assert attachments == [adaptive_card_attachment(card)]
+
+
+def test_build_attachments_skips_malformed_adaptive_cards() -> None:
+    response = _FakeResponse(adaptive_cards=[{"type": "AdaptiveCard"}])
+    assert build_attachments(response) == []
+
+
+def test_build_attachments_passes_explicit_teams_attachments() -> None:
+    attachment = {
+        "contentType": "application/vnd.microsoft.card.thumbnail",
+        "content": {"title": "Title"},
+    }
+    response = _FakeResponse(teams_attachments=[attachment])
+
+    assert build_attachments(response) == [attachment]
 
 
 def test_build_attachments_passes_url_through_unchanged() -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -99,7 +99,7 @@ requires-dist = [
 
 [[package]]
 name = "agno-agent-builder"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "agno-agent-builder" }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -144,7 +144,7 @@ dev = [
 
 [[package]]
 name = "agno-microsoft-teams"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "agno-microsoft-teams" }
 dependencies = [
     { name = "agno" },
@@ -1656,7 +1656,7 @@ requires-dist = [
 
 [[package]]
 name = "payload-documents-worker-builder"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "payload-documents-worker-builder" }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary
- Send Teams typing activities while long-running agent responses are pending.
- Add explicit outbound Adaptive Card support via response.adaptive_cards, response.teams_cards, response.teams_attachments, or structured response.content.
- Re-export the card helpers through the builder compatibility module and sync backend/uv.lock.

## Validation
- uv sync --frozen --all-packages
- uv run ruff check .
- uv run ruff format --check .
- uv run mypy agno-agent-builder/agno_agent_builder agno-agent/agno_agent agno-microsoft-teams/agno_microsoft_teams
- uv run pytest agno-agent-builder/tests agno-microsoft-teams/tests -q