### PR TITLE
ci: run CI jobs on self-hosted herschel-runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci:
     name: Build, Lint & Type Check
-    runs-on: ubuntu-latest
+    runs-on: herschel-runners
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
 
   agent-runtime:
     name: Agent Runtime (Python)
-    runs-on: ubuntu-latest
+    runs-on: herschel-runners
     defaults:
       run:
         working-directory: backend


### PR DESCRIPTION
## What

Move both jobs in `ci.yml` (`ci` and `agent-runtime`) from GitHub-hosted `ubuntu-latest` to the self-hosted `herschel-runners`.

## Why

These jobs run on every `push` and `pull_request` to `main`. On private repos, GitHub-hosted runners consume Actions minutes — this is the highest-volume offender across the org since PR activity on this submodule is frequent. The self-hosted runners already build the ZP Docker images and run its tests, so they have the capacity.

Release/publish jobs (`release-please.yml`, `publish-python.yml`) are intentionally left on `ubuntu-latest` so a cluster outage can't block a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)