### PR TITLE
fix(ci): use pypa/gh-action-pypi-publish for PyPI Trusted Publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -104,7 +104,9 @@ jobs:
           rm -rf dist
           uv build --package agno-agent-builder
       - name: Publish to PyPI
-        run: uv publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: backend/dist
 
   publish-agno-microsoft-teams:
     needs: release-please
@@ -132,7 +134,9 @@ jobs:
           rm -rf dist
           uv build --package agno-microsoft-teams
       - name: Publish to PyPI
-        run: uv publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: backend/dist
 
   publish-payload-documents-worker-builder:
     needs: release-please
@@ -160,4 +164,6 @@ jobs:
           rm -rf dist
           uv build --package payload-documents-worker-builder
       - name: Publish to PyPI
-        run: uv publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: backend/dist


### PR DESCRIPTION
## Summary

\`uv publish\` was failing OIDC negotiation against PyPI's Trusted Publisher with:

\`\`\`
403 Invalid API Token: OIDC scoped token is not valid for project 'agno-agent-builder',
project-scoped token is not valid for project: 'agno-agent-builder'
\`\`\`

even after cleaning the TP config to a single \`release-please.yml\` (Any) publisher.

Switching the 3 Python publish jobs to \`pypa/gh-action-pypi-publish@release/v1\`, the canonical action for PyPI Trusted Publishing from GitHub Actions. It handles the OIDC audience exchange reliably.

## Changes

- \`publish-agno-agent-builder\`
- \`publish-agno-microsoft-teams\`
- \`publish-payload-documents-worker-builder\`

Each: replace \`run: uv publish\` with \`uses: pypa/gh-action-pypi-publish@release/v1\` + \`packages-dir: backend/dist\` (since the previous \`uv publish\` ran with \`working-directory: backend\` and \`dist/\` ended up under \`backend/dist/\`).

## Test plan

- [ ] Merge → next push to main runs Release Please; if there are pending releases, publish jobs use the new action
- [ ] To unblock \`agno-agent-builder@0.1.9\` (already tagged but unpublished), publish manually post-merge with a classic PyPI token, or wait for the next release-please bump to cover it

## Why not stick with \`uv publish\`?

\`uv publish\` does support Trusted Publishing but its OIDC negotiation has been flaky in this exact setup. \`pypa/gh-action-pypi-publish\` is what PyPI's official docs recommend and what every Python project ships with — fewer moving parts when something breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)