### PR TITLE
fix(nexus-queue): import OTLP exporter lazily (fixes worker crash-loop)

### DIFF
--- a/backend/nexus-queue/nexus_queue/tracing.py
+++ b/backend/nexus-queue/nexus_queue/tracing.py
@@ -11,11 +11,6 @@ from __future__ import annotations
 import os
 
 import structlog
-from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from nexus_queue.config import RuntimeConfig
 
@@ -27,11 +22,21 @@ OTLP_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT"
 def configure_tracing(config: RuntimeConfig) -> None:
     """Wire an OTLP span exporter when a collector endpoint is configured.
 
-    No-op unless ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set. The exporter reads the
+    No-op unless ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set. The OTel SDK + exporter
+    are imported **lazily** here, after the endpoint guard, so the worker starts
+    untraced — and without the exporter package installed — wherever no
+    collector exists (the module promises exactly this). The exporter reads the
     endpoint (and any other ``OTEL_*`` options) from the environment itself."""
     endpoint = os.environ.get(OTLP_ENDPOINT_ENV)
     if not endpoint:
         return
+
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
     provider = TracerProvider(resource=Resource.create({"service.name": config.app_name}))
     provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     trace.set_tracer_provider(provider)


### PR DESCRIPTION
## Problem
The documents-worker (rebuilt to v0.1.5) **crash-loops in prod**: `ModuleNotFoundError: No module named 'opentelemetry.exporter'`. `tracing.py` imports the OTLP span exporter at **module load**, but the worker image doesn't ship that package (the OTel API/SDK arrive transitively via agno; the OTLP exporter is exclusive to nexus-queue and isn't installed). The module already documents tracing as opt-in (`OTEL_EXPORTER_OTLP_ENDPOINT`), so importing the exporter eagerly broke its own contract.

## Fix
Move the SDK + exporter imports **inside** `configure_tracing`, after the endpoint guard. An untraced deployment (no `OTEL_EXPORTER_OTLP_ENDPOINT`) never imports them, so the worker starts cleanly without the exporter package.

## Follow-up (separate)
The worker image not installing nexus-queue's declared deps is a Docker/uv-sync gap worth a closer look, but lazy import is the correct design regardless (tracing is optional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)