### PR TITLE
feat(payload-agents-metrics): persist the gateway's real per-call cost

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -99,7 +99,7 @@ requires-dist = [
 
 [[package]]
 name = "agno-agent-builder"
-version = "0.1.8"
+version = "0.1.11"
 source = { editable = "agno-agent-builder" }
 dependencies = [
     { name = "ag-ui-protocol" },

--- a/packages/payload-agents-metrics/src/collections/llm-usage-events.ts
+++ b/packages/payload-agents-metrics/src/collections/llm-usage-events.ts
@@ -74,6 +74,19 @@ export function createLlmUsageEventsCollection(config: ResolvedMetricsConfig): C
     { name: 'cachedInputTokens', type: 'number', defaultValue: 0 },
     { name: 'totalTokens', type: 'number', required: true, defaultValue: 0 },
     { name: 'costUsd', type: 'number', required: true, defaultValue: 0 },
+    {
+      name: 'costSource',
+      type: 'select',
+      defaultValue: 'table',
+      index: true,
+      options: [
+        { label: 'Gateway (real)', value: 'gateway' },
+        { label: 'Pricing table (estimated)', value: 'table' }
+      ],
+      admin: {
+        description: "Whether costUsd is the LiteLLM gateway's real figure or the static table estimate"
+      }
+    },
     // ── Execution ───────────────────────────────────────────────────
     { name: 'startedAt', type: 'date', index: true },
     { name: 'completedAt', type: 'date', required: true, index: true },

--- a/packages/payload-agents-metrics/src/endpoints/ingest.spec.ts
+++ b/packages/payload-agents-metrics/src/endpoints/ingest.spec.ts
@@ -144,6 +144,7 @@ describe('createIngestHandler — single event happy path', () => {
     // gpt-4o-mini: input $0.15/M, output $0.60/M → 100*0.15e-6 + 50*0.60e-6 = ~4.5e-5
     await handler(makeReq({ secret: 'secret-xyz', body: validEvent }, payload))
     expect(create.mock.calls[0]?.[0]?.data?.costUsd).toBeCloseTo(4.5e-5, 10)
+    expect(create.mock.calls[0]?.[0]?.data?.costSource).toBe('table')
   })
 
   it('uses an explicit costUsd when the caller provides it (including 0)', async () => {
@@ -151,6 +152,15 @@ describe('createIngestHandler — single event happy path', () => {
     const { payload, create } = makePayload(async () => ({ id: 1 }))
     await handler(makeReq({ secret: 'secret-xyz', body: { ...validEvent, costUsd: 0 } }, payload))
     expect(create.mock.calls[0]?.[0]?.data?.costUsd).toBe(0)
+    // An explicit cost is the gateway's real figure.
+    expect(create.mock.calls[0]?.[0]?.data?.costSource).toBe('gateway')
+  })
+
+  it('honours an explicit costSource override', async () => {
+    const handler = createIngestHandler(baseConfig())
+    const { payload, create } = makePayload(async () => ({ id: 1 }))
+    await handler(makeReq({ secret: 'secret-xyz', body: { ...validEvent, costSource: 'gateway' } }, payload))
+    expect(create.mock.calls[0]?.[0]?.data?.costSource).toBe('gateway')
   })
 
   it('defaults completedAt to now when not provided', async () => {

--- a/packages/payload-agents-metrics/src/endpoints/ingest.ts
+++ b/packages/payload-agents-metrics/src/endpoints/ingest.ts
@@ -21,6 +21,7 @@ const EventSchema = z.object({
   cachedInputTokens: z.number().int().nonnegative().optional(),
   totalTokens: z.number().int().nonnegative().optional(),
   costUsd: z.number().nonnegative().optional(),
+  costSource: z.enum(['gateway', 'table']).optional(),
   startedAt: z.string().datetime().optional(),
   completedAt: z.string().datetime().optional(),
   latencyMs: z.number().int().nonnegative().optional(),
@@ -109,6 +110,8 @@ async function persistEvent(
   const inputTokens = event.inputTokens ?? 0
   const outputTokens = event.outputTokens ?? 0
   const totalTokens = event.totalTokens ?? inputTokens + outputTokens
+  // An explicit costUsd is the gateway's real figure; otherwise fall back to
+  // the static pricing table. costSource records which, defaulting to match.
   const costUsd =
     event.costUsd ??
     calculateLlmCost(
@@ -117,6 +120,7 @@ async function persistEvent(
       { input: inputTokens, output: outputTokens },
       config.extraPricing
     )
+  const costSource = event.costSource ?? (event.costUsd !== undefined ? 'gateway' : 'table')
 
   const data: Record<string, unknown> = {
     user: event.user,
@@ -133,6 +137,7 @@ async function persistEvent(
     cachedInputTokens: event.cachedInputTokens,
     totalTokens,
     costUsd,
+    costSource,
     startedAt: event.startedAt,
     completedAt: event.completedAt ?? new Date().toISOString(),
     latencyMs: event.latencyMs,

--- a/packages/payload-agents-metrics/src/lib/on-run-completed.spec.ts
+++ b/packages/payload-agents-metrics/src/lib/on-run-completed.spec.ts
@@ -195,6 +195,7 @@ describe('onRunCompleted — latency & cost', () => {
     )
     const data = create.mock.calls[0]?.[0]?.data
     expect(data?.costUsd).toBeCloseTo(0.75, 6)
+    expect(data?.costSource).toBe('table')
   })
 
   it('honours extraPricing for custom models', async () => {
@@ -203,6 +204,78 @@ describe('onRunCompleted — latency & cost', () => {
     await hook({ ...baseCtx, llmModel: 'openai/gpt-4o-mini', metrics: { input_tokens: 1, output_tokens: 1 } }, payload)
     const data = create.mock.calls[0]?.[0]?.data
     expect(data?.costUsd).toBe(3)
+  })
+
+  it('prefers the gateway run-level cost over the pricing table', async () => {
+    const hook = createOnRunCompleted(baseConfig())
+    const { payload, create } = makePayload()
+    await hook(
+      {
+        ...baseCtx,
+        llmModel: 'openai/gpt-4o-mini',
+        // The table would say 0.75; the gateway's real figure wins.
+        metrics: { input_tokens: 1_000_000, output_tokens: 1_000_000, cost: 0.123456 }
+      },
+      payload
+    )
+    const data = create.mock.calls[0]?.[0]?.data
+    expect(data?.costUsd).toBe(0.123456)
+    expect(data?.costSource).toBe('gateway')
+  })
+
+  it('sums per-model gateway costs when no run-level cost is present', async () => {
+    const hook = createOnRunCompleted(baseConfig())
+    const { payload, create } = makePayload()
+    await hook(
+      {
+        ...baseCtx,
+        llmModel: 'openai/gpt-4o-mini',
+        metrics: {
+          details: {
+            model: [
+              { id: 'gpt-4o-mini', provider: 'openai', input_tokens: 10, output_tokens: 5, cost: 0.002 },
+              { id: 'gpt-4o-mini', provider: 'openai', input_tokens: 20, output_tokens: 8, cost: 0.003 }
+            ]
+          }
+        }
+      },
+      payload
+    )
+    const data = create.mock.calls[0]?.[0]?.data
+    expect(data?.costUsd).toBeCloseTo(0.005, 10)
+    expect(data?.costSource).toBe('gateway')
+  })
+
+  it('keeps a reported gateway cost of 0 instead of falling back to the table', async () => {
+    const hook = createOnRunCompleted(baseConfig())
+    const { payload, create } = makePayload()
+    await hook(
+      {
+        ...baseCtx,
+        llmModel: 'openai/gpt-4o-mini',
+        metrics: { input_tokens: 1_000_000, output_tokens: 1_000_000, cost: 0 }
+      },
+      payload
+    )
+    const data = create.mock.calls[0]?.[0]?.data
+    expect(data?.costUsd).toBe(0)
+    expect(data?.costSource).toBe('gateway')
+  })
+
+  it('falls back to the table when the gateway cost is not a finite number', async () => {
+    const hook = createOnRunCompleted(baseConfig())
+    const { payload, create } = makePayload()
+    await hook(
+      {
+        ...baseCtx,
+        llmModel: 'openai/gpt-4o-mini',
+        metrics: { input_tokens: 1_000_000, output_tokens: 1_000_000, cost: null }
+      },
+      payload
+    )
+    const data = create.mock.calls[0]?.[0]?.data
+    expect(data?.costUsd).toBeCloseTo(0.75, 6)
+    expect(data?.costSource).toBe('table')
   })
 })
 

--- a/packages/payload-agents-metrics/src/lib/on-run-completed.ts
+++ b/packages/payload-agents-metrics/src/lib/on-run-completed.ts
@@ -26,17 +26,42 @@ interface ModelDetail {
   input_tokens?: number
   output_tokens?: number
   cache_read_tokens?: number
+  cost?: number
 }
 
 function num(v: unknown): number | undefined {
   return typeof v === 'number' && Number.isFinite(v) ? v : undefined
 }
 
-function extractModelDetail(metrics: Record<string, unknown>): ModelDetail | null {
+function extractModelList(metrics: Record<string, unknown>): ModelDetail[] {
   const details = metrics.details as Record<string, unknown[]> | undefined
-  if (!details) return null
-  const modelList = details.model as ModelDetail[] | undefined
-  return modelList?.[0] ?? null
+  const modelList = details?.model as ModelDetail[] | undefined
+  return Array.isArray(modelList) ? modelList : []
+}
+
+/**
+ * Real per-run cost as computed by the LiteLLM gateway, when available.
+ *
+ * Behind the gateway Agno reads `usage.cost` off each streaming response
+ * (`include_cost_in_streaming_usage`) into `RunMetrics.cost` / each
+ * `ModelMetrics.cost`. We prefer the run-level total; if only per-model costs
+ * are present we sum them. Returns `undefined` when no gateway cost is
+ * reported (direct-provider path or older runtimes) so the caller falls back
+ * to the static pricing table. A reported `0` is a real value and is kept.
+ */
+function resolveGatewayCost(metrics: Record<string, unknown>, models: ModelDetail[]): number | undefined {
+  const runLevel = num(metrics.cost)
+  if (runLevel !== undefined) return runLevel
+  let sum = 0
+  let any = false
+  for (const model of models) {
+    const cost = num(model.cost)
+    if (cost !== undefined) {
+      sum += cost
+      any = true
+    }
+  }
+  return any ? sum : undefined
 }
 
 function resolveProvider(ctx: RunCompletedContext, detail: ModelDetail | null) {
@@ -58,7 +83,8 @@ function resolveModel(ctx: RunCompletedContext, detail: ModelDetail | null): str
 export function createOnRunCompleted(config: ResolvedMetricsConfig) {
   return async (ctx: RunCompletedContext, payload: Payload): Promise<void> => {
     const { metrics, userId, agentSlug, sessionId, runId } = ctx
-    const detail = extractModelDetail(metrics)
+    const models = extractModelList(metrics)
+    const detail = models[0] ?? null
 
     const provider = resolveProvider(ctx, detail)
     if (!provider) {
@@ -73,7 +99,14 @@ export function createOnRunCompleted(config: ResolvedMetricsConfig) {
     const totalTokens = num(metrics.total_tokens) ?? inputTokens + outputTokens
     const duration = num(metrics.duration)
     const latencyMs = duration !== undefined ? Math.round(duration * 1000) : undefined
-    const costUsd = calculateLlmCost(provider, model, { input: inputTokens, output: outputTokens }, config.extraPricing)
+
+    // Prefer the gateway's real cost; fall back to the static pricing table
+    // (cache-blind, drops to 0 on unknown models) only when none is reported.
+    const gatewayCost = resolveGatewayCost(metrics, models)
+    const costSource: 'gateway' | 'table' = gatewayCost !== undefined ? 'gateway' : 'table'
+    const costUsd =
+      gatewayCost ??
+      calculateLlmCost(provider, model, { input: inputTokens, output: outputTokens }, config.extraPricing)
 
     let tenant: number | string | null | undefined
     if (config.multiTenant) {
@@ -99,6 +132,7 @@ export function createOnRunCompleted(config: ResolvedMetricsConfig) {
         cachedInputTokens,
         totalTokens,
         costUsd,
+        costSource,
         completedAt: new Date().toISOString(),
         latencyMs,
         status: 'success'


### PR DESCRIPTION
## Summary

Closes the last gap of the LiteLLM gateway rollout (E1): the "Consumo LLM" number becomes the **real cost** computed by the gateway instead of an estimate from the hardcoded 9-model pricing table (which ignores cache reads, returns 0 for unknown models — e.g. catalog preset names — and lists retired models).

- `onRunCompleted` prefers Agno's `metrics.cost` — populated when the gateway runs with `include_cost_in_streaming_usage: true` (LiteLLM injects its computed cost into the streaming `usage` chunk and Agno reads it into `RunMetrics.cost`). Per-model costs are summed when no run-level figure exists; a reported `0` is a real value and is kept.
- Falls back to the static pricing table only when no gateway cost is reported (direct-provider path, older runtimes).
- New `costSource: gateway | table` field on `llm-usage-events` and the ingest endpoint, so dashboards can tell real cost from estimates during the transition.

## Verification

- 159 tests pass (6 new: run-level preference, per-model summing, zero-cost kept, non-finite fallback, ingest costSource defaulting/override)
- Verified end-to-end in the devcontainer: a real chat produced `cost_source='gateway'`, `cost_usd=0.0002973` (~3.3k tokens of gpt-4o-mini behind the `chat-estandar` preset) vs the prior event's `table`/`0`.

## Deploy coupling

This package version and the gateway flag (`include_cost_in_streaming_usage: true`, ZetesisPortal PR) must ship **together**: either alone leaves cost on the table-fallback path. The new collection field implies a Payload migration in consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)