### PR TITLE
[codex] Sync agent virtual keys with LiteLLM

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/__init__.py
+++ b/backend/agno-agent-builder/agno_agent_builder/__init__.py
@@ -38,7 +38,7 @@ from agno_agent_builder.exceptions import (
     AuthenticationError,
     InvalidModelError,
     MissingApiKeyError,
-    UnsupportedProviderError,
+    MissingLiteLlmVirtualKeyError,
 )
 from agno_agent_builder.instructions import (
     DEFAULT_OUTPUT_FORMAT,
@@ -64,9 +64,9 @@ __all__ = [
     "AuthenticationError",
     "InvalidModelError",
     "MissingApiKeyError",
+    "MissingLiteLlmVirtualKeyError",
     "PayloadAgentSource",
     "RuntimeConfig",
-    "UnsupportedProviderError",
     "build_agent",
     "build_mcp_tools",
     "build_model",

--- a/backend/agno-agent-builder/agno_agent_builder/app.py
+++ b/backend/agno-agent-builder/agno_agent_builder/app.py
@@ -76,9 +76,6 @@ def create_app(config: RuntimeConfig) -> FastAPI:
         tool_protocol=config.tool_protocol,
         output_format=config.output_format,
         litellm_proxy_url=config.litellm_proxy_url,
-        litellm_master_key=(
-            config.litellm_master_key.get_secret_value() if config.litellm_master_key else None
-        ),
     )
     engine_holder = EngineHolder(config.database_url)
     reload_lock = asyncio.Lock()

--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -4,22 +4,17 @@ from __future__ import annotations
 
 from agno.agent import Agent
 from agno.db.postgres import PostgresDb
-from agno.models.anthropic import Claude
 from agno.models.base import Model
-from agno.models.openai import OpenAIChat, OpenAIResponses
+from agno.models.openai import OpenAIChat
 from agno.tools.mcp import MCPTools
 from agno.tools.mcp.params import StreamableHTTPClientParams
 
 from agno_agent_builder.exceptions import (
-    GatewayRequiredError,
     InvalidModelError,
-    UnsupportedProviderError,
+    MissingLiteLlmVirtualKeyError,
 )
 from agno_agent_builder.instructions import compose_instructions
 from agno_agent_builder.sources.types import AgentConfig
-
-_OPENAI_RESPONSES_PREFIXES = ("o1", "o3", "o4", "gpt-4.1", "gpt-5")
-_NATIVE_REASONER_PREFIXES = ("o1", "o3", "o4")
 
 
 def build_agent(
@@ -29,21 +24,14 @@ def build_agent(
     mcp_url: str,
     tool_protocol: str | None = None,
     output_format: str | None = None,
-    litellm_proxy_url: str | None = None,
-    litellm_master_key: str | None = None,
+    litellm_proxy_url: str,
 ) -> Agent:
     """Construct an Agno Agent from a normalized AgentConfig."""
     llm_model = cfg.llm_model.strip()
     if not llm_model or llm_model.startswith("/") or llm_model.endswith("/"):
         raise InvalidModelError(slug=cfg.slug, llm_model=cfg.llm_model)
 
-    # Through the gateway Agno's reasoning scaffolding stays OFF: the preset
-    # hides the real model (the heuristic would decide blind), the scaffolding
-    # doubles every turn with a strict:true call that OpenAI rejects for
-    # map-shaped tool params (strict mode cannot express
-    # `additionalProperties: <schema>`, e.g. search_collections.filters), and
-    # it inflates the prompt. Native reasoners reason server-side regardless.
-    use_scaffolding = litellm_proxy_url is None and not _is_native_reasoner(llm_model)
+    proxy_key = resolve_litellm_proxy_key(cfg)
 
     return Agent(
         name=cfg.name,
@@ -52,7 +40,7 @@ def build_agent(
             llm_model,
             cfg.api_key.get_secret_value(),
             proxy_url=litellm_proxy_url,
-            proxy_key=litellm_master_key,
+            proxy_key=proxy_key,
         ),
         instructions=compose_instructions(
             cfg, tool_protocol=tool_protocol, output_format=output_format
@@ -61,64 +49,49 @@ def build_agent(
         tools=[build_mcp_tools(mcp_url, cfg)],
         add_history_to_context=True,
         num_history_runs=5,
-        reasoning=use_scaffolding,
+        # Reasoning scaffolding stays OFF through the gateway: the preset hides
+        # the real model from Agno's heuristic and native reasoners reason
+        # server-side anyway; scaffolding doubles turns with a strict:true call
+        # OpenAI rejects for map-shaped tool params and inflates the prompt.
+        reasoning=False,
         tool_call_limit=cfg.tool_call_limit,
         telemetry=False,
     )
 
 
-def _is_native_reasoner(llm_model: str) -> bool:
-    """Whether the model exposes native reasoning (no Agno scaffolding needed).
+def resolve_litellm_proxy_key(cfg: AgentConfig) -> str:
+    """The per-agent virtual key used to authenticate with the LiteLLM gateway.
 
-    For ``provider/model-id`` values the model id is checked. For catalog
-    presets (no slash) the underlying model is unknown to the runtime, so the
-    preset name itself is checked — name presets accordingly (e.g. ``o4-...``)
-    or accept the default scaffolding.
+    Fail-closed: an agent without a synced virtual key cannot reach the gateway.
     """
-    _, _, model_id = llm_model.rpartition("/")
-    return any(model_id.startswith(p) for p in _NATIVE_REASONER_PREFIXES)
+    if not cfg.litellm_virtual_key:
+        raise MissingLiteLlmVirtualKeyError(slug=cfg.slug)
+    return cfg.litellm_virtual_key.get_secret_value()
 
 
 def build_model(
     llm_model: str,
     api_key: str,
     *,
-    proxy_url: str | None = None,
-    proxy_key: str | None = None,
+    proxy_url: str,
+    proxy_key: str,
 ) -> Model:
-    """Map an agent's ``llm_model`` to an Agno model instance.
+    """Route an agent's model through the LiteLLM proxy as an OpenAI-compatible
+    endpoint.
 
-    ``llm_model`` is either a ``provider/model-id`` pair or a catalog preset
-    name (no slash) defined in the LiteLLM gateway's ``model_list``.
-
-    When ``proxy_url`` is set, every model is routed through the LiteLLM proxy
-    as an OpenAI-compatible endpoint — the value travels verbatim and the
-    gateway resolves it against its model_list (catalog presets). BYOK is
+    ``llm_model`` is a catalog preset name (or ``provider/model-id``) that
+    travels verbatim; the gateway resolves it against its catalog. BYOK is
     preserved: the agent's own ``api_key`` goes per-request via ``extra_body``
     (the proxy uses it to call the real provider), while ``proxy_key`` (the
-    proxy master/virtual key) authenticates with the gateway. The proxy
-    computes the real cost and reports it to Langfuse.
-
-    Without a proxy only ``provider/model-id`` can be resolved — catalog
-    presets require the gateway.
+    per-agent virtual key) authenticates with the gateway. The proxy computes
+    the real cost and reports it to Langfuse.
     """
-    if proxy_url:
-        return OpenAIChat(
-            id=llm_model,
-            base_url=proxy_url,
-            api_key=proxy_key,
-            extra_body={"api_key": api_key},
-        )
-    provider, sep, model_id = llm_model.partition("/")
-    if not sep:
-        raise GatewayRequiredError(llm_model=llm_model)
-    if provider == "anthropic":
-        return Claude(id=model_id, api_key=api_key)
-    if provider == "openai":
-        if any(model_id.startswith(p) for p in _OPENAI_RESPONSES_PREFIXES):
-            return OpenAIResponses(id=model_id, api_key=api_key)
-        return OpenAIChat(id=model_id, api_key=api_key)
-    raise UnsupportedProviderError(provider=provider)
+    return OpenAIChat(
+        id=llm_model,
+        base_url=proxy_url,
+        api_key=proxy_key,
+        extra_body={"api_key": api_key},
+    )
 
 
 def build_mcp_tools(mcp_url: str, cfg: AgentConfig) -> MCPTools:

--- a/backend/agno-agent-builder/agno_agent_builder/config.py
+++ b/backend/agno-agent-builder/agno_agent_builder/config.py
@@ -72,7 +72,6 @@ class RuntimeConfig(BaseModel):
     # LiteLLM proxy (LLM gateway). When set, every agent is routed through the
     # proxy as an OpenAI-compatible endpoint so LiteLLM computes the real cost
     # and reports it to Langfuse. BYOK is preserved: each agent's own apiKey is
-    # forwarded per-request via extra_body, while litellm_master_key authenticates
-    # with the proxy. Leave unset for the direct provider path.
-    litellm_proxy_url: str | None = None
-    litellm_master_key: SecretStr | None = None
+    # forwarded per-request via extra_body, while the agent's per-agent virtual
+    # key authenticates with the proxy.
+    litellm_proxy_url: str

--- a/backend/agno-agent-builder/agno_agent_builder/exceptions.py
+++ b/backend/agno-agent-builder/agno_agent_builder/exceptions.py
@@ -52,20 +52,6 @@ class InvalidModelError(AgentConfigError):
         )
 
 
-class GatewayRequiredError(AgentConfigError):
-    """Catalog preset used without the LiteLLM gateway configured."""
-
-    def __init__(self, llm_model: str) -> None:
-        super().__init__(
-            message=(
-                f"llmModel {llm_model!r} is a catalog preset, which requires the "
-                "LiteLLM gateway (set LITELLM_PROXY_URL) to resolve"
-            ),
-            code="GATEWAY_REQUIRED",
-            details={"llmModel": llm_model},
-        )
-
-
 class MissingApiKeyError(AgentConfigError):
     """Agent has no API key configured."""
 
@@ -77,14 +63,14 @@ class MissingApiKeyError(AgentConfigError):
         )
 
 
-class UnsupportedProviderError(AgentConfigError):
-    """LLM provider not supported."""
+class MissingLiteLlmVirtualKeyError(AgentConfigError):
+    """Agent is active but has no synced LiteLLM virtual key."""
 
-    def __init__(self, provider: str) -> None:
+    def __init__(self, slug: str) -> None:
         super().__init__(
-            message=f"Unsupported LLM provider {provider!r}. Expected: 'anthropic', 'openai'.",
-            code="UNSUPPORTED_PROVIDER",
-            details={"provider": provider},
+            message=f"Agent {slug!r} has no synced LiteLLM virtual key",
+            code="MISSING_LITELLM_VIRTUAL_KEY",
+            details={"slug": slug},
         )
 
 

--- a/backend/agno-agent-builder/agno_agent_builder/registry.py
+++ b/backend/agno-agent-builder/agno_agent_builder/registry.py
@@ -25,15 +25,13 @@ class AgentRegistry:
         mcp_url: str,
         tool_protocol: str | None = None,
         output_format: str | None = None,
-        litellm_proxy_url: str | None = None,
-        litellm_master_key: str | None = None,
+        litellm_proxy_url: str,
     ) -> None:
         self._source = source
         self._mcp_url = mcp_url
         self._tool_protocol = tool_protocol
         self._output_format = output_format
         self._litellm_proxy_url = litellm_proxy_url
-        self._litellm_master_key = litellm_master_key
         self._agents: dict[str, Agent] = {}
         self._db = PostgresDb(
             db_url=normalize_pg_url(database_url),
@@ -65,7 +63,6 @@ class AgentRegistry:
                     tool_protocol=self._tool_protocol,
                     output_format=self._output_format,
                     litellm_proxy_url=self._litellm_proxy_url,
-                    litellm_master_key=self._litellm_master_key,
                 )
             except Exception:
                 logger.exception("Failed to build agent", slug=cfg.slug)

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -74,6 +74,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
     api_key = doc.get("apiKey")
     if not isinstance(api_key, str) or not api_key:
         raise ValueError(f"agent {slug!r} missing 'apiKey'")
+    litellm_virtual_key = doc.get("litellmVirtualKey")
 
     tenant = doc.get("tenant")
     tenant_slug = tenant.get("slug") if isinstance(tenant, dict) else None
@@ -130,6 +131,11 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         name=doc.get("name") or slug,
         llm_model=llm_model,
         api_key=SecretStr(api_key),
+        litellm_virtual_key=(
+            SecretStr(litellm_virtual_key)
+            if isinstance(litellm_virtual_key, str) and litellm_virtual_key
+            else None
+        ),
         instructions_extra=doc.get("systemPrompt")
         if isinstance(doc.get("systemPrompt"), str)
         else None,

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -18,6 +18,7 @@ class AgentConfig(BaseModel):
     name: str
     llm_model: str
     api_key: SecretStr
+    litellm_virtual_key: SecretStr | None = None
     instructions_extra: str | None = None
     tenant_slug: str | None = None
     taxonomy_slugs: list[str] = []

--- a/backend/agno-agent-builder/tests/test_builder.py
+++ b/backend/agno-agent-builder/tests/test_builder.py
@@ -1,63 +1,33 @@
-"""Tests for `agno_agent_builder.builder.build_model` provider/model mapping."""
+"""Tests for `agno_agent_builder.builder` — proxy model routing + key resolution."""
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
-from agno.models.anthropic import Claude
-from agno.models.openai import OpenAIChat, OpenAIResponses
-from agno_agent_builder.builder import build_model
-from agno_agent_builder.exceptions import GatewayRequiredError, UnsupportedProviderError
-
-
-class TestBuildModel:
-    def test_anthropic_returns_claude(self) -> None:
-        model = build_model("anthropic/claude-sonnet-4-5", "sk-test")
-        assert isinstance(model, Claude)
-        assert model.id == "claude-sonnet-4-5"
-
-    @pytest.mark.parametrize(
-        "model_id", ["o1-preview", "o3-mini", "o4-mini", "gpt-4.1", "gpt-5-turbo"]
-    )
-    def test_openai_reasoning_series_returns_responses(self, model_id: str) -> None:
-        model = build_model(f"openai/{model_id}", "sk-test")
-        assert isinstance(model, OpenAIResponses)
-        assert model.id == model_id
-
-    @pytest.mark.parametrize("model_id", ["gpt-4o", "gpt-4o-mini", "gpt-3.5-turbo"])
-    def test_openai_chat_series_returns_chat(self, model_id: str) -> None:
-        model = build_model(f"openai/{model_id}", "sk-test")
-        assert isinstance(model, OpenAIChat)
-        assert model.id == model_id
-
-    def test_unknown_provider_raises(self) -> None:
-        with pytest.raises(UnsupportedProviderError) as exc:
-            build_model("cohere/command-r", "sk-test")
-        assert exc.value.details == {"provider": "cohere"}
-        assert exc.value.http_status == 422
-
-    def test_catalog_preset_without_proxy_raises(self) -> None:
-        # Presets only exist in the gateway's model_list — the direct path
-        # cannot resolve them.
-        with pytest.raises(GatewayRequiredError) as exc:
-            build_model("chat-premium", "sk-test")
-        assert exc.value.details == {"llmModel": "chat-premium"}
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno_agent_builder.builder import build_agent, build_model, resolve_litellm_proxy_key
+from agno_agent_builder.exceptions import InvalidModelError, MissingLiteLlmVirtualKeyError
+from agno_agent_builder.sources import AgentConfig
+from pydantic import SecretStr
 
 
 class TestBuildModelViaProxy:
-    """With proxy_url set, every model is routed through the LiteLLM proxy as an
-    OpenAI-compatible endpoint, with BYOK forwarded via extra_body."""
+    """Every model is routed through the LiteLLM proxy as an OpenAI-compatible
+    endpoint, with BYOK forwarded via extra_body."""
 
     def test_proxy_routes_openai_with_byok(self) -> None:
         model = build_model(
             "openai/gpt-4o",
             "sk-agent-key",
             proxy_url="http://litellm:4000/v1",
-            proxy_key="sk-master",
+            proxy_key="sk-virtual",
         )
         assert isinstance(model, OpenAIChat)
         assert model.id == "openai/gpt-4o"
         assert model.base_url == "http://litellm:4000/v1"
-        assert model.api_key == "sk-master"
+        assert model.api_key == "sk-virtual"
         assert model.extra_body == {"api_key": "sk-agent-key"}
 
     def test_proxy_routes_anthropic_as_openai_compatible(self) -> None:
@@ -67,7 +37,7 @@ class TestBuildModelViaProxy:
             "anthropic/claude-sonnet-4-5",
             "sk-ant-agent",
             proxy_url="http://litellm:4000/v1",
-            proxy_key="sk-master",
+            proxy_key="sk-virtual",
         )
         assert isinstance(model, OpenAIChat)
         assert model.id == "anthropic/claude-sonnet-4-5"
@@ -75,17 +45,81 @@ class TestBuildModelViaProxy:
 
     def test_proxy_routes_catalog_preset_verbatim(self) -> None:
         # Catalog presets (no slash) pass through untouched — the gateway's
-        # model_list resolves them to the real provider/model.
+        # catalog resolves them to the real provider/model.
         model = build_model(
             "chat-premium",
             "sk-ant-agent",
             proxy_url="http://litellm:4000/v1",
-            proxy_key="sk-master",
+            proxy_key="sk-virtual",
         )
         assert isinstance(model, OpenAIChat)
         assert model.id == "chat-premium"
         assert model.extra_body == {"api_key": "sk-ant-agent"}
 
-    def test_no_proxy_keeps_direct_path(self) -> None:
-        model = build_model("anthropic/claude-sonnet-4-5", "sk-test")
-        assert isinstance(model, Claude)
+
+class TestLiteLlmProxyKeyResolution:
+    def _cfg(self, virtual_key: str | None = None) -> AgentConfig:
+        return AgentConfig(
+            slug="bastos",
+            name="Bastos",
+            llm_model="chat-premium",
+            api_key=SecretStr("sk-ant-agent"),
+            litellm_virtual_key=SecretStr(virtual_key) if virtual_key else None,
+        )
+
+    def test_uses_agent_virtual_key(self) -> None:
+        assert resolve_litellm_proxy_key(self._cfg("sk-virtual")) == "sk-virtual"
+
+    def test_fail_closed_when_virtual_key_missing(self) -> None:
+        with pytest.raises(MissingLiteLlmVirtualKeyError) as exc:
+            resolve_litellm_proxy_key(self._cfg())
+        assert exc.value.details == {"slug": "bastos"}
+
+
+class TestBuildAgent:
+    """build_agent is what registry.load_all() calls per agent — guard its two
+    fail-closed paths and the proxy wiring end-to-end."""
+
+    def _cfg(
+        self, *, llm_model: str = "chat-premium", virtual_key: str | None = "sk-virtual"
+    ) -> AgentConfig:
+        return AgentConfig(
+            slug="bastos",
+            name="Bastos",
+            llm_model=llm_model,
+            api_key=SecretStr("sk-ant-agent"),
+            litellm_virtual_key=SecretStr(virtual_key) if virtual_key else None,
+        )
+
+    def _build(self, cfg: AgentConfig) -> Agent:
+        return build_agent(
+            cfg,
+            db=MagicMock(),
+            mcp_url="http://mcp:9000",
+            litellm_proxy_url="http://litellm:4000/v1",
+        )
+
+    def test_malformed_model_raises_invalid_model_error(self) -> None:
+        with pytest.raises(InvalidModelError) as exc:
+            self._build(self._cfg(llm_model="/"))
+        assert exc.value.details["slug"] == "bastos"
+
+    def test_active_agent_without_virtual_key_fails_closed(self) -> None:
+        with pytest.raises(MissingLiteLlmVirtualKeyError) as exc:
+            self._build(self._cfg(virtual_key=None))
+        assert exc.value.details == {"slug": "bastos"}
+
+    def test_valid_config_routes_model_through_proxy(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # build_mcp_tools constructs a real MCPTools; stub it so the test stays a
+        # pure unit of build_agent's wiring.
+        monkeypatch.setattr(
+            "agno_agent_builder.builder.build_mcp_tools", lambda mcp_url, cfg: MagicMock()
+        )
+
+        agent = self._build(self._cfg())
+
+        assert isinstance(agent, Agent)
+        assert isinstance(agent.model, OpenAIChat)
+        assert agent.model.base_url == "http://litellm:4000/v1"
+        assert agent.model.api_key == "sk-virtual"
+        assert agent.model.extra_body == {"api_key": "sk-ant-agent"}

--- a/backend/agno-agent-builder/tests/test_exceptions.py
+++ b/backend/agno-agent-builder/tests/test_exceptions.py
@@ -10,7 +10,6 @@ from agno_agent_builder.exceptions import (
     AuthenticationError,
     InvalidModelError,
     MissingApiKeyError,
-    UnsupportedProviderError,
     agno_agent_builder_exception_handler,
 )
 from fastapi import Request
@@ -29,12 +28,6 @@ class TestExceptionShapes:
         assert exc.code == "MISSING_API_KEY"
         assert exc.http_status == 422
         assert exc.details == {"slug": "bastos"}
-
-    def test_unsupported_provider(self) -> None:
-        exc = UnsupportedProviderError(provider="cohere")
-        assert exc.code == "UNSUPPORTED_PROVIDER"
-        assert exc.http_status == 422
-        assert exc.details == {"provider": "cohere"}
 
     def test_authentication_error_is_401(self) -> None:
         exc = AuthenticationError()

--- a/backend/agno-agent-builder/tests/test_payload_source.py
+++ b/backend/agno-agent-builder/tests/test_payload_source.py
@@ -54,6 +54,7 @@ class TestPayloadDocToAgentConfig:
         assert cfg.name == "Bastos"
         assert cfg.llm_model == "openai/o4-mini"
         assert cfg.api_key.get_secret_value() == "sk-test"
+        assert cfg.litellm_virtual_key is None
         assert cfg.tenant_slug == "internal"
         assert cfg.taxonomy_slugs == ["bastos"]
         assert cfg.search_collections == ["posts_chunk"]
@@ -65,6 +66,11 @@ class TestPayloadDocToAgentConfig:
         assert cfg.input_k == 50
         assert cfg.top_k == 10
         assert cfg.rewrite_template == "{{query}} en filosofía libertaria austríaca"
+
+    def test_maps_litellm_virtual_key_when_present(self) -> None:
+        cfg = payload_doc_to_agent_config(self._doc(litellmVirtualKey="sk-litellm-agent"))
+        assert cfg.litellm_virtual_key
+        assert cfg.litellm_virtual_key.get_secret_value() == "sk-litellm-agent"
 
     def test_unpopulated_tenant_becomes_none(self) -> None:
         cfg = payload_doc_to_agent_config(self._doc(tenant=2))

--- a/backend/agno-agent/agno_agent/main.py
+++ b/backend/agno-agent/agno_agent/main.py
@@ -24,5 +24,6 @@ app = create_app(
         langfuse_host=settings.langfuse_host,
         langfuse_public_key=settings.langfuse_public_key,
         langfuse_secret_key=settings.langfuse_secret_key,
+        litellm_proxy_url=settings.litellm_proxy_url,
     )
 )

--- a/backend/agno-agent/agno_agent/settings.py
+++ b/backend/agno-agent/agno_agent/settings.py
@@ -31,9 +31,12 @@ class Settings(BaseSettings):
     langfuse_host: str | None = None
     langfuse_public_key: SecretStr | None = None
     langfuse_secret_key: SecretStr | None = None
+    litellm_proxy_url: str = ""
 
     def model_post_init(self, __context: Any) -> None:
         if not self.database_url:
             raise ValueError("DATABASE_URL environment variable is required")
         if not self.internal_secret.get_secret_value():
             raise ValueError("INTERNAL_SECRET environment variable is required")
+        if not self.litellm_proxy_url:
+            raise ValueError("LITELLM_PROXY_URL environment variable is required")

--- a/backend/nexus-queue/nexus_queue/delayed.py
+++ b/backend/nexus-queue/nexus_queue/delayed.py
@@ -78,8 +78,20 @@ class DelayedRetryPoller:
         due = await self._redis.zrangebyscore(self._config.delayed_set, "-inf", time.time())
         for record in due:
             # Atomic claim: only the replica that removes the member re-enqueues it.
-            if await self._redis.zrem(self._config.delayed_set, record) == 1:
+            if await self._redis.zrem(self._config.delayed_set, record) != 1:
+                continue
+            try:
                 await self._reenqueue(json.loads(record))
+            except Exception:
+                # The claim already removed the record; a failed re-enqueue
+                # (broker blip, SIGTERM between the two awaits) would lose the
+                # retry forever. Re-park it slightly in the future so the next
+                # tick retries it instead of dropping it silently.
+                await self._redis.zadd(
+                    self._config.delayed_set,
+                    {record: time.time() + self._config.retry_poll_interval_s},
+                )
+                logger.exception("retry-reenqueue-failed-reparked")
 
     async def _reenqueue(self, data: dict[str, Any]) -> None:
         kicker: AsyncKicker[Any, Any] = AsyncKicker(

--- a/backend/nexus-queue/nexus_queue/handlers.py
+++ b/backend/nexus-queue/nexus_queue/handlers.py
@@ -53,28 +53,33 @@ def register(broker: AsyncBroker, spec: HandlerSpec, config: RuntimeConfig) -> N
 
         raw_idem = labels.get(LABEL_IDEM) if spec.idempotent else None
         idem = str(raw_idem) if raw_idem else None
+        tenant = str(labels.get(LABEL_TENANT, SINGLE_TENANT))
         store: IdempotencyStore | None = state.nexus_idempotency if idem else None
-        if store is not None and idem and await store.already_processed(idem):
+        # Claim up front so two concurrent in-flight redeliveries can't both run.
+        if store is not None and idem and not await store.claim(idem, tenant):
             logger.info("duplicate-skipped", task=spec.task_name, idem=idem)
             return
 
         adapters = state.nexus_adapters
-        payload = spec.payload_model(**kwargs)
+        try:
+            payload = spec.payload_model(**kwargs)
 
-        traceparent = labels.get(LABEL_TRACE)
-        parent = extract({"traceparent": str(traceparent)}) if traceparent else None
-        with _tracer.start_as_current_span(
-            f"nexus_queue.consume {spec.task_name}",
-            context=parent,
-        ) as span:
-            span.set_attribute("nq.task", spec.task_name)
-            span.set_attribute("nq.tenant", str(labels.get(LABEL_TENANT, SINGLE_TENANT)))
-            with CONSUME_SECONDS.labels(config.project, config.queue, spec.task_name).time():
-                await spec.handler(payload, adapters)
-
-        # Record dedup only after success: a failed attempt must stay retryable.
-        if store is not None and idem:
-            await store.mark_processed(idem)
+            traceparent = labels.get(LABEL_TRACE)
+            parent = extract({"traceparent": str(traceparent)}) if traceparent else None
+            with _tracer.start_as_current_span(
+                f"nexus_queue.consume {spec.task_name}",
+                context=parent,
+            ) as span:
+                span.set_attribute("nq.task", spec.task_name)
+                span.set_attribute("nq.tenant", tenant)
+                with CONSUME_SECONDS.labels(config.project, config.queue, spec.task_name).time():
+                    await spec.handler(payload, adapters)
+        except Exception:
+            # Release the claim so a legitimate retry can re-claim — otherwise the
+            # up-front claim would make the retry skip itself as a phantom dup.
+            if store is not None and idem:
+                await store.release(idem, tenant)
+            raise
 
     _run.__name__ = "nexus_run_" + spec.task_name.replace(".", "_").replace(":", "_")
     broker.task(task_name=spec.task_name)(_run)

--- a/backend/nexus-queue/nexus_queue/lifecycle.py
+++ b/backend/nexus-queue/nexus_queue/lifecycle.py
@@ -22,11 +22,14 @@ logger = structlog.get_logger("nexus_queue.lifecycle")
 
 
 class IdempotencyStore:
-    """Redis mark-done dedup keyed by the message's ``nq_idem`` label.
+    """Redis claim-based dedup keyed by the message's ``nq_idem`` label.
 
-    The key is recorded only *after* a handler succeeds, so a failed attempt
-    leaves no marker and stays eligible for retry/DLQ. Claiming the key up
-    front would make a re-enqueued retry skip itself as a phantom duplicate."""
+    The claim is taken up front with ``SET NX`` so two concurrent in-flight
+    redeliveries (Redis Streams pending-entry reclaim, a racing replica) can't
+    both run the handler — the loser of the atomic SET short-circuits. A failed
+    handler ``release``s the claim so a legitimate retry can re-claim; a
+    successful handler leaves the claim for the TTL to skip later duplicates.
+    Keys are namespaced per project + tenant."""
 
     def __init__(self, config: RuntimeConfig) -> None:
         self._config = config
@@ -39,21 +42,24 @@ class IdempotencyStore:
         if self._redis is not None:
             await self._redis.aclose()
 
-    async def already_processed(self, idem: str) -> bool:
-        """True if a message with this key already completed within the TTL."""
-        if self._config.idempotency_ttl_s <= 0 or self._redis is None:
-            return False
-        return bool(await self._redis.exists(idempotency_redis_key(idem)))
+    def _key(self, idem: str, tenant: str) -> str:
+        return idempotency_redis_key(idem, project=self._config.project, tenant=tenant)
 
-    async def mark_processed(self, idem: str) -> None:
-        """Record completion so later duplicates are skipped within the TTL."""
+    async def claim(self, idem: str, tenant: str) -> bool:
+        """Atomically claim the key. True -> claimed (run the handler); False ->
+        a prior claim exists (skip as a duplicate)."""
+        if self._config.idempotency_ttl_s <= 0 or self._redis is None:
+            return True
+        claimed = await self._redis.set(
+            self._key(idem, tenant), "1", nx=True, ex=self._config.idempotency_ttl_s
+        )
+        return bool(claimed)
+
+    async def release(self, idem: str, tenant: str) -> None:
+        """Release a claim after a failed attempt so a retry can re-claim."""
         if self._config.idempotency_ttl_s <= 0 or self._redis is None:
             return
-        await self._redis.set(
-            idempotency_redis_key(idem),
-            "1",
-            ex=self._config.idempotency_ttl_s,
-        )
+        await self._redis.delete(self._key(idem, tenant))
 
 
 def configure_logging(config: RuntimeConfig) -> None:

--- a/backend/nexus-queue/nexus_queue/naming.py
+++ b/backend/nexus-queue/nexus_queue/naming.py
@@ -67,6 +67,11 @@ def status_stream(project: str) -> str:
     return f"nq:{project}:status"
 
 
-def idempotency_redis_key(idem: str) -> str:
-    """Redis key used by the idempotency middleware to dedup a message."""
-    return f"nq:idem:{idem}"
+def idempotency_redis_key(idem: str, *, project: str, tenant: str) -> str:
+    """Redis key used by the idempotency middleware to dedup a message.
+
+    Namespaced by project + tenant (like every other key here) so a shared Redis
+    can't let one tenant poison another's dedup state or collide on a shared
+    natural key.
+    """
+    return f"nq:{project}:idem:{tenant}:{idem}"

--- a/backend/nexus-queue/tests/test_integration.py
+++ b/backend/nexus-queue/tests/test_integration.py
@@ -147,9 +147,14 @@ async def test_idempotency_store(redis_client: aioredis.Redis) -> None:
     store = IdempotencyStore(_config("q3"))
     await store.startup()
     try:
-        assert await store.already_processed("test-idem") is False
-        await store.mark_processed("test-idem")
-        assert await store.already_processed("test-idem") is True
+        # First claim wins; a concurrent re-delivery of the same key is skipped.
+        assert await store.claim("test-idem", "_") is True
+        assert await store.claim("test-idem", "_") is False
+        # A failed attempt releases the claim so a legitimate retry can re-claim.
+        await store.release("test-idem", "_")
+        assert await store.claim("test-idem", "_") is True
+        # A different tenant is namespaced apart, so it never collides.
+        assert await store.claim("test-idem", "other") is True
     finally:
         await store.shutdown()
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1590,7 +1590,7 @@ wheels = [
 
 [[package]]
 name = "nexus-queue"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "nexus-queue" }
 dependencies = [
     { name = "fastapi" },
@@ -1879,7 +1879,7 @@ requires-dist = [
 
 [[package]]
 name = "payload-documents-worker-builder"
-version = "0.1.3"
+version = "0.1.5"
 source = { editable = "payload-documents-worker-builder" }
 dependencies = [
     { name = "httpx" },

--- a/packages/agent-ui/src/components/LimitAlert.tsx
+++ b/packages/agent-ui/src/components/LimitAlert.tsx
@@ -5,6 +5,11 @@ import { AlertTriangle, X } from 'lucide-react'
 import type { FC } from 'react'
 import { useAgentChat } from '../runtime/AgentChatProvider'
 
+export function shouldShowLimitReset(errorMessage: string): boolean {
+  const normalized = errorMessage.toLowerCase()
+  return normalized.includes('daily token limit reached') || normalized.includes('http 429')
+}
+
 export const LimitAlert: FC = () => {
   const { limitError, setLimitError, usage } = useAgentChat()
   if (!limitError) return null
@@ -12,6 +17,7 @@ export const LimitAlert: FC = () => {
   const resetTime = usage?.reset_at
     ? new Date(usage.reset_at).toLocaleTimeString('es-ES', { hour: '2-digit', minute: '2-digit' })
     : null
+  const showResetTime = resetTime && shouldShowLimitReset(limitError)
 
   return (
     <motion.div
@@ -24,7 +30,9 @@ export const LimitAlert: FC = () => {
         <AlertTriangle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
         <div className="flex-1 space-y-1">
           <p className="text-sm font-medium text-destructive">{limitError}</p>
-          {resetTime && <p className="text-xs text-muted-foreground">Tu límite se restablecerá a las {resetTime}</p>}
+          {showResetTime && (
+            <p className="text-xs text-muted-foreground">Tu límite se restablecerá a las {resetTime}</p>
+          )}
         </div>
         <button
           type="button"

--- a/packages/payload-agents-core/src/collections/agents.ts
+++ b/packages/payload-agents-core/src/collections/agents.ts
@@ -10,6 +10,11 @@ import type { CollectionConfig } from 'payload'
 import type { ResolvedPluginConfig } from '../types'
 import { createDecryptAfterReadHook, createEncryptBeforeChangeHook } from './hooks/encrypt-api-key'
 import { createAfterChangeHook, createAfterDeleteHook } from './hooks/reload-runtime'
+import {
+  createLiteLlmVirtualKeySyncAfterChangeHook,
+  createLiteLlmVirtualKeySyncAfterDeleteHook,
+  createLiteLlmVirtualKeySyncBeforeDeleteHook
+} from './hooks/sync-litellm-virtual-key'
 import { createModelCatalogValidateHook } from './hooks/validate-model'
 
 export function createAgentsCollection(config: ResolvedPluginConfig): CollectionConfig {
@@ -24,9 +29,10 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
     hooks: {
       beforeValidate: [createModelCatalogValidateHook(config)],
       beforeChange: [createEncryptBeforeChangeHook(config)],
-      afterChange: [createAfterChangeHook(config)],
+      beforeDelete: [createLiteLlmVirtualKeySyncBeforeDeleteHook(config)],
+      afterChange: [createLiteLlmVirtualKeySyncAfterChangeHook(config), createAfterChangeHook(config)],
       afterRead: [createDecryptAfterReadHook(config)],
-      afterDelete: [createAfterDeleteHook(config)]
+      afterDelete: [createLiteLlmVirtualKeySyncAfterDeleteHook(), createAfterDeleteHook(config)]
     },
     admin: {
       useAsTitle: 'name',
@@ -77,22 +83,16 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
                 name: 'llmModel',
                 type: 'text',
                 required: true,
-                // With a catalog there is no sensible default — the admin picks
-                // a preset; without one, keep the historical free-form default.
-                defaultValue: config.modelCatalog ? undefined : 'openai/gpt-4o',
-                admin: config.modelCatalog
-                  ? {
-                      description: 'Model preset from the gateway catalog',
-                      components: {
-                        Field: {
-                          path: '@zetesis/payload-agents-core/client#ModelSelectField',
-                          clientProps: { catalogPath: `/api${config.basePath}/models` }
-                        }
-                      }
+                // The admin picks a preset from the gateway catalog.
+                admin: {
+                  description: 'Model preset from the gateway catalog',
+                  components: {
+                    Field: {
+                      path: '@zetesis/payload-agents-core/client#ModelSelectField',
+                      clientProps: { catalogPath: `/api${config.basePath}/models` }
                     }
-                  : {
-                      description: 'LLM model to use (e.g., openai/gpt-4o, anthropic/claude-sonnet-4-20250514)'
-                    }
+                  }
+                }
               },
               {
                 name: 'apiKey',
@@ -122,6 +122,83 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
                 name: 'toolCallLimit',
                 type: 'number',
                 admin: { description: 'Max tool calls per turn. Leave empty for no limit.' }
+              },
+              {
+                type: 'row',
+                fields: [
+                  {
+                    name: 'maxBudgetUsd',
+                    type: 'number',
+                    min: 0,
+                    admin: { description: 'Optional LiteLLM max budget for this agent virtual key, in USD.' }
+                  },
+                  {
+                    name: 'budgetDuration',
+                    type: 'text',
+                    admin: { description: 'Optional LiteLLM budget reset window, e.g. 1d, 30d, 1mo.' }
+                  }
+                ]
+              },
+              {
+                type: 'row',
+                fields: [
+                  {
+                    name: 'rpmLimit',
+                    type: 'number',
+                    min: 0,
+                    admin: { description: 'Optional LiteLLM requests-per-minute limit for this agent.' }
+                  },
+                  {
+                    name: 'tpmLimit',
+                    type: 'number',
+                    min: 0,
+                    admin: { description: 'Optional LiteLLM tokens-per-minute limit for this agent.' }
+                  }
+                ]
+              },
+              {
+                type: 'collapsible',
+                label: 'LiteLLM Virtual Key',
+                admin: { initCollapsed: true },
+                fields: [
+                  {
+                    name: 'litellmVirtualKey',
+                    type: 'text',
+                    admin: { hidden: true }
+                  },
+                  {
+                    name: 'litellmVirtualKeyAlias',
+                    type: 'text',
+                    admin: { readOnly: true, description: 'LiteLLM key alias managed by Payload.' }
+                  },
+                  {
+                    name: 'litellmVirtualKeyFingerprint',
+                    type: 'text',
+                    admin: { readOnly: true, description: 'Last 4 characters of the LiteLLM virtual key.' }
+                  },
+                  {
+                    name: 'litellmVirtualKeySyncStatus',
+                    type: 'select',
+                    admin: { readOnly: true, description: 'Last LiteLLM virtual key sync status.' },
+                    options: [
+                      { label: 'Pending', value: 'pending' },
+                      { label: 'Synced', value: 'synced' },
+                      { label: 'Blocked', value: 'blocked' },
+                      { label: 'Disabled', value: 'disabled' },
+                      { label: 'Error', value: 'error' }
+                    ]
+                  },
+                  {
+                    name: 'litellmVirtualKeySyncedAt',
+                    type: 'date',
+                    admin: { readOnly: true, description: 'Last successful LiteLLM virtual key sync.' }
+                  },
+                  {
+                    name: 'litellmVirtualKeySyncError',
+                    type: 'textarea',
+                    admin: { readOnly: true, description: 'Last LiteLLM virtual key sync error, if any.' }
+                  }
+                ]
               }
             ]
           },

--- a/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.spec.ts
+++ b/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+import { decrypt, isEncrypted } from '../../lib/encryption'
+import type { ResolvedPluginConfig } from '../../types'
+import { createDecryptAfterReadHook, createEncryptBeforeChangeHook } from './encrypt-api-key'
+
+const CFG = { encryptionKey: 'test-secret' } as ResolvedPluginConfig
+
+type BeforeArgs = Parameters<ReturnType<typeof createEncryptBeforeChangeHook>>[0]
+type AfterArgs = Parameters<ReturnType<typeof createDecryptAfterReadHook>>[0]
+
+function beforeArgs(data: Record<string, unknown>): BeforeArgs {
+  return { data } as unknown as BeforeArgs
+}
+
+function afterArgs(doc: Record<string, unknown>, context: Record<string, unknown> = {}): AfterArgs {
+  return {
+    doc,
+    context,
+    req: {
+      payloadAPI: 'REST',
+      user: undefined
+    }
+  } as unknown as AfterArgs
+}
+
+describe('agent secret field hooks', () => {
+  it('encrypts provider and LiteLLM keys before save', async () => {
+    const data = { apiKey: 'sk-provider', litellmVirtualKey: 'sk-litellm' }
+
+    await createEncryptBeforeChangeHook(CFG)(beforeArgs(data))
+
+    expect(isEncrypted(data.apiKey)).toBe(true)
+    expect(isEncrypted(data.litellmVirtualKey)).toBe(true)
+    expect(data.apiKeyFingerprint).toBe('ider')
+    expect(decrypt(data.apiKey, 'test-secret')).toBe('sk-provider')
+    expect(decrypt(data.litellmVirtualKey, 'test-secret')).toBe('sk-litellm')
+  })
+
+  it('hides secrets from normal reads', async () => {
+    const doc = {
+      apiKey: 'enc:any',
+      litellmVirtualKey: 'enc:any'
+    }
+
+    await createDecryptAfterReadHook(CFG)(afterArgs(doc))
+
+    expect(doc.apiKey).toBeUndefined()
+    expect(doc.litellmVirtualKey).toBeUndefined()
+  })
+
+  it('decrypts both secrets for internal runtime reads', async () => {
+    const doc = {
+      apiKey: 'sk-provider',
+      litellmVirtualKey: 'sk-litellm'
+    }
+    await createEncryptBeforeChangeHook(CFG)(beforeArgs(doc))
+
+    await createDecryptAfterReadHook(CFG)(afterArgs(doc, { internalAgentRead: true }))
+
+    expect(doc.apiKey).toBe('sk-provider')
+    expect(doc.litellmVirtualKey).toBe('sk-litellm')
+  })
+
+  it('redacts the key fingerprint and raw sync error from normal reads', async () => {
+    const doc = {
+      litellmVirtualKeyFingerprint: 'x9f2',
+      litellmVirtualKeySyncError: 'LiteLLM /key/generate failed: HTTP 500 http://litellm:4000'
+    }
+
+    await createDecryptAfterReadHook(CFG)(afterArgs(doc))
+
+    expect(doc.litellmVirtualKeyFingerprint).toBeUndefined()
+    expect(doc.litellmVirtualKeySyncError).toBeUndefined()
+  })
+
+  it('keeps the fingerprint and sync error for internal runtime reads', async () => {
+    const doc = {
+      litellmVirtualKeyFingerprint: 'x9f2',
+      litellmVirtualKeySyncError: 'boom'
+    }
+
+    await createDecryptAfterReadHook(CFG)(afterArgs(doc, { internalAgentRead: true }))
+
+    expect(doc.litellmVirtualKeyFingerprint).toBe('x9f2')
+    expect(doc.litellmVirtualKeySyncError).toBe('boom')
+  })
+})

--- a/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.ts
+++ b/packages/payload-agents-core/src/collections/hooks/encrypt-api-key.ts
@@ -1,14 +1,46 @@
 /**
- * Hooks for encrypting/decrypting the `apiKey` field on the Agents collection.
+ * Hooks for encrypting/decrypting secret fields on the Agents collection.
  *
  * - `beforeChange`: encrypts the API key before saving to the database.
  * - `afterRead`: decrypts only for internal requests or super-admin users;
  *   all other consumers receive `apiKey: undefined`.
  */
 
-import type { CollectionAfterReadHook, CollectionBeforeChangeHook } from 'payload'
+import type { CollectionAfterReadHook, CollectionBeforeChangeHook, PayloadRequest } from 'payload'
 import { decrypt, encrypt, isEncrypted } from '../../lib/encryption'
 import type { ResolvedPluginConfig } from '../../types'
+
+const SECRET_FIELDS = ['apiKey', 'litellmVirtualKey'] as const
+// Non-encrypted but operator-only: the key fingerprint (last-4) and the raw
+// LiteLLM error text (internal gateway URLs / HTTP bodies) must not reach tenant
+// chat users, who can read the agent (collection read is permissive).
+const REDACTED_FIELDS = ['litellmVirtualKeyFingerprint', 'litellmVirtualKeySyncError'] as const
+
+function hideSecretFields(doc: Record<string, unknown>): void {
+  for (const field of [...SECRET_FIELDS, ...REDACTED_FIELDS]) {
+    doc[field] = undefined
+  }
+}
+
+function canExposeSecretFields(context: Record<string, unknown> | undefined, req: PayloadRequest): boolean {
+  if (req.payloadAPI === 'local') return true
+  if (context?.internalAgentRead === true) return true
+  const userRoles = req.user && 'role' in req.user ? (req.user as unknown as { role: string[] }).role : []
+  return Array.isArray(userRoles) && userRoles.includes('superadmin')
+}
+
+function decryptSecretFields(doc: Record<string, unknown>, encryptionKey: string): void {
+  for (const field of SECRET_FIELDS) {
+    const value = doc[field]
+    if (typeof value !== 'string' || !isEncrypted(value)) continue
+    try {
+      doc[field] = decrypt(value, encryptionKey)
+    } catch (error) {
+      console.error(`[Agents Security] Failed to decrypt ${field}:`, error instanceof Error ? error.message : 'unknown')
+      doc[field] = '[DECRYPTION_FAILED]'
+    }
+  }
+}
 
 export function createEncryptBeforeChangeHook(config: ResolvedPluginConfig): CollectionBeforeChangeHook {
   return async ({ data }) => {
@@ -18,6 +50,9 @@ export function createEncryptBeforeChangeHook(config: ResolvedPluginConfig): Col
         data.apiKey = encrypt(data.apiKey, config.encryptionKey)
       }
     }
+    if (data.litellmVirtualKey && !isEncrypted(data.litellmVirtualKey) && config.encryptionKey) {
+      data.litellmVirtualKey = encrypt(data.litellmVirtualKey, config.encryptionKey)
+    }
     return data
   }
 }
@@ -25,27 +60,15 @@ export function createEncryptBeforeChangeHook(config: ResolvedPluginConfig): Col
 export function createDecryptAfterReadHook(config: ResolvedPluginConfig): CollectionAfterReadHook {
   return async ({ context, doc, req }) => {
     if (!config.encryptionKey) return doc
-    if (!doc.apiKey || !isEncrypted(doc.apiKey)) return doc
 
-    const isLocalAPI = req.payloadAPI === 'local'
     // Set by the internal `agents/internal/list` endpoint — the only
     // out-of-process caller that needs decrypted keys.
-    const isInternalRead = context?.internalAgentRead === true
-    const userRoles = req.user && 'role' in req.user ? (req.user as unknown as { role: string[] }).role : []
-    const isSuperAdminUser = Array.isArray(userRoles) && userRoles.includes('superadmin')
-
-    if (!isLocalAPI && !isInternalRead && !isSuperAdminUser) {
-      doc.apiKey = undefined
+    if (!canExposeSecretFields(context, req)) {
+      hideSecretFields(doc)
       return doc
     }
 
-    try {
-      doc.apiKey = decrypt(doc.apiKey, config.encryptionKey)
-    } catch (error) {
-      console.error('[Agents Security] Failed to decrypt API key:', error instanceof Error ? error.message : 'unknown')
-      doc.apiKey = '[DECRYPTION_FAILED]'
-    }
-
+    decryptSecretFields(doc, config.encryptionKey)
     return doc
   }
 }

--- a/packages/payload-agents-core/src/collections/hooks/reload-runtime.ts
+++ b/packages/payload-agents-core/src/collections/hooks/reload-runtime.ts
@@ -13,6 +13,7 @@
 import { sql } from 'drizzle-orm'
 import type { CollectionAfterChangeHook, CollectionAfterDeleteHook, Payload } from 'payload'
 import type { ResolvedPluginConfig } from '../../types'
+import { shouldSkipAgentRuntimeReload } from './sync-litellm-virtual-key'
 
 const RELOAD_CHANNEL = 'agent_reload'
 
@@ -22,7 +23,7 @@ function getDrizzle(payload: Payload): Drizzle {
   return (payload.db as unknown as { drizzle: Drizzle }).drizzle
 }
 
-async function notifyReload(payload: Payload, slug: string): Promise<void> {
+export async function notifyReload(payload: Payload, slug: string): Promise<void> {
   try {
     const drizzle = getDrizzle(payload)
     await drizzle.execute(sql`SELECT pg_notify(${RELOAD_CHANNEL}, ${slug})`)
@@ -39,7 +40,8 @@ function docSlug(doc: unknown): string | null {
 }
 
 export function createAfterChangeHook(_config: ResolvedPluginConfig): CollectionAfterChangeHook {
-  return async ({ doc, operation, req }) => {
+  return async ({ context, doc, operation, req }) => {
+    if (shouldSkipAgentRuntimeReload(context)) return doc
     const slug = docSlug(doc)
     if (!slug) return doc
     console.log(`[Agents] ${operation} → notifying agent-runtime to reload "${slug}"`)
@@ -49,7 +51,8 @@ export function createAfterChangeHook(_config: ResolvedPluginConfig): Collection
 }
 
 export function createAfterDeleteHook(_config: ResolvedPluginConfig): CollectionAfterDeleteHook {
-  return async ({ doc, req }) => {
+  return async ({ context, doc, req }) => {
+    if (shouldSkipAgentRuntimeReload(context)) return doc
     const slug = docSlug(doc)
     if (!slug) return doc
     console.log(`[Agents] delete → notifying agent-runtime to reload (removed "${slug}")`)

--- a/packages/payload-agents-core/src/collections/hooks/sync-litellm-virtual-key.spec.ts
+++ b/packages/payload-agents-core/src/collections/hooks/sync-litellm-virtual-key.spec.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { decrypt, encrypt } from '../../lib/encryption'
+import type { ResolvedPluginConfig } from '../../types'
+import {
+  clientFor,
+  createLiteLlmVirtualKeySyncAfterChangeHook,
+  createLiteLlmVirtualKeySyncAfterDeleteHook,
+  createLiteLlmVirtualKeySyncBeforeDeleteHook,
+  enqueueExistingLiteLlmVirtualKeySyncs,
+  LITELLM_SYNC_QUEUE,
+  LITELLM_SYNC_TASK_SLUG,
+  syncAgentRecord
+} from './sync-litellm-virtual-key'
+
+const CFG = {
+  collectionSlug: 'agents',
+  encryptionKey: 'test-secret',
+  modelCatalog: { gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master', cacheTtlMs: 60_000 }
+} as ResolvedPluginConfig
+
+type AfterChangeArgs = Parameters<ReturnType<typeof createLiteLlmVirtualKeySyncAfterChangeHook>>[0]
+type AfterDeleteArgs = Parameters<ReturnType<typeof createLiteLlmVirtualKeySyncAfterDeleteHook>>[0]
+type BeforeDeleteArgs = Parameters<ReturnType<typeof createLiteLlmVirtualKeySyncBeforeDeleteHook>>[0]
+type SyncPayload = Parameters<typeof syncAgentRecord>[1]
+type SyncRecord = Parameters<typeof syncAgentRecord>[3]
+type StartupPayload = Parameters<typeof enqueueExistingLiteLlmVirtualKeySyncs>[0]
+
+function stubFetch(body: unknown = { key: 'sk-generated' }, ok = true, status = 200) {
+  const fn = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+function reqWithJobs() {
+  const update = vi.fn().mockResolvedValue({})
+  const queue = vi.fn().mockResolvedValue({})
+  return { req: { payload: { update, jobs: { queue } } }, update, queue }
+}
+
+function activeDoc(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    slug: 'bastos',
+    isActive: true,
+    llmModel: 'chat-premium',
+    tenant: { slug: 'internal' },
+    maxBudgetUsd: 12,
+    budgetDuration: '1d',
+    rpmLimit: 10,
+    tpmLimit: 1000,
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ── Hooks: enqueue only, never call LiteLLM inline ──────────────────────────
+
+describe('createLiteLlmVirtualKeySyncAfterChangeHook', () => {
+  it('marks the key pending and enqueues a sync job on a key-relevant change', async () => {
+    const { req, update, queue } = reqWithJobs()
+
+    await createLiteLlmVirtualKeySyncAfterChangeHook(CFG)({
+      doc: activeDoc(),
+      previousDoc: undefined,
+      req,
+      context: {}
+    } as unknown as AfterChangeArgs)
+
+    expect(update.mock.calls[0]?.[0].data).toMatchObject({ litellmVirtualKeySyncStatus: 'pending' })
+    expect(queue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: LITELLM_SYNC_TASK_SLUG,
+        input: { agentId: '1' },
+        queue: LITELLM_SYNC_QUEUE
+      })
+    )
+  })
+
+  it('skips enqueue when already synced and nothing key-relevant changed', async () => {
+    const { req, queue } = reqWithJobs()
+    const doc = activeDoc({ litellmVirtualKeySyncStatus: 'synced' })
+
+    await createLiteLlmVirtualKeySyncAfterChangeHook(CFG)({
+      doc,
+      previousDoc: doc,
+      req,
+      context: {}
+    } as unknown as AfterChangeArgs)
+
+    expect(queue).not.toHaveBeenCalled()
+  })
+
+  it('re-enqueues an agent stuck in error even when nothing key-relevant changed', async () => {
+    const { req, queue } = reqWithJobs()
+    const doc = activeDoc({ litellmVirtualKeySyncStatus: 'error' })
+
+    await createLiteLlmVirtualKeySyncAfterChangeHook(CFG)({
+      doc,
+      previousDoc: doc,
+      req,
+      context: {}
+    } as unknown as AfterChangeArgs)
+
+    expect(queue).toHaveBeenCalled()
+  })
+})
+
+describe('createLiteLlmVirtualKeySyncAfterDeleteHook', () => {
+  it('enqueues a block job carrying the already-encrypted key', async () => {
+    const { req, queue } = reqWithJobs()
+    const encryptedKey = encrypt('sk-existing', 'test-secret')
+
+    await createLiteLlmVirtualKeySyncAfterDeleteHook()({
+      doc: activeDoc({ litellmVirtualKey: encryptedKey }),
+      req,
+      context: {}
+    } as unknown as AfterDeleteArgs)
+
+    expect(queue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: LITELLM_SYNC_TASK_SLUG,
+        input: { blockEncryptedKey: encryptedKey, slug: 'bastos' }
+      })
+    )
+  })
+})
+
+describe('createLiteLlmVirtualKeySyncBeforeDeleteHook', () => {
+  it('captures the key so afterDelete still blocks it when afterRead stripped the doc', async () => {
+    const queue = vi.fn().mockResolvedValue({})
+    // With internalAgentRead the afterRead hook returns the DECRYPTED key.
+    const findByID = vi.fn().mockResolvedValue(activeDoc({ litellmVirtualKey: 'sk-existing' }))
+    const req = { payload: { jobs: { queue }, findByID }, context: {} }
+
+    await createLiteLlmVirtualKeySyncBeforeDeleteHook(CFG)({
+      id: 1,
+      req,
+      context: {}
+    } as unknown as BeforeDeleteArgs)
+
+    // The deleted doc no longer carries the secret (non-superadmin delete).
+    await createLiteLlmVirtualKeySyncAfterDeleteHook()({
+      doc: activeDoc({ litellmVirtualKey: undefined }),
+      req,
+      context: {}
+    } as unknown as AfterDeleteArgs)
+
+    expect(findByID).toHaveBeenCalledWith(
+      expect.objectContaining({ context: { internalAgentRead: true }, overrideAccess: true })
+    )
+    const enqueued = queue.mock.calls[0]?.[0]
+    expect(enqueued).toMatchObject({
+      task: LITELLM_SYNC_TASK_SLUG,
+      input: expect.objectContaining({ slug: 'bastos' })
+    })
+    expect(decrypt(enqueued.input.blockEncryptedKey, 'test-secret')).toBe('sk-existing')
+  })
+})
+
+// ── syncAgentRecord: the actual LiteLLM reconciliation run by the task ───────
+
+describe('syncAgentRecord', () => {
+  it('generates and stores an encrypted virtual key for an active agent', async () => {
+    const fetchMock = stubFetch({ key: 'sk-generated' })
+    const update = vi.fn().mockResolvedValue({})
+
+    await syncAgentRecord(clientFor(CFG), { update } as unknown as SyncPayload, CFG, activeDoc() as SyncRecord)
+
+    expect(fetchMock).toHaveBeenCalledWith('http://litellm:4000/key/generate', expect.any(Object))
+    const persisted = update.mock.calls[0]?.[0]
+    expect(persisted.data.litellmVirtualKeyAlias).toBe('agent/bastos')
+    expect(persisted.data.litellmVirtualKeySyncStatus).toBe('synced')
+    expect(decrypt(persisted.data.litellmVirtualKey, 'test-secret')).toBe('sk-generated')
+  })
+
+  it('updates an existing virtual key when one is present', async () => {
+    const fetchMock = stubFetch({})
+    const update = vi.fn().mockResolvedValue({})
+    const doc = activeDoc({ litellmVirtualKey: encrypt('sk-existing', 'test-secret') })
+
+    await syncAgentRecord(clientFor(CFG), { update } as unknown as SyncPayload, CFG, doc as SyncRecord)
+
+    expect(fetchMock).toHaveBeenCalledWith('http://litellm:4000/key/update', expect.any(Object))
+    expect(update.mock.calls[0]?.[0].data).toMatchObject({
+      litellmVirtualKeyAlias: 'agent/bastos',
+      litellmVirtualKeySyncStatus: 'synced',
+      litellmVirtualKeySyncError: null
+    })
+  })
+
+  it('blocks the existing key when the agent is disabled', async () => {
+    const fetchMock = stubFetch({})
+    const update = vi.fn().mockResolvedValue({})
+    const doc = activeDoc({ isActive: false, litellmVirtualKey: encrypt('sk-existing', 'test-secret') })
+
+    await syncAgentRecord(clientFor(CFG), { update } as unknown as SyncPayload, CFG, doc as SyncRecord)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://litellm:4000/key/block',
+      expect.objectContaining({ body: JSON.stringify({ key: 'sk-existing' }) })
+    )
+    expect(update.mock.calls[0]?.[0].data).toMatchObject({ litellmVirtualKeySyncStatus: 'blocked' })
+  })
+
+  it('persists disabled without calling LiteLLM when an inactive agent has no key', async () => {
+    const fetchMock = stubFetch({})
+    const update = vi.fn().mockResolvedValue({})
+    const doc = activeDoc({ isActive: false })
+
+    await syncAgentRecord(clientFor(CFG), { update } as unknown as SyncPayload, CFG, doc as SyncRecord)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(update.mock.calls[0]?.[0].data).toMatchObject({
+      litellmVirtualKeySyncStatus: 'disabled',
+      litellmVirtualKeySyncError: null
+    })
+  })
+
+  it('throws on LiteLLM failure so the job retries', async () => {
+    stubFetch({ error: 'bad gateway' }, false, 502)
+    const update = vi.fn().mockResolvedValue({})
+
+    await expect(
+      syncAgentRecord(clientFor(CFG), { update } as unknown as SyncPayload, CFG, activeDoc() as SyncRecord)
+    ).rejects.toThrow(/HTTP 502/)
+  })
+
+  it('treats a zero rpm/tpm/budget as unset rather than forwarding 0 to LiteLLM', async () => {
+    const fetchMock = stubFetch({ key: 'sk-generated' })
+    const update = vi.fn().mockResolvedValue({})
+    const doc = activeDoc({ rpmLimit: 0, tpmLimit: 0, maxBudgetUsd: 0 })
+
+    await syncAgentRecord(clientFor(CFG), { update } as unknown as SyncPayload, CFG, doc as SyncRecord)
+
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)
+    expect(body).not.toHaveProperty('rpm_limit')
+    expect(body).not.toHaveProperty('tpm_limit')
+    expect(body).not.toHaveProperty('max_budget')
+  })
+})
+
+// ── Startup reconcile: enqueue, don't sync inline ───────────────────────────
+
+describe('enqueueExistingLiteLlmVirtualKeySyncs', () => {
+  it('enqueues a sync job for each unsynced agent', async () => {
+    const find = vi.fn().mockResolvedValue({ docs: [activeDoc()], hasNextPage: false, nextPage: null })
+    const queue = vi.fn().mockResolvedValue({})
+
+    await enqueueExistingLiteLlmVirtualKeySyncs({ find, jobs: { queue } } as unknown as StartupPayload, CFG)
+
+    expect(find).toHaveBeenCalledWith(expect.objectContaining({ collection: 'agents', overrideAccess: true }))
+    expect(queue).toHaveBeenCalledWith(
+      expect.objectContaining({ task: LITELLM_SYNC_TASK_SLUG, input: { agentId: '1' }, queue: LITELLM_SYNC_QUEUE })
+    )
+  })
+
+  it('paginates through every agent when there is more than one page', async () => {
+    const find = vi
+      .fn()
+      .mockResolvedValueOnce({ docs: [activeDoc({ id: 1 })], hasNextPage: true, nextPage: 2 })
+      .mockResolvedValueOnce({ docs: [activeDoc({ id: 2, slug: 'mises' })], hasNextPage: false, nextPage: null })
+    const queue = vi.fn().mockResolvedValue({})
+
+    await enqueueExistingLiteLlmVirtualKeySyncs({ find, jobs: { queue } } as unknown as StartupPayload, CFG)
+
+    expect(find).toHaveBeenCalledTimes(2)
+    expect(find).toHaveBeenNthCalledWith(2, expect.objectContaining({ page: 2 }))
+    expect(queue).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/payload-agents-core/src/collections/hooks/sync-litellm-virtual-key.ts
+++ b/packages/payload-agents-core/src/collections/hooks/sync-litellm-virtual-key.ts
@@ -1,0 +1,442 @@
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+  CollectionBeforeDeleteHook,
+  PayloadRequest
+} from 'payload'
+import { decrypt, encrypt, isEncrypted } from '../../lib/encryption'
+import { LiteLlmAdminClient, type LiteLlmVirtualKeyPayload } from '../../lib/litellm-admin'
+import type { ResolvedPluginConfig } from '../../types'
+
+const SKIP_CONTEXT_KEY = 'skipLiteLlmVirtualKeySync'
+const SKIP_RELOAD_CONTEXT_KEY = 'skipAgentRuntimeReload'
+// Carries deleted agents' (re-encrypted) virtual keys from beforeDelete to
+// afterDelete, keyed by agent id. afterRead strips the secret for non-superadmin
+// callers, so the afterDelete doc alone can't be trusted to block the key; the
+// map (rather than a single value) keeps bulk deletes from clobbering each other.
+const PENDING_BLOCK_KEY_CONTEXT = 'litellmVirtualKeyPendingBlock'
+
+/** Dedicated queue so virtual-key jobs never starve behind the host's jobs. */
+export const LITELLM_SYNC_QUEUE = 'litellm-sync'
+/** Task slug — kept in one place so the hook, the task and the plugin agree. */
+export const LITELLM_SYNC_TASK_SLUG = 'syncLiteLlmVirtualKey'
+
+/** Agent fields that change the LiteLLM virtual key and warrant a re-sync. */
+const KEY_RELEVANT_FIELDS = [
+  'slug',
+  'llmModel',
+  'isActive',
+  'maxBudgetUsd',
+  'budgetDuration',
+  'rpmLimit',
+  'tpmLimit'
+] as const
+
+type AgentRecord = Record<string, unknown>
+type PayloadApi = PayloadRequest['payload']
+
+/**
+ * Input accepted by the `syncLiteLlmVirtualKey` task. Either reconcile a live
+ * agent by id, or block a key whose agent was deleted (the doc is gone, so the
+ * already-encrypted key value travels in the job payload).
+ */
+export interface LiteLlmSyncJobInput {
+  agentId?: string
+  blockEncryptedKey?: string
+  slug?: string
+}
+
+function readString(record: AgentRecord, key: string): string | undefined {
+  const value = record[key]
+  return typeof value === 'string' && value ? value : undefined
+}
+
+function readNumber(record: AgentRecord, key: string): number | undefined {
+  const value = record[key]
+  // Treat 0 / negatives as 'unset': forwarding rpm_limit:0 to LiteLLM pins the
+  // key to 0 req/min (a self-inflicted outage), and negatives are invalid.
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value
+  return undefined
+}
+
+function readTenantSlug(record: AgentRecord): string | undefined {
+  const tenant = record.tenant
+  if (!tenant || typeof tenant !== 'object') return undefined
+  const slug = (tenant as Record<string, unknown>).slug
+  return typeof slug === 'string' && slug ? slug : undefined
+}
+
+export function decryptMaybe(value: string | undefined, encryptionKey: string | undefined): string | undefined {
+  if (!value) return undefined
+  if (!encryptionKey || !isEncrypted(value)) return value
+  return decrypt(value, encryptionKey)
+}
+
+function fingerprint(key: string): string {
+  return key.slice(-4)
+}
+
+function keyAlias(slug: string): string {
+  return `agent/${slug}`
+}
+
+function buildPayload(doc: AgentRecord, slug: string): LiteLlmVirtualKeyPayload {
+  const model = readString(doc, 'llmModel')
+  if (!model) throw new Error(`agent ${slug} missing llmModel`)
+  return {
+    keyAlias: keyAlias(slug),
+    models: [model],
+    metadata: {
+      source: 'payload',
+      agentId: doc.id,
+      agentSlug: slug,
+      tenantSlug: readTenantSlug(doc)
+    },
+    maxBudget: readNumber(doc, 'maxBudgetUsd'),
+    budgetDuration: readString(doc, 'budgetDuration'),
+    rpmLimit: readNumber(doc, 'rpmLimit'),
+    tpmLimit: readNumber(doc, 'tpmLimit')
+  }
+}
+
+async function persistSyncState(
+  payload: PayloadApi,
+  config: ResolvedPluginConfig,
+  id: unknown,
+  data: Record<string, unknown>,
+  req?: PayloadRequest
+): Promise<void> {
+  await payload.update({
+    collection: config.collectionSlug,
+    id: id as string | number,
+    data,
+    overrideAccess: true,
+    req,
+    context: {
+      [SKIP_CONTEXT_KEY]: true,
+      [SKIP_RELOAD_CONTEXT_KEY]: true
+    }
+  })
+}
+
+/**
+ * Persist a terminal sync failure on the agent. Called from the job's `onFail`
+ * once all retries are exhausted, so an agent whose key never minted lands in
+ * 'error' instead of being stuck 'pending' forever.
+ */
+export async function persistSyncError(
+  payload: PayloadApi,
+  config: ResolvedPluginConfig,
+  id: unknown,
+  message: string,
+  req?: PayloadRequest
+): Promise<void> {
+  await persistSyncState(
+    payload,
+    config,
+    id,
+    { litellmVirtualKeySyncStatus: 'error', litellmVirtualKeySyncError: message },
+    req
+  )
+}
+
+export function clientFor(config: ResolvedPluginConfig): LiteLlmAdminClient {
+  const { gatewayUrl, masterKey } = config.modelCatalog
+  return new LiteLlmAdminClient({ gatewayUrl, masterKey })
+}
+
+async function syncDisabledAgent(
+  client: LiteLlmAdminClient,
+  payload: PayloadApi,
+  config: ResolvedPluginConfig,
+  id: unknown,
+  existingKey: string | undefined,
+  req?: PayloadRequest
+): Promise<void> {
+  if (existingKey) await client.blockKey(existingKey)
+  await persistSyncState(
+    payload,
+    config,
+    id,
+    {
+      litellmVirtualKeySyncStatus: existingKey ? 'blocked' : 'disabled',
+      litellmVirtualKeySyncedAt: new Date().toISOString(),
+      litellmVirtualKeySyncError: null
+    },
+    req
+  )
+}
+
+async function syncActiveAgent(
+  client: LiteLlmAdminClient,
+  payloadApi: PayloadApi,
+  config: ResolvedPluginConfig,
+  id: unknown,
+  record: AgentRecord,
+  slug: string,
+  existingKey: string | undefined,
+  req?: PayloadRequest
+): Promise<void> {
+  const payload = buildPayload(record, slug)
+  if (existingKey) {
+    await client.updateKey(existingKey, payload)
+    await persistSyncState(
+      payloadApi,
+      config,
+      id,
+      {
+        litellmVirtualKeyAlias: payload.keyAlias,
+        litellmVirtualKeyFingerprint: fingerprint(existingKey),
+        litellmVirtualKeySyncStatus: 'synced',
+        litellmVirtualKeySyncedAt: new Date().toISOString(),
+        litellmVirtualKeySyncError: null
+      },
+      req
+    )
+    return
+  }
+
+  const generated = await client.generateKey(payload)
+  const storedKey = config.encryptionKey ? encrypt(generated.key, config.encryptionKey) : generated.key
+  try {
+    await persistSyncState(
+      payloadApi,
+      config,
+      id,
+      {
+        litellmVirtualKey: storedKey,
+        litellmVirtualKeyAlias: payload.keyAlias,
+        litellmVirtualKeyFingerprint: fingerprint(generated.key),
+        litellmVirtualKeySyncStatus: 'synced',
+        litellmVirtualKeySyncedAt: new Date().toISOString(),
+        litellmVirtualKeySyncError: null
+      },
+      req
+    )
+  } catch (persistError) {
+    // The key was already minted in LiteLLM but we failed to record it on the
+    // agent. Block it so the job retry doesn't leave an orphaned active key,
+    // then rethrow so the retry mints a fresh one against a clean state.
+    await client.blockKey(generated.key).catch(() => {})
+    throw persistError
+  }
+}
+
+/**
+ * Reconcile one agent's LiteLLM virtual key against its current Payload state.
+ *
+ * Pure side-effecting worker shared by the job handler and the startup
+ * reconcile. Throws on LiteLLM failure so the caller (the job) can retry.
+ * Returns `false` when the record carries no id/slug to act on.
+ */
+export async function syncAgentRecord(
+  client: LiteLlmAdminClient,
+  payload: PayloadApi,
+  config: ResolvedPluginConfig,
+  record: AgentRecord,
+  req?: PayloadRequest
+): Promise<boolean> {
+  const id = record.id
+  const slug = readString(record, 'slug')
+  if (!id || !slug) return false
+
+  const existingKey = decryptMaybe(readString(record, 'litellmVirtualKey'), config.encryptionKey)
+  if (record.isActive === false) {
+    if (!existingKey) {
+      await persistSyncState(
+        payload,
+        config,
+        id,
+        { litellmVirtualKeySyncStatus: 'disabled', litellmVirtualKeySyncError: null },
+        req
+      )
+      return true
+    }
+    await syncDisabledAgent(client, payload, config, id, existingKey, req)
+    return true
+  }
+
+  await syncActiveAgent(client, payload, config, id, record, slug, existingKey, req)
+  return true
+}
+
+// ── Enqueue helpers ─────────────────────────────────────────────────────────
+
+interface QueueJobArgs {
+  task: string
+  input: LiteLlmSyncJobInput
+  queue?: string
+  req?: PayloadRequest
+}
+
+/**
+ * Bridge to `payload.jobs.queue`. Inside the isolated package `TypedJobs` is
+ * empty, so the typed `queue()` narrows `task` to `never`; we cast the function
+ * to a string-slug signature in one place rather than at every call site.
+ */
+async function queueJob(payload: PayloadApi, args: QueueJobArgs): Promise<void> {
+  const enqueue = payload.jobs.queue as unknown as (a: QueueJobArgs) => Promise<unknown>
+  await enqueue({ ...args, queue: args.queue ?? LITELLM_SYNC_QUEUE })
+}
+
+async function enqueueSync(payload: PayloadApi, agentId: string, req?: PayloadRequest): Promise<void> {
+  await queueJob(payload, { task: LITELLM_SYNC_TASK_SLUG, input: { agentId }, req })
+}
+
+function keyRelevantChanged(doc: AgentRecord, previous: AgentRecord | undefined): boolean {
+  if (!previous) return true
+  return KEY_RELEVANT_FIELDS.some(field => doc[field] !== previous[field])
+}
+
+export function createLiteLlmVirtualKeySyncAfterChangeHook(config: ResolvedPluginConfig): CollectionAfterChangeHook {
+  return async ({ context, doc, previousDoc, req }) => {
+    if (context?.[SKIP_CONTEXT_KEY] === true) return doc
+
+    const record = doc as AgentRecord
+    const id = record.id
+    const slug = readString(record, 'slug')
+    if (!id || !slug) return doc
+
+    // Skip when nothing key-relevant changed and the key is already synced —
+    // editing the name shouldn't re-mint the LiteLLM key. Anything not yet
+    // 'synced' still gets re-enqueued so transient failures self-heal.
+    const status = readString(record, 'litellmVirtualKeySyncStatus')
+    if (status === 'synced' && !keyRelevantChanged(record, previousDoc as AgentRecord | undefined)) {
+      return doc
+    }
+
+    try {
+      await persistSyncState(req.payload, config, id, { litellmVirtualKeySyncStatus: 'pending' }, req)
+      await enqueueSync(req.payload, String(id), req)
+    } catch (error) {
+      // Enqueue failures must never block the agent write — the startup
+      // reconcile will pick the agent up on the next boot.
+      const message = error instanceof Error ? error.message : 'Unknown enqueue error'
+      console.warn(`[Agents] Failed to enqueue LiteLLM virtual key sync for "${slug}":`, message)
+    }
+    return doc
+  }
+}
+
+/**
+ * Capture the agent's virtual key *before* it is deleted. `afterRead` strips
+ * `litellmVirtualKey` for non-superadmin / non-internal callers, so by the time
+ * the afterDelete hook runs the doc no longer carries it — and the key would be
+ * left active in LiteLLM (orphaned, billable). Read it with internal access and
+ * stash the re-encrypted value on the request context, keyed by id.
+ */
+export function createLiteLlmVirtualKeySyncBeforeDeleteHook(config: ResolvedPluginConfig): CollectionBeforeDeleteHook {
+  return async ({ context, id, req }) => {
+    if (context?.[SKIP_CONTEXT_KEY] === true) return
+
+    try {
+      const agent = await req.payload.findByID({
+        collection: config.collectionSlug,
+        id,
+        depth: 0,
+        overrideAccess: true,
+        disableErrors: true,
+        context: { internalAgentRead: true }
+      })
+      const plaintextKey = agent
+        ? decryptMaybe(readString(agent as AgentRecord, 'litellmVirtualKey'), config.encryptionKey)
+        : undefined
+      if (!plaintextKey) return
+      const encryptedKey = config.encryptionKey ? encrypt(plaintextKey, config.encryptionKey) : plaintextKey
+      const ctx = req.context as Record<string, unknown>
+      const pending = (ctx[PENDING_BLOCK_KEY_CONTEXT] as Record<string, string> | undefined) ?? {}
+      pending[String(id)] = encryptedKey
+      ctx[PENDING_BLOCK_KEY_CONTEXT] = pending
+    } catch (error) {
+      // Best-effort: afterDelete falls back to the (possibly stripped) doc.
+      const message = error instanceof Error ? error.message : 'Unknown read error'
+      console.warn('[Agents] Failed to capture LiteLLM virtual key before delete:', message)
+    }
+  }
+}
+
+export function createLiteLlmVirtualKeySyncAfterDeleteHook(): CollectionAfterDeleteHook {
+  return async ({ context, doc, req }) => {
+    if (context?.[SKIP_CONTEXT_KEY] === true) return doc
+
+    const record = doc as AgentRecord
+    const slug = readString(record, 'slug')
+    // Prefer the key captured by beforeDelete (afterRead strips it from the doc
+    // for non-superadmin callers); fall back to the doc for internal/super-admin
+    // deletes where it's still present. The agent row is gone, so the
+    // already-encrypted value travels in the job and the handler decrypts it.
+    const pending = (req.context as Record<string, unknown> | undefined)?.[PENDING_BLOCK_KEY_CONTEXT] as
+      | Record<string, string>
+      | undefined
+    const encryptedKey = pending?.[String(record.id)] ?? readString(record, 'litellmVirtualKey')
+    if (!encryptedKey) return doc
+
+    try {
+      await queueJob(req.payload, {
+        task: LITELLM_SYNC_TASK_SLUG,
+        input: { blockEncryptedKey: encryptedKey, slug },
+        req
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unknown enqueue error'
+      console.warn(
+        `[Agents] Failed to enqueue LiteLLM virtual key block for deleted agent "${slug ?? 'unknown'}":`,
+        message
+      )
+    }
+    return doc
+  }
+}
+
+export function shouldSkipAgentRuntimeReload(context: Record<string, unknown> | undefined): boolean {
+  return context?.[SKIP_RELOAD_CONTEXT_KEY] === true
+}
+
+/**
+ * Startup reconcile — enqueue a sync job for every agent that isn't already in
+ * a resolved ('synced'/'blocked'/'disabled') state. Cheap and idempotent: the
+ * jobs run on the `litellm-sync` queue after boot, so a LiteLLM outage during
+ * startup no longer blocks the whole boot and self-heals once it recovers.
+ */
+export async function enqueueExistingLiteLlmVirtualKeySyncs(
+  payload: PayloadApi,
+  config: ResolvedPluginConfig
+): Promise<void> {
+  let page = 1
+  let queued = 0
+
+  while (true) {
+    const result = await payload.find({
+      collection: config.collectionSlug,
+      depth: 0,
+      limit: 100,
+      page,
+      overrideAccess: true,
+      where: {
+        or: [
+          { litellmVirtualKeySyncStatus: { in: ['pending', 'error'] } },
+          { litellmVirtualKeySyncStatus: { exists: false } }
+        ]
+      }
+    })
+
+    for (const doc of result.docs as AgentRecord[]) {
+      const id = doc.id
+      if (!id) continue
+      try {
+        await enqueueSync(payload, String(id))
+        queued += 1
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown enqueue error'
+        console.warn('[Agents] Failed to enqueue startup LiteLLM virtual key sync:', message)
+      }
+    }
+
+    if (!result.hasNextPage || !result.nextPage) break
+    page = result.nextPage
+  }
+
+  if (queued) {
+    console.info(`[Agents] LiteLLM virtual key startup reconcile enqueued ${queued} sync job(s)`)
+  }
+}

--- a/packages/payload-agents-core/src/collections/hooks/validate-model.spec.ts
+++ b/packages/payload-agents-core/src/collections/hooks/validate-model.spec.ts
@@ -32,11 +32,6 @@ afterEach(() => {
 })
 
 describe('createModelCatalogValidateHook', () => {
-  it('is a no-op when no catalog is configured', async () => {
-    const data = { llmModel: 'whatever/model' }
-    await expect(run(configWith(undefined), { data, operation: 'create' })).resolves.toBe(data)
-  })
-
   it('rejects a create with a model outside the catalog', async () => {
     stubFetch()
     await expect(
@@ -76,10 +71,9 @@ describe('createModelCatalogValidateHook', () => {
     ).rejects.toThrow(/requires one/)
   })
 
-  it('fails closed with a clear error when the gateway is down', async () => {
+  it('skips validation (never blocks the write) when the gateway is down', async () => {
     stubFetch({}, false, 502)
-    await expect(run(CFG, { data: { llmModel: 'chat-premium' }, operation: 'create' })).rejects.toThrow(
-      /catalog unavailable/i
-    )
+    const data = { llmModel: 'chat-premium' }
+    await expect(run(CFG, { data, operation: 'create' })).resolves.toBe(data)
   })
 })

--- a/packages/payload-agents-core/src/collections/hooks/validate-model.ts
+++ b/packages/payload-agents-core/src/collections/hooks/validate-model.ts
@@ -20,14 +20,15 @@ function readString(record: unknown, key: string): string | undefined {
   return typeof value === 'string' ? value : undefined
 }
 
-async function loadCatalog(settings: ModelCatalogSettings): Promise<ModelPreset[]> {
+async function loadCatalog(settings: ModelCatalogSettings): Promise<ModelPreset[] | null> {
   try {
     return await fetchModelCatalog(settings)
   } catch {
-    throw new APIError(
-      'Model catalog unavailable — cannot validate the agent against the gateway. Try again in a moment.',
-      503
-    )
+    // Don't couple the agent write to LiteLLM uptime. If the catalog can't be
+    // reached (and isn't cached), skip validation rather than 503: the sync
+    // job reconciles the key afterwards, and the runtime is fail-closed — an
+    // agent referencing a bogus model simply won't load.
+    return null
   }
 }
 
@@ -52,7 +53,7 @@ function assertKeyMatchesPreset(preset: ModelPreset | undefined, apiKey: string)
 export function createModelCatalogValidateHook(config: ResolvedPluginConfig): CollectionBeforeValidateHook {
   return async ({ data, operation, originalDoc }) => {
     const catalog = config.modelCatalog
-    if (!catalog || !data) return data
+    if (!data) return data
 
     const model = readString(data, 'llmModel')
     const previousModel = readString(originalDoc, 'llmModel')
@@ -64,6 +65,12 @@ export function createModelCatalogValidateHook(config: ResolvedPluginConfig): Co
     if (!modelChanged && !keyProvided) return data
 
     const presets = await loadCatalog(catalog)
+    if (!presets) {
+      console.warn(
+        '[Agents] Model catalog unavailable — skipping model validation; the sync job will reconcile the key.'
+      )
+      return data
+    }
     if (modelChanged) assertPresetExists(presets, model)
 
     if (keyProvided && apiKey) {

--- a/packages/payload-agents-core/src/collections/jobs/sync-litellm-virtual-key-task.spec.ts
+++ b/packages/payload-agents-core/src/collections/jobs/sync-litellm-virtual-key-task.spec.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { encrypt } from '../../lib/encryption'
+import type { ResolvedPluginConfig } from '../../types'
+import { createSyncLiteLlmVirtualKeyTask } from './sync-litellm-virtual-key-task'
+
+const CFG = {
+  collectionSlug: 'agents',
+  encryptionKey: 'test-secret',
+  modelCatalog: { gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master', cacheTtlMs: 60_000 }
+} as ResolvedPluginConfig
+
+type OnFailArgs = Parameters<NonNullable<ReturnType<typeof createSyncLiteLlmVirtualKeyTask>['onFail']>>[0]
+
+function onFailWith(input: unknown, totalTried: number) {
+  const update = vi.fn().mockResolvedValue({})
+  const task = createSyncLiteLlmVirtualKeyTask(CFG)
+  const run = task.onFail?.({
+    input,
+    req: { payload: { update } },
+    taskStatus: { totalTried }
+  } as unknown as OnFailArgs)
+  return { update, run }
+}
+
+describe('createSyncLiteLlmVirtualKeyTask onFail', () => {
+  it('leaves the agent pending while retries remain', async () => {
+    const { update, run } = onFailWith({ agentId: '1' }, 3)
+    await run
+    expect(update).not.toHaveBeenCalled()
+  })
+
+  it('marks the agent error once retries are exhausted', async () => {
+    const { update, run } = onFailWith({ agentId: '1' }, 8)
+    await run
+    expect(update.mock.calls[0]?.[0].data).toMatchObject({
+      litellmVirtualKeySyncStatus: 'error',
+      litellmVirtualKeySyncError: expect.any(String)
+    })
+  })
+
+  it('ignores the block path (a deleted agent has no row to update)', async () => {
+    const { update, run } = onFailWith({ blockEncryptedKey: 'enc' }, 8)
+    await run
+    expect(update).not.toHaveBeenCalled()
+  })
+})
+
+function stubFetch(body: unknown = { key: 'sk-generated' }) {
+  const fn = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('createSyncLiteLlmVirtualKeyTask handler', () => {
+  function runHandler(input: unknown, req: unknown) {
+    const handler = createSyncLiteLlmVirtualKeyTask(CFG).handler as (a: {
+      input: unknown
+      req: unknown
+    }) => Promise<unknown>
+    return handler({ input, req })
+  }
+
+  it('notifies the runtime to reload once the key is synced', async () => {
+    stubFetch({ key: 'sk-generated' })
+    const execute = vi.fn().mockResolvedValue(undefined)
+    const update = vi.fn().mockResolvedValue({})
+    const findByID = vi.fn().mockResolvedValue({
+      id: 1,
+      slug: 'bastos',
+      isActive: true,
+      llmModel: 'chat-premium',
+      tenant: { slug: 'internal' }
+    })
+
+    await runHandler({ agentId: '1' }, { payload: { findByID, update, db: { drizzle: { execute } } } })
+
+    // pg_notify(agent_reload, 'bastos') emitted via drizzle after the mint
+    expect(execute).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload on the block path (the deleted agent already reloaded)', async () => {
+    stubFetch({})
+    const execute = vi.fn().mockResolvedValue(undefined)
+
+    await runHandler(
+      { blockEncryptedKey: encrypt('sk-existing', 'test-secret') },
+      { payload: { db: { drizzle: { execute } } } }
+    )
+
+    expect(execute).not.toHaveBeenCalled()
+  })
+})

--- a/packages/payload-agents-core/src/collections/jobs/sync-litellm-virtual-key-task.ts
+++ b/packages/payload-agents-core/src/collections/jobs/sync-litellm-virtual-key-task.ts
@@ -1,0 +1,91 @@
+/**
+ * Payload Jobs task that reconciles an agent's LiteLLM virtual key.
+ *
+ * The Agents `afterChange`/`afterDelete` hooks enqueue this task instead of
+ * calling LiteLLM inline, so saving an agent never waits on (nor fails with)
+ * the gateway. The handler throws on LiteLLM failure; Payload retries it with
+ * exponential backoff until the gateway recovers.
+ */
+
+import type { Field, TaskConfig } from 'payload'
+import type { ResolvedPluginConfig } from '../../types'
+import { notifyReload } from '../hooks/reload-runtime'
+import {
+  clientFor,
+  decryptMaybe,
+  LITELLM_SYNC_TASK_SLUG,
+  type LiteLlmSyncJobInput,
+  persistSyncError,
+  syncAgentRecord
+} from '../hooks/sync-litellm-virtual-key'
+
+const inputSchema: Field[] = [
+  { name: 'agentId', type: 'text' },
+  { name: 'blockEncryptedKey', type: 'text' },
+  { name: 'slug', type: 'text' }
+]
+
+// 8 attempts with exponential backoff from 10s (10s, 20s, 40s … ≈ 42 min total)
+// so a LiteLLM outage is ridden out instead of being left in 'error'.
+const SYNC_MAX_ATTEMPTS = 8
+
+type SyncTaskIO = { input: LiteLlmSyncJobInput; output: Record<string, never> }
+
+export function createSyncLiteLlmVirtualKeyTask(config: ResolvedPluginConfig): TaskConfig<SyncTaskIO> {
+  return {
+    slug: LITELLM_SYNC_TASK_SLUG,
+    label: 'Sync LiteLLM virtual key',
+    inputSchema,
+    // Serialize sync jobs per agent: two concurrent first-time syncs would
+    // otherwise both see "no key" and each mint one, orphaning a billable key.
+    // With an exclusive key the second job waits, then sees the first's key and
+    // updates instead of generating. Block jobs are idempotent — key separately.
+    concurrency: ({ input }) =>
+      input.agentId ? `agent:${input.agentId}` : `block:${input.blockEncryptedKey?.slice(-12) ?? 'unknown'}`,
+    retries: { attempts: SYNC_MAX_ATTEMPTS, backoff: { type: 'exponential', delay: 10_000 } },
+    // onFail fires on EVERY failed attempt; only write 'error' once retries are
+    // exhausted (Payload's own final-error condition is totalTried >= attempts)
+    // so the agent reads 'pending' while the gateway recovers, not a premature
+    // 'error'. The block path (deleted agent) has no agent row left to update.
+    onFail: async ({ input, req, taskStatus }) => {
+      const typed = input as LiteLlmSyncJobInput | undefined
+      if (!typed?.agentId) return
+      if ((taskStatus?.totalTried ?? 0) < SYNC_MAX_ATTEMPTS) return
+      await persistSyncError(req.payload, config, typed.agentId, 'LiteLLM virtual key sync failed after all retries')
+    },
+    handler: async ({ input, req }) => {
+      const client = clientFor(config)
+
+      // Block path — the agent was deleted, so its already-encrypted key rides
+      // in the job payload. Decrypt and block; LiteLLM failure throws → retry.
+      if (input.blockEncryptedKey) {
+        const key = decryptMaybe(input.blockEncryptedKey, config.encryptionKey)
+        if (key) await client.blockKey(key)
+        return { output: {} }
+      }
+
+      if (!input.agentId) return { output: {} }
+
+      const agent = await req.payload.findByID({
+        collection: config.collectionSlug,
+        id: input.agentId,
+        depth: 1,
+        overrideAccess: true,
+        disableErrors: true,
+        context: { internalAgentRead: true }
+      })
+      // Deleted between enqueue and run — the delete hook handles its own block.
+      if (!agent) return { output: {} }
+
+      // Throws on LiteLLM failure so Payload retries per `retries` above.
+      await syncAgentRecord(client, req.payload, config, agent as Record<string, unknown>, req)
+      // The agent's afterChange reload fired before this job minted the key, so
+      // build_agent failed and the runtime dropped the agent. Notify again now
+      // that the synced key is persisted — otherwise the agent stays fail-closed
+      // until the runtime's 5-minute periodic resync or a pod restart.
+      const slug = (agent as Record<string, unknown>).slug
+      if (typeof slug === 'string' && slug) await notifyReload(req.payload, slug)
+      return { output: {} }
+    }
+  }
+}

--- a/packages/payload-agents-core/src/endpoints/agents-internal-list.ts
+++ b/packages/payload-agents-core/src/endpoints/agents-internal-list.ts
@@ -1,7 +1,7 @@
 /**
  * GET /api/{collectionSlug}/internal/list — internal endpoint the agent
- * runtime calls to fetch all active agents (with decrypted apiKey + populated
- * tenant + populated retrieval profile at depth=2 so its
+ * runtime calls to fetch all active agents (with decrypted apiKey,
+ * litellmVirtualKey + populated tenant + populated retrieval profile at depth=2 so its
  * taxonomy/folder filters are inlined). Authenticated by `X-Internal-Secret`,
  * scoped to active agents, calls Payload's local API with `overrideAccess:
  * true` so the host's collection access can stay honestly user-scoped.
@@ -50,7 +50,7 @@ export function createAgentsInternalListHandler(config: ResolvedPluginConfig): P
 
     const where: Where = { isActive: { equals: true } }
 
-    // `context.internalAgentRead` tells the apiKey afterRead hook to decrypt;
+    // `context.internalAgentRead` tells the secret-field afterRead hook to decrypt;
     // `overrideAccess: true` skips the host's collection access (and the
     // populated tenant/taxonomies relations) so we don't need bypass branches
     // in the host's collection access functions.

--- a/packages/payload-agents-core/src/lib/litellm-admin.spec.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.spec.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LiteLlmAdminClient, type LiteLlmVirtualKeyPayload } from './litellm-admin'
+
+const PAYLOAD: LiteLlmVirtualKeyPayload = {
+  keyAlias: 'agent/bastos',
+  models: ['chat-premium'],
+  metadata: { source: 'payload', agentId: 1, agentSlug: 'bastos', tenantSlug: 'internal' },
+  maxBudget: 12,
+  budgetDuration: '1d',
+  rpmLimit: 10,
+  tpmLimit: 1000
+}
+
+function stubFetch(body: unknown = { ok: true }, ok = true, status = 200) {
+  const fn = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body))
+  })
+  vi.stubGlobal('fetch', fn)
+  return fn
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('LiteLlmAdminClient', () => {
+  it('generates a virtual key with LiteLLM snake_case fields', async () => {
+    const fetchMock = stubFetch({ key: 'sk-litellm-agent' })
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000/', masterKey: 'sk-master' })
+
+    await expect(client.generateKey(PAYLOAD)).resolves.toEqual({ key: 'sk-litellm-agent' })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://litellm:4000/key/generate',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sk-master',
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          key_alias: 'agent/bastos',
+          models: ['chat-premium'],
+          metadata: { source: 'payload', agentId: 1, agentSlug: 'bastos', tenantSlug: 'internal' },
+          max_budget: 12,
+          budget_duration: '1d',
+          rpm_limit: 10,
+          tpm_limit: 1000
+        })
+      })
+    )
+  })
+
+  it('updates an existing key by key value', async () => {
+    const fetchMock = stubFetch({})
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await client.updateKey('sk-existing', PAYLOAD)
+
+    expect(JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)).toMatchObject({
+      key: 'sk-existing',
+      key_alias: 'agent/bastos',
+      models: ['chat-premium']
+    })
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('http://litellm:4000/key/update')
+  })
+
+  it('clears unset limits with null on update but omits them on generate', async () => {
+    const fetchMock = stubFetch({ key: 'sk-generated' })
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+    const noLimits: LiteLlmVirtualKeyPayload = { keyAlias: 'agent/bastos', models: ['chat-premium'], metadata: {} }
+
+    await client.generateKey(noLimits)
+    const genBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string)
+    expect(genBody).not.toHaveProperty('max_budget')
+    expect(genBody).not.toHaveProperty('rpm_limit')
+
+    await client.updateKey('sk-existing', noLimits)
+    const updBody = JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)
+    expect(updBody.max_budget).toBeNull()
+    expect(updBody.budget_duration).toBeNull()
+    expect(updBody.rpm_limit).toBeNull()
+    expect(updBody.tpm_limit).toBeNull()
+  })
+
+  it('blocks an existing key', async () => {
+    const fetchMock = stubFetch({})
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await client.blockKey('sk-existing')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://litellm:4000/key/block',
+      expect.objectContaining({ body: JSON.stringify({ key: 'sk-existing' }) })
+    )
+  })
+
+  it('throws on non-OK responses', async () => {
+    stubFetch({ error: 'bad' }, false, 502)
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await expect(client.blockKey('sk-existing')).rejects.toThrow('HTTP 502')
+  })
+
+  it('lists model names from /model/info', async () => {
+    stubFetch({ data: [{ model_name: 'chat-premium' }, { model_name: 123 }, { model_name: 'economico' }] })
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await expect(client.listModelNames()).resolves.toEqual(new Set(['chat-premium', 'economico']))
+  })
+
+  it('creates a model with /model/new', async () => {
+    const fetchMock = stubFetch({})
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await client.createModel({
+      modelName: 'chat-premium',
+      model: 'anthropic/claude-sonnet-4-6',
+      modelInfo: { requires_key: 'anthropic', catalog_tier: 'premium' }
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://litellm:4000/model/new',
+      expect.objectContaining({
+        body: JSON.stringify({
+          model_name: 'chat-premium',
+          litellm_params: { model: 'anthropic/claude-sonnet-4-6' },
+          model_info: { requires_key: 'anthropic', catalog_tier: 'premium' }
+        })
+      })
+    )
+  })
+
+  it('bootstraps only missing models', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: [{ model_name: 'chat-premium' }] }),
+        text: () => Promise.resolve('')
+      })
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('')
+      })
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await expect(
+      client.bootstrapModels([
+        { modelName: 'chat-premium', model: 'anthropic/claude-sonnet-4-6' },
+        { modelName: 'economico', model: 'gemini/gemini-2.5-flash' }
+      ])
+    ).resolves.toEqual({ created: 1, existing: 1 })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('http://litellm:4000/model/new')
+    expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).toMatchObject({
+      model_name: 'economico'
+    })
+  })
+})

--- a/packages/payload-agents-core/src/lib/litellm-admin.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.ts
@@ -1,0 +1,123 @@
+export interface LiteLlmAdminSettings {
+  gatewayUrl: string
+  masterKey: string
+}
+
+export interface LiteLlmVirtualKeyPayload {
+  keyAlias: string
+  models: string[]
+  metadata: Record<string, unknown>
+  maxBudget?: number
+  budgetDuration?: string
+  rpmLimit?: number
+  tpmLimit?: number
+}
+
+export interface LiteLlmGeneratedKey {
+  key: string
+}
+
+export interface LiteLlmModelPayload {
+  modelName: string
+  model: string
+  modelInfo?: Record<string, unknown>
+}
+
+function toApiPayload(payload: LiteLlmVirtualKeyPayload, key?: string): Record<string, unknown> {
+  const isUpdate = key !== undefined
+  const result: Record<string, unknown> = {
+    ...(key ? { key } : {}),
+    key_alias: payload.keyAlias,
+    models: payload.models,
+    metadata: payload.metadata
+  }
+  // On update, an unset limit becomes explicit null so LiteLLM clears a
+  // previously-set value — /key/update is a partial PATCH, so an omitted field
+  // would otherwise keep the old limit live. On generate, an unset limit is
+  // simply omitted.
+  const limits: Record<string, number | string | undefined> = {
+    max_budget: payload.maxBudget,
+    budget_duration: payload.budgetDuration || undefined,
+    rpm_limit: payload.rpmLimit,
+    tpm_limit: payload.tpmLimit
+  }
+  for (const [apiField, value] of Object.entries(limits)) {
+    if (value !== undefined) result[apiField] = value
+    else if (isUpdate) result[apiField] = null
+  }
+  return result
+}
+
+function toModelApiPayload(payload: LiteLlmModelPayload): Record<string, unknown> {
+  return {
+    model_name: payload.modelName,
+    litellm_params: { model: payload.model },
+    ...(payload.modelInfo ? { model_info: payload.modelInfo } : {})
+  }
+}
+
+export class LiteLlmAdminClient {
+  private readonly gatewayUrl: string
+  private readonly masterKey: string
+
+  constructor(settings: LiteLlmAdminSettings) {
+    this.gatewayUrl = settings.gatewayUrl.replace(/\/$/, '')
+    this.masterKey = settings.masterKey
+  }
+
+  private async request<T>(path: string, body?: Record<string, unknown>, method = 'POST'): Promise<T> {
+    const res = await fetch(`${this.gatewayUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.masterKey}`,
+        'Content-Type': 'application/json'
+      },
+      ...(body ? { body: JSON.stringify(body) } : {})
+    })
+    if (!res.ok) {
+      const message = await res.text().catch(() => '')
+      throw new Error(`LiteLLM ${path} failed: HTTP ${res.status}${message ? ` ${message}` : ''}`)
+    }
+    return (await res.json()) as T
+  }
+
+  async generateKey(payload: LiteLlmVirtualKeyPayload): Promise<LiteLlmGeneratedKey> {
+    const body = await this.request<Record<string, unknown>>('/key/generate', toApiPayload(payload))
+    const key = body.key
+    if (typeof key !== 'string' || !key) throw new Error('LiteLLM /key/generate did not return a key')
+    return { key }
+  }
+
+  async updateKey(key: string, payload: LiteLlmVirtualKeyPayload): Promise<void> {
+    await this.request<Record<string, unknown>>('/key/update', toApiPayload(payload, key))
+  }
+
+  async blockKey(key: string): Promise<void> {
+    await this.request<Record<string, unknown>>('/key/block', { key })
+  }
+
+  async listModelNames(): Promise<Set<string>> {
+    const body = await this.request<{ data?: Array<{ model_name?: unknown }> }>('/model/info', undefined, 'GET')
+    const names = new Set<string>()
+    for (const item of body.data ?? []) {
+      if (typeof item.model_name === 'string') names.add(item.model_name)
+    }
+    return names
+  }
+
+  async createModel(payload: LiteLlmModelPayload): Promise<void> {
+    await this.request<Record<string, unknown>>('/model/new', toModelApiPayload(payload))
+  }
+
+  async bootstrapModels(models: LiteLlmModelPayload[]): Promise<{ created: number; existing: number }> {
+    const existingModels = await this.listModelNames()
+    let created = 0
+    for (const model of models) {
+      if (existingModels.has(model.modelName)) continue
+      await this.createModel(model)
+      existingModels.add(model.modelName)
+      created += 1
+    }
+    return { created, existing: existingModels.size - created }
+  }
+}

--- a/packages/payload-agents-core/src/lib/model-catalog.ts
+++ b/packages/payload-agents-core/src/lib/model-catalog.ts
@@ -1,11 +1,11 @@
 /**
  * Model catalog backed by a LiteLLM gateway.
  *
- * The gateway's config (`model_list` with named presets plus `model_info`
- * metadata) is the single source of truth for which models agents may use.
- * This module fetches `/model/info`, normalises it into presets and caches
- * the result briefly so the admin select and the validation hook don't hit
- * the gateway on every call.
+ * The LiteLLM gateway catalog is the source of truth for which models agents
+ * may use. In config mode it is backed by `model_list`; in DB mode it is backed
+ * by LiteLLM DB/Admin UI. This module fetches `/model/info`, normalises it into
+ * presets and caches the result briefly so the admin select and the validation
+ * hook don't hit the gateway on every call.
  */
 
 export interface ModelPreset {

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -6,6 +6,8 @@
 
 import type { Config, Plugin } from 'payload'
 import { createAgentsCollection } from './collections/agents'
+import { enqueueExistingLiteLlmVirtualKeySyncs, LITELLM_SYNC_QUEUE } from './collections/hooks/sync-litellm-virtual-key'
+import { createSyncLiteLlmVirtualKeyTask } from './collections/jobs/sync-litellm-virtual-key-task'
 import { createAgentsInternalListHandler } from './endpoints/agents-internal-list'
 import { createAgentsListHandler } from './endpoints/agents-list'
 import { createChatHandler } from './endpoints/chat'
@@ -16,10 +18,45 @@ import { createUsageHandler } from './endpoints/usage'
 import { defaultBuildSessionId, defaultValidateSessionOwnership } from './lib/session-id'
 import type { AgentPluginConfig, ResolvedPluginConfig } from './types'
 
+type Endpoints = NonNullable<Config['endpoints']>
+type JobsConfig = NonNullable<Config['jobs']>
+type AutoRunConfig = NonNullable<JobsConfig['autoRun']>
+type AutorunCronConfig = Extract<AutoRunConfig, unknown[]>[number]
+
+function mergeAutoRun(incoming: JobsConfig['autoRun'], additions: AutorunCronConfig[]): AutoRunConfig {
+  if (!incoming) return additions
+  if (Array.isArray(incoming)) return [...incoming, ...additions]
+  // Host configured autoRun as a function — compose so both still run.
+  return async payload => [...(await incoming(payload)), ...additions]
+}
+
+/**
+ * Merge the LiteLLM virtual-key sync task + its autoRun into the host's jobs
+ * config. The task runs on a dedicated `litellm-sync` queue scanned every
+ * minute (up to 20 jobs), so it never competes with the host's own jobs.
+ */
+function buildLiteLlmJobs(incoming: JobsConfig | undefined, config: ResolvedPluginConfig): JobsConfig {
+  const tasks = [...(incoming?.tasks ?? []), createSyncLiteLlmVirtualKeyTask(config)]
+  const autoRun: AutorunCronConfig[] = [{ queue: LITELLM_SYNC_QUEUE, cron: '* * * * *', limit: 20 }]
+  // Required by the sync task's `concurrency` key — adds the `concurrencyKey`
+  // column to payload_jobs (see migration) so per-agent jobs run exclusively.
+  return { ...incoming, tasks, autoRun: mergeAutoRun(incoming?.autoRun, autoRun), enableConcurrencyControl: true }
+}
+
 function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
   const runtimeSecret = userConfig.runtimeSecret ?? ''
   if (!runtimeSecret) {
     console.warn('[agent-plugin] runtimeSecret is empty — all runtime requests will be unauthenticated')
+  }
+  const gatewayUrl = userConfig.modelCatalog.gatewayUrl.replace(/\/$/, '')
+  const masterKey = userConfig.modelCatalog.masterKey ?? ''
+  // LiteLLM is a hard dependency: an empty admin key would make every /key
+  // management call go out as `Bearer ` → 401 → every sync silently fails closed.
+  // Fail fast at boot with a clear error instead of degrading invisibly.
+  if (!gatewayUrl || !masterKey) {
+    throw new Error(
+      '[agent-plugin] modelCatalog.gatewayUrl and masterKey are required — LiteLLM is a hard dependency; the admin key mints per-agent virtual keys (set LITELLM_GATEWAY_URL / LITELLM_MASTER_KEY)'
+    )
   }
   return {
     runtimeUrl: userConfig.runtimeUrl,
@@ -34,13 +71,11 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
     mediaCollectionSlug: userConfig.mediaCollectionSlug,
     collectionOverrides: userConfig.collectionOverrides,
     onRunCompleted: userConfig.onRunCompleted,
-    modelCatalog: userConfig.modelCatalog
-      ? {
-          gatewayUrl: userConfig.modelCatalog.gatewayUrl.replace(/\/$/, ''),
-          masterKey: userConfig.modelCatalog.masterKey ?? '',
-          cacheTtlMs: userConfig.modelCatalog.cacheTtlMs ?? 60_000
-        }
-      : undefined
+    modelCatalog: {
+      gatewayUrl,
+      masterKey,
+      cacheTtlMs: userConfig.modelCatalog.cacheTtlMs ?? 60_000
+    }
   }
 }
 
@@ -53,10 +88,15 @@ function assertCollectionExists(config: Config, slug: string, configField: strin
   }
 }
 
+function endpointList(endpoints: false | Endpoints | undefined): Endpoints {
+  return Array.isArray(endpoints) ? endpoints : []
+}
+
 export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
   return (incomingConfig: Config): Config => {
     const config = resolveConfig(userConfig)
     const basePath = config.basePath
+    const incomingOnInit = incomingConfig.onInit
 
     assertCollectionExists(incomingConfig, config.mediaCollectionSlug, 'mediaCollectionSlug')
 
@@ -65,7 +105,7 @@ export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
     // bypass that lived in the host's collection access functions).
     const agentsCollection = createAgentsCollection(config)
     agentsCollection.endpoints = [
-      ...(agentsCollection.endpoints ?? []),
+      ...endpointList(agentsCollection.endpoints),
       {
         path: '/internal/list',
         method: 'get' as const,
@@ -112,18 +152,21 @@ export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
       }
     ]
 
-    if (config.modelCatalog) {
-      endpoints.push({
-        path: `${basePath}/models`,
-        method: 'get' as const,
-        handler: createModelsListHandler(config)
-      })
-    }
+    endpoints.push({
+      path: `${basePath}/models`,
+      method: 'get' as const,
+      handler: createModelsListHandler(config)
+    })
 
     return {
       ...incomingConfig,
       collections: [...(incomingConfig.collections ?? []), agentsCollection],
-      endpoints: [...(incomingConfig.endpoints ?? []), ...endpoints]
+      endpoints: [...endpointList(incomingConfig.endpoints), ...endpoints],
+      jobs: buildLiteLlmJobs(incomingConfig.jobs, config),
+      onInit: async payload => {
+        await incomingOnInit?.(payload)
+        await enqueueExistingLiteLlmVirtualKeySyncs(payload, config)
+      }
     }
   }
 }

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -166,9 +166,14 @@ export interface AgentPluginConfig {
    * `/model/info`, renders the presets as a select in the admin, and a
    * beforeValidate hook enforces that agents reference a catalog preset and
    * that the BYOK key format matches the provider the preset requires
-   * (`model_info.requires_key`). Untouched legacy documents keep working.
+   * (`model_info.requires_key`).
+   *
+   * Required — LiteLLM is a hard dependency. Payload is the source of truth for
+   * provider BYOK keys and mints one LiteLLM virtual key per agent; the runtime
+   * authenticates to LiteLLM with that per-agent key and forwards the provider
+   * key per request.
    */
-  modelCatalog?: {
+  modelCatalog: {
     /** Gateway base URL without /v1 (e.g. http://litellm:4000). */
     gatewayUrl: string
     /** Key used to read /model/info (the gateway master key). */
@@ -261,5 +266,5 @@ export interface ResolvedPluginConfig {
   mediaCollectionSlug: string
   collectionOverrides: CollectionOverrides | undefined
   onRunCompleted: OnRunCompleted | undefined
-  modelCatalog: { gatewayUrl: string; masterKey: string; cacheTtlMs: number } | undefined
+  modelCatalog: { gatewayUrl: string; masterKey: string; cacheTtlMs: number }
 }

--- a/packages/payload-documents/src/endpoints/shared.ts
+++ b/packages/payload-documents/src/endpoints/shared.ts
@@ -1,3 +1,4 @@
+import { createHash, timingSafeEqual } from 'node:crypto'
 import type { PayloadRequest } from 'payload'
 import type { DocumentRecord, DocumentsWorkerConfig } from '../plugin/types'
 
@@ -19,9 +20,19 @@ export const requireAuth = (req: PayloadRequest): Response | null => {
   return null
 }
 
+/**
+ * Constant-time secret comparison. Both sides are SHA-256'd first so the compare
+ * runs over equal-length buffers (no length leak, no length-mismatch throw); the
+ * digest equality still implies the secrets match.
+ */
+const secretsMatch = (a: string, b: string): boolean =>
+  timingSafeEqual(createHash('sha256').update(a).digest(), createHash('sha256').update(b).digest())
+
 export const requireInternalSecret = (req: PayloadRequest, worker: DocumentsWorkerConfig): Response | null => {
   const headerSecret = req.headers?.get?.(INTERNAL_SECRET_HEADER)
-  if (!headerSecret || headerSecret !== worker.internalSecret) {
+  // Reject an unconfigured secret so it can't fail open, then compare in constant
+  // time to deny a timing oracle on this overrideAccess service-account bypass.
+  if (!headerSecret || !worker.internalSecret || !secretsMatch(headerSecret, worker.internalSecret)) {
     return Response.json({ error: 'Unauthorized' }, { status: 401 })
   }
   return null


### PR DESCRIPTION
## Summary

- Add a LiteLLM Admin API client for model catalog and virtual key operations.
- Sync one LiteLLM virtual key per active agent, including model allowlists, metadata, optional budgets, RPM and TPM limits.
- Block virtual keys when agents are disabled or deleted, and fail closed in the runtime when virtual keys are enabled but missing.
- Keep provider BYOK in Payload; the runtime still forwards it per request via `extra_body.api_key`.

## Why

This lets LiteLLM enforce per-agent controls without making LiteLLM the source of truth for provider API keys. Payload remains the product source of truth for agents and BYOK, while LiteLLM owns gateway auth, model allowlists, budgets and usage controls.

## Validation

- `git diff --check origin/main...HEAD`
- During implementation before the final rebase: payload-agents core tests and agno-agent-builder tests were run successfully.
