### PR TITLE
feat(nexus-queue): serve worker Prometheus metrics over HTTP

### DIFF
--- a/backend/nexus-queue/nexus_queue/config.py
+++ b/backend/nexus-queue/nexus_queue/config.py
@@ -69,6 +69,21 @@ class RuntimeConfig(BaseModel):
         description="Approx MAXLEN for the dead-letter stream; 0 = unbounded.",
     )
 
+    # ── Observability ──────────────────────────────────────────────────────
+    metrics_port: int | None = Field(
+        default=None,
+        gt=0,
+        lt=65_536,
+        description=(
+            "If set, the worker serves Prometheus metrics on this port via an "
+            "in-process HTTP server (scrape target for a ServiceMonitor). The "
+            "taskiq worker has no HTTP server otherwise, so its consume counters "
+            "are invisible without this. Run the worker single-process "
+            "(taskiq --workers 1) and scale by pods, or the port will collide. "
+            "None disables it."
+        ),
+    )
+
     # ── Logging ────────────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
 

--- a/backend/nexus-queue/nexus_queue/lifecycle.py
+++ b/backend/nexus-queue/nexus_queue/lifecycle.py
@@ -11,11 +11,14 @@ import logging
 
 import redis.asyncio as aioredis
 import structlog
+from prometheus_client import start_http_server
 from taskiq import AsyncBroker, TaskiqEvents, TaskiqState
 
 from nexus_queue.config import RuntimeConfig
 from nexus_queue.delayed import DelayedRetryPoller
 from nexus_queue.naming import idempotency_redis_key
+
+logger = structlog.get_logger("nexus_queue.lifecycle")
 
 
 class IdempotencyStore:
@@ -71,6 +74,28 @@ def configure_logging(config: RuntimeConfig) -> None:
     )
 
 
+def _start_metrics_server(config: RuntimeConfig) -> None:
+    """Serve the Prometheus registry over HTTP from the worker process.
+
+    The consume counters/histogram live in this process; the kicker is a
+    separate pod with its own registry, so without this the worker's metrics
+    have no scrape endpoint. Best-effort: a metrics-server failure (e.g. a
+    port collision when mistakenly run multi-process) must never take the
+    worker down."""
+    if config.metrics_port is None:
+        return
+    try:
+        start_http_server(config.metrics_port)
+        logger.info("metrics-server-started", port=config.metrics_port)
+    except OSError as exc:
+        logger.warning(
+            "metrics-server-failed",
+            port=config.metrics_port,
+            error=str(exc),
+            hint="run the worker single-process (taskiq --workers 1)",
+        )
+
+
 def register_lifecycle(
     broker: AsyncBroker,
     config: RuntimeConfig,
@@ -89,6 +114,7 @@ def register_lifecycle(
     async def _startup(state: TaskiqState) -> None:  # pyright: ignore[reportUnusedFunction]
         state.nexus_config = config
         state.nexus_adapters = adapters
+        _start_metrics_server(config)
         store = IdempotencyStore(config)
         await store.startup()
         state.nexus_idempotency = store

--- a/backend/payload-documents-worker-builder/payload_documents_worker_builder/config.py
+++ b/backend/payload-documents-worker-builder/payload_documents_worker_builder/config.py
@@ -64,6 +64,12 @@ class RuntimeConfig(BaseModel):
         description="Paths the InternalAuthMiddleware lets through without the secret.",
     )
 
+    # ── Observability ─────────────────────────────────────────────────────
+    metrics_port: int | None = Field(
+        default=None,
+        description="If set, the worker serves Prometheus metrics on this port. None disables it.",
+    )
+
     # ── Logging ───────────────────────────────────────────────────────────
     log_level: str = Field(default="INFO")
 
@@ -77,5 +83,6 @@ class RuntimeConfig(BaseModel):
             internal_secret=self.internal_secret,
             public_paths=self.public_paths,
             max_retries=2,
+            metrics_port=self.metrics_port,
             log_level=self.log_level,
         )


### PR DESCRIPTION
## Problem
The nexus-queue consume metrics (`nexus_queue_received_total`, `nexus_queue_completed_total`, `nexus_queue_failed_total`, `nexus_queue_consume_seconds`) are incremented inside the **taskiq worker** process, which has no HTTP server. `/metrics` was only served by the **kicker** — a separate pod with its own `prometheus_client` registry — so the worker's metrics had no scrape endpoint and never reached Prometheus/Grafana.

## Fix
- **`nexus-queue`**: add `metrics_port` to `RuntimeConfig`. When set, the worker starts an in-process `prometheus_client` HTTP server on `WORKER_STARTUP`. Best-effort — a bind failure (e.g. accidental multi-process run) logs and continues instead of crashing the worker. Run the worker single-process (`taskiq --workers 1`) so the port binds once per pod; scale by replicas.
- **`payload-documents-worker-builder`**: surface `metrics_port` and forward it in `to_nexus_config`.

Konect inherits this once it adopts nexus-queue.

## Companion
ZetesisPortal PR wires `METRICS_PORT`, runs the worker single-process, and adds the Service + ServiceMonitor + the Prometheus→worker NetworkPolicy ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)