### PR TITLE
fix(payload-agents-core): force automatic JSX runtime so client components keep their 'use client' boundary

### DIFF
--- a/packages/payload-agents-core/tsdown.config.ts
+++ b/packages/payload-agents-core/tsdown.config.ts
@@ -11,5 +11,16 @@ export default defineConfig({
   treeshake: true,
   outDir: 'dist',
   tsconfig: './tsconfig.json',
+  // Force the automatic JSX runtime regardless of any inherited
+  // `"jsx": "preserve"` from a parent tsconfig. Without this, tsdown emits
+  // literal JSX into the .mjs output, which Next/Turbopack will not transform
+  // when the package is consumed from node_modules — the `'use client'`
+  // boundary is lost so admin field components (e.g. ModelSelectField) render
+  // server-side and crash with "Functions are not valid as a React child".
+  inputOptions: {
+    transform: {
+      jsx: { runtime: 'automatic' }
+    }
+  },
   external: ['payload', 'drizzle-orm', 'node:crypto', '@toon-format/toon', '@payloadcms/ui', 'react', 'react/jsx-runtime']
 })


### PR DESCRIPTION
## Problem

`@zetesis/payload-agents-core@0.6.1` ships **literal JSX** in `dist/client.mjs` (e.g. `return <div className="field-type">…`) instead of compiled `_jsx()` calls. Next/Turbopack does **not** transform JSX coming from `node_modules`, so when a consumer (Nexus) imports the package from npm, the `'use client'` module boundary is lost. Payload's `isReactServerComponentOrFunction` then sees `ModelSelectField` as a plain function (no `react.client.reference` `$$typeof`), renders it server-side, and passes `serverProps` (which include a function child) → runtime crash:

> Functions are not valid as a React child … `<ModelSelectField>{Zr}</ModelSelectField>`

The agents admin shows a plain text field instead of the gateway preset selector (or crashes the LLM Configuration tab).

ZetesisPortal didn't hit this because it consumes the package via the workspace **source** (`src/*.ts`), which Next transforms correctly.

## Fix

Add `inputOptions.transform.jsx.runtime: 'automatic'` to `tsdown.config.ts` — identical to the fix already present in `payload-indexer` (whose config carries the explanatory comment). Rebuilt `dist/client.mjs` now starts with `'use client';` and emits `import { jsx, jsxs } from "react/jsx-runtime"` + `_jsx()` calls (0 literal JSX), so the client boundary survives bundling.

## Verification

- Rebuilt with tsdown: `dist/client.mjs` → `'use client';` first line, 6 `jsx()` calls, 0 literal JSX.
- Patched into a Nexus devcontainer's `node_modules` → `ModelSelectField` renders as the preset select, no "Functions are not valid as a React child".

🤖 Generated with [Claude Code](https://claude.com/claude-code)