### PR TITLE
fix(agno-agent-builder): default ports optional in httpx exclusion pattern

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/telemetry.py
+++ b/backend/agno-agent-builder/agno_agent_builder/telemetry.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 
 import base64
 import os
+import re
 from typing import Any
+from urllib.parse import urlparse
 
 from openinference.instrumentation.agno import AgnoInstrumentor
 from opentelemetry import baggage
@@ -150,13 +152,35 @@ def configure_langfuse_tracing(config: RuntimeConfig, logger: Any) -> TracerProv
             # exclusions from this env var; respect an operator override.
             os.environ.setdefault(
                 "OTEL_PYTHON_HTTPX_EXCLUDED_URLS",
-                f"{config.payload_url.rstrip('/')}/api/.*",
+                httpx_exclusion_pattern(config.payload_url),
             )
         HTTPXClientInstrumentor().instrument()
         logger.info("HTTPX traceparent propagation enabled for LiteLLM proxy")
 
     logger.info("Langfuse tracing enabled", host=config.langfuse_host)
     return provider
+
+
+def httpx_exclusion_pattern(base_url: str) -> str:
+    """Regex for ``OTEL_PYTHON_HTTPX_EXCLUDED_URLS`` matching the CMS API.
+
+    httpx normalizes default ports away (``http://web:80/x`` is recorded as
+    ``http://web/x``), so a pattern built verbatim from the configured base
+    URL never matches when the deployment uses the scheme's default port —
+    in prod the runtime polls ``http://<svc>:80`` and every poll leaked as a
+    detached root "GET" trace. Make the default port optional; keep
+    non-default ports literal.
+    """
+    parsed = urlparse(base_url)
+    host = re.escape(parsed.hostname or "")
+    default_port = {"http": 80, "https": 443}.get(parsed.scheme)
+    if parsed.port is None:
+        host_part = host
+    elif parsed.port == default_port:
+        host_part = f"{host}(:{parsed.port})?"
+    else:
+        host_part = f"{host}:{parsed.port}"
+    return f"{parsed.scheme}://{host_part}/api/.*"
 
 
 def tenant_baggage_context(

--- a/backend/agno-agent-builder/tests/test_telemetry.py
+++ b/backend/agno-agent-builder/tests/test_telemetry.py
@@ -1,0 +1,48 @@
+"""Tests for the httpx exclusion pattern fed to OTEL_PYTHON_HTTPX_EXCLUDED_URLS."""
+
+from __future__ import annotations
+
+import re
+
+from agno_agent_builder.telemetry import httpx_exclusion_pattern
+
+
+def _matches(pattern: str, url: str) -> bool:
+    # Mirrors opentelemetry.util.http.ExcludeList.url_disabled (re.search).
+    return bool(re.search(pattern, url))
+
+
+class TestHttpxExclusionPattern:
+    def test_default_http_port_is_optional(self) -> None:
+        """httpx records http://host:80/x as http://host/x — both must match.
+
+        This is the prod regression: PAYLOAD_URL=http://zp-prod-web:80 leaked
+        every CMS poll as a detached root GET trace.
+        """
+        pattern = httpx_exclusion_pattern("http://zp-prod-web:80")
+        assert _matches(pattern, "http://zp-prod-web/api/agents/internal/list")
+        assert _matches(pattern, "http://zp-prod-web:80/api/agents/internal/list")
+
+    def test_default_https_port_is_optional(self) -> None:
+        pattern = httpx_exclusion_pattern("https://cms.example:443")
+        assert _matches(pattern, "https://cms.example/api/x")
+        assert _matches(pattern, "https://cms.example:443/api/x")
+
+    def test_non_default_port_stays_literal(self) -> None:
+        pattern = httpx_exclusion_pattern("http://app:3000")
+        assert _matches(pattern, "http://app:3000/api/agents/internal/list")
+        assert not _matches(pattern, "http://app/api/agents/internal/list")
+
+    def test_no_port_matches_bare_host(self) -> None:
+        pattern = httpx_exclusion_pattern("http://web")
+        assert _matches(pattern, "http://web/api/x")
+
+    def test_only_api_paths_are_excluded(self) -> None:
+        """The LLM gateway and MCP calls must stay instrumented."""
+        pattern = httpx_exclusion_pattern("http://app:3000")
+        assert not _matches(pattern, "http://litellm:4000/v1/chat/completions")
+        assert not _matches(pattern, "http://app:3030/mcp")
+
+    def test_trailing_slash_in_base_url(self) -> None:
+        pattern = httpx_exclusion_pattern("http://zp-prod-web:80/")
+        assert _matches(pattern, "http://zp-prod-web/api/x")


### PR DESCRIPTION
Prod regression found right after activating the gateway (phase B): every CMS poll from the runtime leaked as a detached root `GET` trace in Langfuse.

**Root cause**: httpx normalizes default ports away — `http://zp-prod-web:80/api/...` is recorded as `http://zp-prod-web/api/...` — so the `OTEL_PYTHON_HTTPX_EXCLUDED_URLS` pattern built verbatim from `PAYLOAD_URL` (which uses `:80` in prod) never matched. Dev never showed it because the devcontainer CMS runs on `:3000`. Verified live: the leaked spans carry `http.url: http://zp-prod-web/api/agents/internal/list` (no port).

**Fix**: `httpx_exclusion_pattern()` makes the scheme's default port optional (`(:80)?` / `(:443)?`), keeps non-default ports literal. Pinned by tests: the prod regression, https variant, non-default port, and the contract that only `/api/` paths are excluded (gateway + MCP calls stay instrumented — the traceparent link depends on it).

80 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)