### PR TITLE
fix(agno-agent-builder): exclude channel-auth endpoints from httpx tracing

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/telemetry.py
+++ b/backend/agno-agent-builder/agno_agent_builder/telemetry.py
@@ -145,20 +145,37 @@ def configure_langfuse_tracing(config: RuntimeConfig, logger: Any) -> TracerProv
         # traceparent into `metadata.existing_trace_id` for the classic
         # `langfuse` callback (`langfuse_otel` drops inbound traceparent in
         # v1.82.0; BerriAI/litellm#15940).
-        if config.payload_url:
-            # Internal CMS calls (agent/installation polling, reads during a
-            # run) add nothing in Langfuse, and outside a run each becomes a
-            # detached root "GET" trace. The global instrumentor only reads
-            # exclusions from this env var; respect an operator override.
-            os.environ.setdefault(
-                "OTEL_PYTHON_HTTPX_EXCLUDED_URLS",
-                httpx_exclusion_pattern(config.payload_url),
-            )
+        #
+        # Exclusions: CMS polling and channel-auth plumbing happen outside any
+        # run, so each call would become a detached root trace in Langfuse.
+        # The global instrumentor only reads them from this env var; respect
+        # an operator override.
+        os.environ.setdefault(
+            "OTEL_PYTHON_HTTPX_EXCLUDED_URLS",
+            httpx_excluded_urls(config.payload_url),
+        )
         HTTPXClientInstrumentor().instrument()
         logger.info("HTTPX traceparent propagation enabled for LiteLLM proxy")
 
     logger.info("Langfuse tracing enabled", host=config.langfuse_host)
     return provider
+
+
+# Channel-auth plumbing (JWKS/OpenID discovery at startup, OAuth token
+# refresh when replying) — pure infrastructure noise with no observability
+# value, and outside any run each fetch becomes a detached root trace.
+_CHANNEL_AUTH_EXCLUSIONS = (
+    r"https://login\.botframework\.com/.*",
+    r"https://login\.microsoftonline\.com/.*",
+)
+
+
+def httpx_excluded_urls(payload_url: str | None) -> str:
+    """Comma-joined value for ``OTEL_PYTHON_HTTPX_EXCLUDED_URLS``."""
+    patterns = list(_CHANNEL_AUTH_EXCLUSIONS)
+    if payload_url:
+        patterns.insert(0, httpx_exclusion_pattern(payload_url))
+    return ",".join(patterns)
 
 
 def httpx_exclusion_pattern(base_url: str) -> str:

--- a/backend/agno-agent-builder/tests/test_telemetry.py
+++ b/backend/agno-agent-builder/tests/test_telemetry.py
@@ -1,15 +1,42 @@
-"""Tests for the httpx exclusion pattern fed to OTEL_PYTHON_HTTPX_EXCLUDED_URLS."""
+"""Tests for the httpx exclusions fed to OTEL_PYTHON_HTTPX_EXCLUDED_URLS."""
 
 from __future__ import annotations
 
 import re
 
-from agno_agent_builder.telemetry import httpx_exclusion_pattern
+from agno_agent_builder.telemetry import httpx_excluded_urls, httpx_exclusion_pattern
 
 
 def _matches(pattern: str, url: str) -> bool:
     # Mirrors opentelemetry.util.http.ExcludeList.url_disabled (re.search).
     return bool(re.search(pattern, url))
+
+
+def _any_matches(env_value: str, url: str) -> bool:
+    # ExcludeList splits the env var on commas and ORs the patterns.
+    return any(_matches(p.strip(), url) for p in env_value.split(","))
+
+
+class TestHttpxExcludedUrls:
+    def test_includes_cms_and_channel_auth(self) -> None:
+        value = httpx_excluded_urls("http://zp-prod-web:80")
+        assert _any_matches(value, "http://zp-prod-web/api/agents/internal/list")
+        assert _any_matches(value, "https://login.botframework.com/v1/.well-known/keys")
+        assert _any_matches(
+            value, "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token"
+        )
+
+    def test_channel_auth_excluded_even_without_payload_url(self) -> None:
+        value = httpx_excluded_urls(None)
+        assert _any_matches(
+            value, "https://login.botframework.com/v1/.well-known/openidconfiguration"
+        )
+
+    def test_gateway_and_channel_delivery_stay_instrumented(self) -> None:
+        value = httpx_excluded_urls("http://zp-prod-web:80")
+        assert not _any_matches(value, "http://litellm:4000/v1/chat/completions")
+        assert not _any_matches(value, "https://smba.trafficmanager.net/emea/v3/conversations")
+        assert not _any_matches(value, "https://api.telegram.org/bot123/sendMessage")
 
 
 class TestHttpxExclusionPattern:


### PR DESCRIPTION
Follow-up to #87, from prod observation right after it landed: the CMS-polling root traces are gone, and the remaining `GET` noise is **Bot Framework auth plumbing** — JWKS/OpenID discovery at pod startup (`login.botframework.com`, 2 per pod) plus OAuth token refresh against `login.microsoftonline.com` when replying. All outside any run → detached root traces.

`httpx_excluded_urls()` now joins the CMS `/api` pattern with the channel-auth endpoints (applied even without `payload_url`). The contract pinned by tests: channel **delivery** calls (`smba.trafficmanager.net`, `api.telegram.org`, …) and the LiteLLM gateway stay instrumented — the traceparent cost-link depends on the latter.

83 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)