### PR TITLE
fix(payload-documents): per-attempt idempotency key for parse

### DIFF
--- a/packages/payload-documents/src/endpoints/parse-endpoint.ts
+++ b/packages/payload-documents/src/endpoints/parse-endpoint.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import { NexusQueueClient } from '@zetesis/nexus-queue'
 import type { Endpoint, PayloadRequest } from 'payload'
 import type { DocumentsWorkerConfig } from '../plugin/types'
@@ -40,7 +41,11 @@ const queueOnWorker = async (
   const queue = new NexusQueueClient({ kickerUrl: worker.url, secret: worker.internalSecret })
 
   try {
-    await queue.enqueue(worker.taskName ?? DEFAULT_TASK_NAME, { document_id: id }, { idempotencyKey: id })
+    // Per-attempt idempotency key: dedupes a redelivery of THIS enqueue, but a
+    // static `id` would block intentional reprocessing (a re-parse) for the
+    // dedup TTL. Each POST /parse is a fresh attempt.
+    const idempotencyKey = `${id}:${randomUUID()}`
+    await queue.enqueue(worker.taskName ?? DEFAULT_TASK_NAME, { document_id: id }, { idempotencyKey })
     return Response.json({ status: 'queued' })
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Worker is unreachable'


### PR DESCRIPTION
## Problem
Re-parsing a document hangs: it stays in \`pending\` and the worker skips it as \`duplicate-skipped\`. Root cause: the parse endpoint enqueued with a **static** idempotency key (the document id), so after the first successful parse the nexus-queue dedup key \`nq:idem:<id>\` lived for the dedup TTL (24h). Every subsequent "process" click was deduped away — reprocessing was impossible for 24h.

Found in prod (doc 18): `Executing task zp.documents.parse ... {"idem":"18","event":"duplicate-skipped"}` on a loop; doc stuck `pending`.

## Fix
Per-attempt key `${id}:${randomUUID()}`. A redelivery of the *same* enqueued message keeps its key (dedup still works), but each `POST /parse` the user triggers is a fresh attempt that reprocesses. Keeps the `nq_idem` label so we stay spec-conformant (idempotency mandatory).

The stuck prod doc was already unblocked manually (cleared the stale Redis key); this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)