### PR TITLE
feat: learned heads (lentes) — standalone collection + MCP re-ranking

### DIFF
--- a/packages/mcp-typesense/src/auth/resolve.spec.ts
+++ b/packages/mcp-typesense/src/auth/resolve.spec.ts
@@ -1,0 +1,51 @@
+import type { IncomingMessage } from 'node:http'
+import { describe, expect, it } from 'vitest'
+import { resolveAuth } from './resolve'
+
+const req = (headers: Record<string, string>): IncomingMessage => ({ headers }) as unknown as IncomingMessage
+
+/** Encode weights the same way the proxy does: Float32LE [...w, b], base64. */
+function encodeLearnedHead(w: number[], b: number): string {
+  const buf = Buffer.alloc((w.length + 1) * 4)
+  for (let i = 0; i < w.length; i++) buf.writeFloatLE(w[i] ?? 0, i * 4)
+  buf.writeFloatLE(b, w.length * 4)
+  return buf.toString('base64')
+}
+
+const encodeProfiles = (p: Array<{ slug: string; name: string; description: string }>): string =>
+  Buffer.from(JSON.stringify(p)).toString('base64')
+
+describe('resolveAuth', () => {
+  it('returns null when no recognized headers are present', () => {
+    expect(resolveAuth(req({}), { type: 'header' })).toBeNull()
+  })
+
+  it('reads the tenant slug', () => {
+    expect(resolveAuth(req({ 'x-tenant-slug': 'acme' }), { type: 'header' })?.tenantSlug).toBe('acme')
+  })
+
+  it('round-trips learned-head weights from the header', () => {
+    const w = [0.5, -1.25, 3.0, 0]
+    const b = -0.0625
+    const ctx = resolveAuth(req({ 'x-learned-head': encodeLearnedHead(w, b) }), { type: 'header' })
+    const head = ctx?.retrieval?.learnedHead
+    expect(head?.w).toHaveLength(4)
+    head?.w.forEach((v, i) => expect(v).toBeCloseTo(w[i] ?? 0, 5))
+    expect(head?.b).toBeCloseTo(b, 5)
+  })
+
+  it('ignores a learned-head header that is too short to be valid weights', () => {
+    // "AAA" decodes to 2 bytes — below the 8-byte floor (at least one weight + bias).
+    const ctx = resolveAuth(req({ 'x-tenant-slug': 'acme', 'x-learned-head': 'AAA' }), { type: 'header' })
+    expect(ctx?.retrieval?.learnedHead).toBeUndefined()
+  })
+
+  it('decodes the available-profiles catalog', () => {
+    const profiles = [
+      { slug: 'legal', name: 'Legal', description: 'legal docs' },
+      { slug: 'tech', name: 'Tech', description: 'technical' }
+    ]
+    const ctx = resolveAuth(req({ 'x-retrieval-profiles': encodeProfiles(profiles) }), { type: 'header' })
+    expect(ctx?.availableProfiles).toEqual(profiles)
+  })
+})

--- a/packages/mcp-typesense/src/auth/resolve.spec.ts
+++ b/packages/mcp-typesense/src/auth/resolve.spec.ts
@@ -30,7 +30,7 @@ describe('resolveAuth', () => {
     const ctx = resolveAuth(req({ 'x-learned-head': encodeLearnedHead(w, b) }), { type: 'header' })
     const head = ctx?.retrieval?.learnedHead
     expect(head?.w).toHaveLength(4)
-    head?.w.forEach((v, i) => expect(v).toBeCloseTo(w[i] ?? 0, 5))
+    for (let i = 0; i < w.length; i++) expect(head?.w[i]).toBeCloseTo(w[i] ?? 0, 5)
     expect(head?.b).toBeCloseTo(b, 5)
   })
 
@@ -47,5 +47,27 @@ describe('resolveAuth', () => {
     ]
     const ctx = resolveAuth(req({ 'x-retrieval-profiles': encodeProfiles(profiles) }), { type: 'header' })
     expect(ctx?.availableProfiles).toEqual(profiles)
+  })
+
+  it('decodes the per-group profiles map with binary weights', () => {
+    const map = {
+      austriaco: {
+        taxonomySlugs: ['mises'],
+        folderSlugs: [],
+        retrieval: { hybridAlpha: 0.7, learnedHead: encodeLearnedHead([1, 2], 0.5) }
+      },
+      perennialista: {
+        taxonomySlugs: ['guenon'],
+        retrieval: { learnedHead: encodeLearnedHead([-1, -2], -0.5) }
+      }
+    }
+    const header = Buffer.from(JSON.stringify(map)).toString('base64')
+    const ctx = resolveAuth(req({ 'x-group-profiles': header }), { type: 'header' })
+
+    expect(Object.keys(ctx?.groupProfiles ?? {})).toEqual(['austriaco', 'perennialista'])
+    expect(ctx?.groupProfiles?.austriaco?.taxonomySlugs).toEqual(['mises'])
+    expect(ctx?.groupProfiles?.austriaco?.retrieval?.hybridAlpha).toBe(0.7)
+    expect(ctx?.groupProfiles?.austriaco?.retrieval?.learnedHead?.w[0]).toBeCloseTo(1, 5)
+    expect(ctx?.groupProfiles?.perennialista?.retrieval?.learnedHead?.b).toBeCloseTo(-0.5, 5)
   })
 })

--- a/packages/mcp-typesense/src/auth/resolve.ts
+++ b/packages/mcp-typesense/src/auth/resolve.ts
@@ -8,7 +8,7 @@
  */
 
 import type { IncomingMessage } from 'node:http'
-import type { McpAuthContext, McpAuthStrategy } from '../types'
+import type { McpAuthContext, McpAuthStrategy, ResolvedRetrievalScope } from '../types'
 
 const DEFAULT_HEADER_NAME = 'x-tenant-slug'
 const TAXONOMY_HEADER_NAME = 'x-taxonomy-slugs'
@@ -21,6 +21,7 @@ const HYBRID_ALPHA_HEADER = 'x-hybrid-alpha'
 const QUERY_REWRITE_TEMPLATE_HEADER = 'x-query-rewrite-template'
 const LEARNED_HEAD_HEADER = 'x-learned-head'
 const RETRIEVAL_PROFILES_HEADER = 'x-retrieval-profiles'
+const GROUP_PROFILES_HEADER = 'x-group-profiles'
 
 const parseSlugList = (raw: string | string[] | undefined): string[] | undefined => {
   const value = Array.isArray(raw) ? raw[0] : raw
@@ -65,11 +66,21 @@ export function resolveAuth(req: IncomingMessage, strategy: McpAuthStrategy | un
     // Catalog of profiles the agent can choose from (metadata only).
     const availableProfiles = readAvailableProfiles(req.headers[RETRIEVAL_PROFILES_HEADER])
 
-    if (!tenantSlug && !taxonomySlugs?.length && !folderSlugs?.length && !retrieval && !availableProfiles?.length) {
+    // Per-profile resolved config for multi-profile requests (compare).
+    const groupProfiles = readGroupProfiles(req.headers[GROUP_PROFILES_HEADER])
+
+    if (
+      !tenantSlug &&
+      !taxonomySlugs?.length &&
+      !folderSlugs?.length &&
+      !retrieval &&
+      !availableProfiles?.length &&
+      !groupProfiles
+    ) {
       return null
     }
 
-    return { tenantSlug, taxonomySlugs, folderSlugs, retrieval, availableProfiles }
+    return { tenantSlug, taxonomySlugs, folderSlugs, retrieval, availableProfiles, groupProfiles }
   }
 
   // Exhaustive guard. When new variants are added, TypeScript will force
@@ -93,6 +104,50 @@ function readAvailableProfiles(
       )
       .map(p => ({ slug: p.slug, name: p.name ?? p.slug, description: p.description ?? '' }))
     return profiles.length > 0 ? profiles : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Decode the per-profile config map for multi-profile requests. The proxy sends
+ * a base64 JSON `{ [slug]: { taxonomySlugs, folderSlugs, retrieval } }`, where
+ * `retrieval.learnedHead` is itself a base64 weights blob (same encoding as the
+ * single-profile header), kept binary so it doesn't bloat the JSON.
+ */
+const str = (v: unknown): string | undefined => (typeof v === 'string' ? v : undefined)
+const num = (v: unknown): number | undefined => (typeof v === 'number' ? v : undefined)
+const strArr = (v: unknown): string[] | undefined => (Array.isArray(v) ? (v as string[]) : undefined)
+
+function parseGroupRetrieval(retrieval: Record<string, unknown> | undefined): ResolvedRetrievalScope['retrieval'] {
+  if (!retrieval) return undefined
+  return {
+    rerankerKind: str(retrieval.rerankerKind),
+    rerankerModel: str(retrieval.rerankerModel),
+    inputK: num(retrieval.inputK),
+    topK: num(retrieval.topK),
+    hybridAlpha: num(retrieval.hybridAlpha),
+    rewriteTemplate: str(retrieval.rewriteTemplate),
+    learnedHead: decodeLearnedHead(str(retrieval.learnedHead))
+  }
+}
+
+function readGroupProfiles(raw: string | string[] | undefined): Record<string, ResolvedRetrievalScope> | undefined {
+  const value = readScalar(raw)
+  if (!value) return undefined
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64').toString('utf8')) as unknown
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return undefined
+    const out: Record<string, ResolvedRetrievalScope> = {}
+    for (const [slug, raw0] of Object.entries(parsed as Record<string, unknown>)) {
+      const entry = raw0 as { taxonomySlugs?: unknown; folderSlugs?: unknown; retrieval?: Record<string, unknown> }
+      out[slug] = {
+        taxonomySlugs: strArr(entry.taxonomySlugs),
+        folderSlugs: strArr(entry.folderSlugs),
+        retrieval: parseGroupRetrieval(entry.retrieval)
+      }
+    }
+    return Object.keys(out).length > 0 ? out : undefined
   } catch {
     return undefined
   }

--- a/packages/mcp-typesense/src/auth/resolve.ts
+++ b/packages/mcp-typesense/src/auth/resolve.ts
@@ -19,6 +19,7 @@ const INPUT_K_HEADER = 'x-input-k'
 const TOP_K_HEADER = 'x-top-k'
 const HYBRID_ALPHA_HEADER = 'x-hybrid-alpha'
 const QUERY_REWRITE_TEMPLATE_HEADER = 'x-query-rewrite-template'
+const LEARNED_HEAD_HEADER = 'x-learned-head'
 
 const parseSlugList = (raw: string | string[] | undefined): string[] | undefined => {
   const value = Array.isArray(raw) ? raw[0] : raw
@@ -73,6 +74,21 @@ export function resolveAuth(req: IncomingMessage, strategy: McpAuthStrategy | un
   return _exhaustive
 }
 
+function decodeLearnedHead(raw: string | undefined): { w: number[]; b: number } | undefined {
+  if (!raw) return undefined
+  try {
+    const buf = Buffer.from(raw, 'base64')
+    if (buf.byteLength < 8 || buf.byteLength % 4 !== 0) return undefined
+    const dims = buf.byteLength / 4 - 1
+    const w: number[] = []
+    for (let i = 0; i < dims; i++) w.push(buf.readFloatLE(i * 4))
+    const b = buf.readFloatLE(dims * 4)
+    return { w, b }
+  } catch {
+    return undefined
+  }
+}
+
 function readRetrievalHeaders(headers: IncomingMessage['headers']): McpAuthContext['retrieval'] | undefined {
   const rerankerKind = readScalar(headers[RERANKER_KIND_HEADER])
   const rerankerModel = readScalar(headers[RERANKER_MODEL_HEADER])
@@ -80,6 +96,7 @@ function readRetrievalHeaders(headers: IncomingMessage['headers']): McpAuthConte
   const topK = parseFiniteNumber(headers[TOP_K_HEADER])
   const hybridAlpha = parseFiniteNumber(headers[HYBRID_ALPHA_HEADER])
   const rewriteTemplate = readScalar(headers[QUERY_REWRITE_TEMPLATE_HEADER])
+  const learnedHead = decodeLearnedHead(readScalar(headers[LEARNED_HEAD_HEADER]))
 
   if (
     rerankerKind === undefined &&
@@ -87,9 +104,10 @@ function readRetrievalHeaders(headers: IncomingMessage['headers']): McpAuthConte
     inputK === undefined &&
     topK === undefined &&
     hybridAlpha === undefined &&
-    rewriteTemplate === undefined
+    rewriteTemplate === undefined &&
+    learnedHead === undefined
   ) {
     return undefined
   }
-  return { rerankerKind, rerankerModel, inputK, topK, hybridAlpha, rewriteTemplate }
+  return { rerankerKind, rerankerModel, inputK, topK, hybridAlpha, rewriteTemplate, learnedHead }
 }

--- a/packages/mcp-typesense/src/auth/resolve.ts
+++ b/packages/mcp-typesense/src/auth/resolve.ts
@@ -20,6 +20,7 @@ const TOP_K_HEADER = 'x-top-k'
 const HYBRID_ALPHA_HEADER = 'x-hybrid-alpha'
 const QUERY_REWRITE_TEMPLATE_HEADER = 'x-query-rewrite-template'
 const LEARNED_HEAD_HEADER = 'x-learned-head'
+const RETRIEVAL_PROFILES_HEADER = 'x-retrieval-profiles'
 
 const parseSlugList = (raw: string | string[] | undefined): string[] | undefined => {
   const value = Array.isArray(raw) ? raw[0] : raw
@@ -56,22 +57,45 @@ export function resolveAuth(req: IncomingMessage, strategy: McpAuthStrategy | un
     const taxonomySlugs = parseSlugList(req.headers[TAXONOMY_HEADER_NAME])
     const folderSlugs = parseSlugList(req.headers[FOLDER_HEADER_NAME])
 
-    // Retrieval params from the attached SearchProfile. Empty/absent
-    // headers leave the corresponding field undefined so the search tool
-    // can fall back to its own defaults.
+    // Retrieval params from the chosen SearchProfile. Empty/absent headers
+    // leave the corresponding field undefined so the search tool can fall back
+    // to its own defaults.
     const retrieval = readRetrievalHeaders(req.headers)
 
-    if (!tenantSlug && !taxonomySlugs?.length && !folderSlugs?.length && !retrieval) {
+    // Catalog of profiles the agent can choose from (metadata only).
+    const availableProfiles = readAvailableProfiles(req.headers[RETRIEVAL_PROFILES_HEADER])
+
+    if (!tenantSlug && !taxonomySlugs?.length && !folderSlugs?.length && !retrieval && !availableProfiles?.length) {
       return null
     }
 
-    return { tenantSlug, taxonomySlugs, folderSlugs, retrieval }
+    return { tenantSlug, taxonomySlugs, folderSlugs, retrieval, availableProfiles }
   }
 
   // Exhaustive guard. When new variants are added, TypeScript will force
   // handling them here instead of silently returning null.
   const _exhaustive: never = effective
   return _exhaustive
+}
+
+function readAvailableProfiles(
+  raw: string | string[] | undefined
+): Array<{ slug: string; name: string; description: string }> | undefined {
+  const value = readScalar(raw)
+  if (!value) return undefined
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64').toString('utf8')) as unknown
+    if (!Array.isArray(parsed)) return undefined
+    const profiles = parsed
+      .filter(
+        (p): p is { slug: string; name?: string; description?: string } =>
+          Boolean(p) && typeof p === 'object' && typeof (p as { slug?: unknown }).slug === 'string'
+      )
+      .map(p => ({ slug: p.slug, name: p.name ?? p.slug, description: p.description ?? '' }))
+    return profiles.length > 0 ? profiles : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function decodeLearnedHead(raw: string | undefined): { w: number[]; b: number } | undefined {

--- a/packages/mcp-typesense/src/tools/compare-perspectives.ts
+++ b/packages/mcp-typesense/src/tools/compare-perspectives.ts
@@ -56,7 +56,13 @@ export const comparePerspectivesSchema = z.object({
     .min(0)
     .max(5)
     .optional()
-    .describe('Inline neighboring chunks (chunk_index ±N) for each hit. Default: 0. Max: 3.')
+    .describe('Inline neighboring chunks (chunk_index ±N) for each hit. Default: 0. Max: 3.'),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe(
+      'Slug of the retrieval profile to use. Same selection rules as search_collections: required when your token exposes profiles. Call list_retrieval_profiles to see the options.'
+    )
 })
 
 export type ComparePerspectivesInput = z.infer<typeof comparePerspectivesSchema>

--- a/packages/mcp-typesense/src/tools/compare-perspectives.ts
+++ b/packages/mcp-typesense/src/tools/compare-perspectives.ts
@@ -26,12 +26,21 @@ export const comparePerspectivesSchema = z.object({
         name: z.string().describe('Display name for this group (e.g., "Mises", "Hayek", "Austrian school").'),
         taxonomy_slugs: z
           .union([z.string(), z.array(z.string())])
-          .describe('Taxonomy slug(s) to scope this group. String or string[].')
+          .optional()
+          .describe('Optional taxonomy slug(s) to scope this group (string or string[]).'),
+        retrieval_profile: z
+          .string()
+          .optional()
+          .describe(
+            "Optional profile slug for THIS group — applies that profile's lente and filters. Lets you compare the SAME query under different lentes (e.g. one group per perspective). Falls back to the top-level retrieval_profile."
+          )
       })
     )
     .min(2)
     .max(MAX_GROUPS)
-    .describe(`2-${MAX_GROUPS} groups to compare. Each group runs as an independent scoped search in parallel.`),
+    .describe(
+      `2-${MAX_GROUPS} groups to compare. Each group runs as an independent search in parallel, scoped by its taxonomy_slugs and/or its retrieval_profile.`
+    ),
   per_group: z
     .number()
     .int()
@@ -67,6 +76,19 @@ export const comparePerspectivesSchema = z.object({
 
 export type ComparePerspectivesInput = z.infer<typeof comparePerspectivesSchema>
 
+/**
+ * Build the auth context a group runs under. When the group names a profile and
+ * the proxy resolved it (groupProfiles), apply that profile's filters + lente;
+ * otherwise fall back to the request's default auth. This is what lets two
+ * groups run the same query under different lentes.
+ */
+function authForGroup(auth: McpAuthContext | null, slug: string | undefined): McpAuthContext | null {
+  if (!auth || !slug) return auth
+  const gp = auth.groupProfiles?.[slug]
+  if (!gp) return auth
+  return { ...auth, taxonomySlugs: gp.taxonomySlugs, folderSlugs: gp.folderSlugs, retrieval: gp.retrieval }
+}
+
 export async function comparePerspectives(
   input: ComparePerspectivesInput,
   ctx: ToolContext,
@@ -77,7 +99,8 @@ export async function comparePerspectives(
 
   const groupResults = await Promise.all(
     input.groups.map(async g => {
-      const filters: Record<string, string | string[]> = { taxonomy_slugs: g.taxonomy_slugs }
+      const filters = g.taxonomy_slugs ? { taxonomy_slugs: g.taxonomy_slugs } : undefined
+      const groupAuth = authForGroup(auth, g.retrieval_profile ?? input.retrieval_profile)
 
       const result = await searchCollections(
         {
@@ -90,12 +113,13 @@ export async function comparePerspectives(
           expand_context: input.expand_context
         },
         ctx,
-        auth
+        groupAuth
       )
 
       return {
         name: g.name,
         taxonomy_slugs: g.taxonomy_slugs,
+        retrieval_profile: g.retrieval_profile ?? input.retrieval_profile,
         total_found: result.total_found,
         hits: result.hits
       }

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -184,8 +184,11 @@ export function registerTools(opts: RegisterToolsOptions): void {
     },
     async input => {
       const auth = getCurrentAuth()
-      const guard = requireProfileSelection(auth, input.retrieval_profile)
-      if (guard) return toolResult(guard, input.format as OutputFormat)
+      // Every group must resolve to a valid profile (its own or the top-level default).
+      for (const g of input.groups) {
+        const guard = requireProfileSelection(auth, g.retrieval_profile ?? input.retrieval_profile)
+        if (guard) return toolResult(guard, input.format as OutputFormat)
+      }
       const result = await comparePerspectives(input, ctx, auth)
       return toolResult(result, input.format as OutputFormat)
     }

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -26,7 +26,8 @@ import { getChunksByIds, getChunksByIdsSchema } from './get-chunks-by-ids'
 import { getFilterCriteria, getFilterCriteriaSchema } from './get-filter-criteria'
 import { getPostSummaries, getPostSummariesSchema } from './get-post-summaries'
 import { getTaxonomyTree, getTaxonomyTreeSchema } from './get-taxonomy-tree'
-import { searchCollections, searchCollectionsSchema } from './search-collections'
+import { listRetrievalProfiles, listRetrievalProfilesSchema } from './list-retrieval-profiles'
+import { requireProfileSelection, searchCollections, searchCollectionsSchema } from './search-collections'
 import { summarizeDocument, summarizeDocumentSchema } from './summarize-document'
 import { synthesizeComparison, synthesizeComparisonSchema } from './synthesize-comparison'
 
@@ -136,6 +137,19 @@ export function registerTools(opts: RegisterToolsOptions): void {
   // -- SEARCH ----------------------------------------------------------------
 
   server.registerTool(
+    toolNames.listRetrievalProfiles ?? 'list_retrieval_profiles',
+    {
+      description:
+        'List the retrieval profiles available to you. Each profile bundles hard filters, hybrid params, an optional reranker and an optional lente (a learned re-ranker that biases results toward a register). Pick the one that best fits the query and pass its slug as `retrieval_profile` to search_collections. If you do not pass one, the first (default) profile is used.',
+      inputSchema: { ...listRetrievalProfilesSchema.shape, format: formatParam }
+    },
+    async input => {
+      const result = listRetrievalProfiles(input, getCurrentAuth())
+      return toolResult(result, input.format as OutputFormat)
+    }
+  )
+
+  server.registerTool(
     toolNames.searchCollections ?? 'search_collections',
     {
       description:
@@ -150,7 +164,10 @@ export function registerTools(opts: RegisterToolsOptions): void {
       }
     },
     async input => {
-      const result = await searchCollections(input, ctx, getCurrentAuth())
+      const auth = getCurrentAuth()
+      const guard = requireProfileSelection(auth, input.retrieval_profile)
+      if (guard) return toolResult(guard, input.format as OutputFormat)
+      const result = await searchCollections(input, ctx, auth)
       return toolResult(result, input.format as OutputFormat)
     }
   )

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -183,7 +183,10 @@ export function registerTools(opts: RegisterToolsOptions): void {
       }
     },
     async input => {
-      const result = await comparePerspectives(input, ctx, getCurrentAuth())
+      const auth = getCurrentAuth()
+      const guard = requireProfileSelection(auth, input.retrieval_profile)
+      if (guard) return toolResult(guard, input.format as OutputFormat)
+      const result = await comparePerspectives(input, ctx, auth)
       return toolResult(result, input.format as OutputFormat)
     }
   )

--- a/packages/mcp-typesense/src/tools/list-retrieval-profiles.ts
+++ b/packages/mcp-typesense/src/tools/list-retrieval-profiles.ts
@@ -1,0 +1,32 @@
+/**
+ * Tool: list_retrieval_profiles
+ * Returns the retrieval profiles available to the caller's token, so the agent
+ * can decide which one to pass as `retrieval_profile` to the search tool. The
+ * catalog is metadata only (slug/name/description) — the proxy resolves the
+ * chosen profile's actual filters, hybrid params, reranker and lente.
+ */
+
+import { z } from 'zod'
+import type { McpAuthContext } from '../types'
+
+export const listRetrievalProfilesSchema = z.object({})
+
+export type ListRetrievalProfilesInput = z.infer<typeof listRetrievalProfilesSchema>
+
+interface RetrievalProfileInfo {
+  slug: string
+  name: string
+  description: string
+}
+
+export interface ListRetrievalProfilesResult {
+  /** The first profile is the default applied when `retrieval_profile` is omitted. */
+  profiles: RetrievalProfileInfo[]
+}
+
+export function listRetrievalProfiles(
+  _input: ListRetrievalProfilesInput,
+  auth: McpAuthContext | null
+): ListRetrievalProfilesResult {
+  return { profiles: auth?.availableProfiles ?? [] }
+}

--- a/packages/mcp-typesense/src/tools/profile-selection.spec.ts
+++ b/packages/mcp-typesense/src/tools/profile-selection.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import type { McpAuthContext } from '../types'
+import { requireProfileSelection } from './search-collections'
+
+const withProfiles = (slugs: string[]): McpAuthContext => ({
+  tenantSlug: 't',
+  availableProfiles: slugs.map(s => ({ slug: s, name: s, description: '' }))
+})
+
+describe('requireProfileSelection', () => {
+  it('allows the call when no auth context is present', () => {
+    expect(requireProfileSelection(null, undefined)).toBeNull()
+  })
+
+  it('allows the call when the token exposes no profiles (legacy/open search)', () => {
+    expect(requireProfileSelection({ tenantSlug: 't' }, undefined)).toBeNull()
+    expect(requireProfileSelection({ tenantSlug: 't', availableProfiles: [] }, 'anything')).toBeNull()
+  })
+
+  it('requires a choice when profiles exist and none was given', () => {
+    const err = requireProfileSelection(withProfiles(['a', 'b']), undefined)
+    expect(err?.error).toBe('retrieval_profile_required')
+    expect(err?.available_profiles.map(p => p.slug)).toEqual(['a', 'b'])
+    expect(err?.message).toMatch(/list_retrieval_profiles/)
+  })
+
+  it('rejects an unknown slug', () => {
+    const err = requireProfileSelection(withProfiles(['a', 'b']), 'zzz')
+    expect(err?.error).toBe('retrieval_profile_required')
+    expect(err?.message).toMatch(/zzz/)
+  })
+
+  it('accepts a valid slug', () => {
+    expect(requireProfileSelection(withProfiles(['a', 'b']), 'b')).toBeNull()
+  })
+})

--- a/packages/mcp-typesense/src/tools/search-collections.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.ts
@@ -67,10 +67,44 @@ export const searchCollectionsSchema = z.object({
     .optional()
     .describe(
       `Inline N neighboring chunks (chunk_index ±N) for each hit, fetched in a single round trip. Default: 0 (no neighbors). Max: ${MAX_EXPAND_CONTEXT}.`
+    ),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe(
+      'Slug of the retrieval profile to use for this query — selects its hard filters, hybrid params, reranker and lente. Call list_retrieval_profiles to see the options available to you and what each is for. If omitted, the default profile is used.'
     )
 })
 
 export type SearchCollectionsInput = z.infer<typeof searchCollectionsSchema>
+
+export interface ProfileRequiredError {
+  error: 'retrieval_profile_required'
+  message: string
+  available_profiles: Array<{ slug: string; name: string; description: string }>
+}
+
+/**
+ * Enforce profile selection: when the caller's token exposes retrieval profiles,
+ * every search MUST pick one (the agent can't query "raw"). Returns an error
+ * payload to surface back to the agent, or null when the call may proceed
+ * (no profiles configured, or a valid one was chosen).
+ */
+export function requireProfileSelection(
+  auth: McpAuthContext | null,
+  chosen: string | undefined
+): ProfileRequiredError | null {
+  const profiles = auth?.availableProfiles ?? []
+  if (profiles.length === 0) return null
+  if (chosen && profiles.some(p => p.slug === chosen)) return null
+  return {
+    error: 'retrieval_profile_required',
+    message: chosen
+      ? `Unknown retrieval_profile "${chosen}". You must search with one of the available profiles.`
+      : 'This search requires a retrieval_profile. Call list_retrieval_profiles and pass the slug of the profile that best fits the query.',
+    available_profiles: profiles
+  }
+}
 
 interface TaxonomyInfo {
   slug: string

--- a/packages/mcp-typesense/src/tools/search-collections.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.ts
@@ -165,14 +165,17 @@ function buildSearchParams(args: {
   page: number
   vectorK: number
   hybridAlpha: number
+  excludeEmbedding: boolean
 }): MultiSearchRequestSchema<ChunkDoc, string> {
-  const { collectionDef, mode, query, filters, perPage, page, vectorK, hybridAlpha } = args
+  const { collectionDef, mode, query, filters, perPage, page, vectorK, hybridAlpha, excludeEmbedding } = args
   const params: MultiSearchRequestSchema<ChunkDoc, string> = {
     collection: collectionDef.chunkCollection,
     per_page: perPage,
     page,
-    exclude_fields: 'embedding',
     q: '*'
+  }
+  if (excludeEmbedding) {
+    params.exclude_fields = 'embedding'
   }
 
   if (filters && Object.keys(filters).length > 0) {
@@ -453,6 +456,9 @@ async function executeSearch(
   const topK = clampPositiveInt(auth?.retrieval?.topK, perPage, 1, MAX_PER_PAGE)
   const fetchPerCollection = Math.min(inputK, MAX_PER_PAGE)
 
+  const learnedHead = auth?.retrieval?.learnedHead
+  const excludeEmbedding = !learnedHead
+
   const searches = targets.map(collectionDef =>
     buildSearchParams({
       collectionDef,
@@ -462,7 +468,8 @@ async function executeSearch(
       perPage: fetchPerCollection,
       page,
       vectorK: inputK,
-      hybridAlpha
+      hybridAlpha,
+      excludeEmbedding
     })
   )
 
@@ -492,11 +499,24 @@ async function executeSearch(
     totalFound += r.found || 0
     totalTime += r.search_time_ms || 0
 
-    const hits = (r.hits as SearchResponseHit<ChunkDoc>[] | undefined) ?? []
-    hitsPerCollection.push(hits.map(h => mapHit(h, collectionDef.chunkCollection, snippetLength)))
+    const rawHits = (r.hits as SearchResponseHit<ChunkDoc>[] | undefined) ?? []
+    const mappedHits = rawHits.map(raw => {
+      const hit = mapHit(raw, collectionDef.chunkCollection, snippetLength)
+      if (learnedHead) {
+        const emb = raw.document.embedding as number[] | undefined
+        if (emb && emb.length === learnedHead.w.length) {
+          let s = learnedHead.b
+          for (let i = 0; i < learnedHead.w.length; i++) s += (learnedHead.w[i] ?? 0) * (emb[i] ?? 0)
+          hit.score = s
+        }
+      }
+      return hit
+    })
+    hitsPerCollection.push(mappedHits)
   })
 
   const merged = roundRobinMerge(hitsPerCollection)
+  const afterHead = learnedHead ? [...merged].sort((a, b) => b.score - a.score) : merged
   setAttributes(parentSpan, {
     'retrieval.merged_candidates': merged.length,
     'retrieval.typesense_total_found': totalFound,
@@ -504,7 +524,7 @@ async function executeSearch(
   })
   // Reranker scores chunks against the rewritten query — the same string
   // Typesense used — so reranker/Typesense agree on what "relevant" means.
-  const reranked = await maybeRerank(ctx, auth, queryUsed, merged)
+  const reranked = await maybeRerank(ctx, auth, queryUsed, afterHead)
   const finalHits = reranked.slice(0, topK)
   setAttributes(parentSpan, {
     'retrieval.final_hits_count': finalHits.length,

--- a/packages/mcp-typesense/src/types.ts
+++ b/packages/mcp-typesense/src/types.ts
@@ -211,10 +211,25 @@ export interface McpAuthContext {
    * the agent can discover and reason about its options.
    */
   availableProfiles?: Array<{ slug: string; name: string; description: string }>
+  /**
+   * Fully-resolved scope+retrieval config (filters + lente weights) for every
+   * profile referenced in THIS request, keyed by slug. Sent by the proxy only
+   * when a request uses more than one profile (e.g. `compare_perspectives` with
+   * a profile per group), so the tool can apply each group's own lente/filters.
+   * Scoped to the request's used profiles to keep the header small.
+   */
+  groupProfiles?: Record<string, ResolvedRetrievalScope>
   /** User identifier, for logging/auditing. */
   userId?: string
   /** Arbitrary metadata the auth strategy wants to propagate. */
   metadata?: Record<string, unknown>
+}
+
+/** The retrieval-affecting slice of an auth context: scope filters + retrieval params. */
+export interface ResolvedRetrievalScope {
+  taxonomySlugs?: string[]
+  folderSlugs?: string[]
+  retrieval?: McpAuthContext['retrieval']
 }
 
 // ============================================================================

--- a/packages/mcp-typesense/src/types.ts
+++ b/packages/mcp-typesense/src/types.ts
@@ -203,6 +203,14 @@ export interface McpAuthContext {
      */
     learnedHead?: { w: number[]; b: number }
   }
+  /**
+   * Retrieval profiles available to the caller's token. The agent selects one
+   * per query via the search tool's `retrieval_profile` argument; the proxy
+   * resolves the chosen one into the `retrieval` fields above. This catalog is
+   * metadata only (no weights) and powers the `list_retrieval_profiles` tool so
+   * the agent can discover and reason about its options.
+   */
+  availableProfiles?: Array<{ slug: string; name: string; description: string }>
   /** User identifier, for logging/auditing. */
   userId?: string
   /** Arbitrary metadata the auth strategy wants to propagate. */
@@ -258,6 +266,7 @@ export interface FeaturesConfig {
 export interface ToolNameOverrides {
   getTaxonomyTree?: string
   getFilterCriteria?: string
+  listRetrievalProfiles?: string
   getPostSummaries?: string
   getBookToc?: string
   searchCollections?: string

--- a/packages/mcp-typesense/src/types.ts
+++ b/packages/mcp-typesense/src/types.ts
@@ -195,6 +195,13 @@ export interface McpAuthContext {
      * string. When unset, the raw user query is passed through unchanged.
      */
     rewriteTemplate?: string
+    /**
+     * Learned head weights for dot-product re-ranking. When present the
+     * search tool fetches embeddings from Typesense (skips exclude_fields)
+     * and applies `score = w·e + b` to each candidate before the reranker.
+     * w has the same dimensionality as the chunk embedding (BGE-M3 → 1024).
+     */
+    learnedHead?: { w: number[]; b: number }
   }
   /** User identifier, for logging/auditing. */
   userId?: string

--- a/packages/payload-agents-core/src/collections/learned-heads.ts
+++ b/packages/payload-agents-core/src/collections/learned-heads.ts
@@ -1,0 +1,170 @@
+/**
+ * Learned Heads collection ("lentes").
+ *
+ * A `LearnedHead` is a tenant-owned, reusable soft re-ranker: a logistic
+ * regression probe trained over frozen embeddings (BGE-M3). It is trained from
+ * a set of labeled example chunks (positive = surface, negative = bury) and,
+ * once `ready`, can be attached to any number of `SearchProfiles` (N:1) to
+ * re-order retrieval candidates by `dot(weights.w, chunk.embedding) + weights.b`.
+ *
+ * The package ships the data model + a UI slot; the consumer wires the builder
+ * component (corpus search + labeling) and the training endpoint, plus
+ * multi-tenant scoping, the same way it does for the agents collection.
+ */
+
+import type { CollectionConfig, Field } from 'payload'
+
+export interface CreateLearnedHeadsCollectionConfig {
+  /** Override the Payload collection slug. Default: `'learned-heads'`. */
+  collectionSlug?: string
+
+  /**
+   * Import-map path to a custom client component rendered at the top of the
+   * edit view (e.g. `@/components/admin/lente-builder#LenteBuilder`). It curates
+   * `examples` and triggers training. When omitted, only the raw fields show.
+   */
+  builderComponentPath?: string
+
+  /**
+   * Transform the generated config before registration. Spread and override
+   * only what you need (access, hooks, indexes, tenant field, endpoints).
+   */
+  collectionOverrides?: (config: CollectionConfig) => CollectionConfig
+}
+
+export function createLearnedHeadsCollection(config: CreateLearnedHeadsCollectionConfig): CollectionConfig {
+  const collectionSlug = config.collectionSlug ?? 'learned-heads'
+
+  const builderField: Field[] = config.builderComponentPath
+    ? [
+        {
+          name: 'builder',
+          type: 'ui',
+          admin: { components: { Field: { path: config.builderComponentPath } } }
+        }
+      ]
+    : []
+
+  const fields: Field[] = [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+      admin: { description: 'Display name, e.g. "Praxeología" or "Registro divulgativo".' }
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      required: true,
+      admin: { description: 'URL-friendly identifier. Must be unique within the tenant.' }
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+      admin: { description: 'What this lente favors vs buries.' }
+    },
+    ...builderField,
+    {
+      name: 'status',
+      type: 'select',
+      options: [
+        { label: 'Draft', value: 'draft' },
+        { label: 'Training', value: 'training' },
+        { label: 'Ready', value: 'ready' },
+        { label: 'Failed', value: 'failed' }
+      ],
+      defaultValue: 'draft',
+      admin: { readOnly: true, description: 'Set automatically by the training endpoint.' }
+    },
+    {
+      name: 'kind',
+      type: 'select',
+      options: [{ label: 'Logistic Regression (frozen encoder)', value: 'logreg' }],
+      defaultValue: 'logreg'
+    },
+    {
+      name: 'baseEncoder',
+      type: 'text',
+      defaultValue: 'bge-m3',
+      admin: { description: 'Must match the encoder the corpus chunks were embedded with.' }
+    },
+    {
+      name: 'version',
+      type: 'number',
+      defaultValue: 0,
+      admin: { readOnly: true, description: 'Incremented on each successful train.' }
+    },
+    {
+      name: 'weights',
+      type: 'json',
+      admin: { hidden: true }
+    },
+    {
+      name: 'metrics',
+      type: 'json',
+      admin: { readOnly: true, description: '{ f1_macro, val_size, trained_at } — populated after training.' }
+    },
+    {
+      name: 'examples',
+      type: 'array',
+      admin: {
+        description:
+          'Labeled chunks. positive = surface, negative = bury. Minimum 8 of each. chunkId + collection identify the Typesense document whose embedding is the feature vector.'
+      },
+      fields: [
+        { name: 'chunkId', type: 'text', required: true, admin: { description: 'Typesense document ID.' } },
+        {
+          name: 'collection',
+          type: 'text',
+          required: true,
+          admin: { description: 'Typesense collection name (e.g. books_chunk).' }
+        },
+        {
+          name: 'chunkText',
+          type: 'textarea',
+          required: true,
+          admin: { description: 'Snapshot of the chunk text — for human review, not re-fetched.' }
+        },
+        {
+          name: 'label',
+          type: 'select',
+          required: true,
+          options: [
+            { label: 'Positive', value: 'positive' },
+            { label: 'Negative', value: 'negative' }
+          ],
+          admin: { description: 'positive = the lente surfaces this; negative = it buries it.' }
+        },
+        { name: 'queryContext', type: 'text', admin: { description: 'Optional query that surfaced this chunk.' } },
+        {
+          name: 'source',
+          type: 'select',
+          options: [
+            { label: 'Manual', value: 'manual' },
+            { label: 'LLM Bootstrap', value: 'llm_bootstrap' },
+            { label: 'Chat Feedback', value: 'feedback_chat' }
+          ],
+          defaultValue: 'manual'
+        }
+      ]
+    }
+  ]
+
+  const base: CollectionConfig = {
+    slug: collectionSlug,
+    access: {
+      read: () => true,
+      create: ({ req: { user } }) => Boolean(user),
+      update: ({ req: { user } }) => Boolean(user),
+      delete: ({ req: { user } }) => Boolean(user)
+    },
+    admin: {
+      useAsTitle: 'name',
+      group: 'Chat',
+      defaultColumns: ['name', 'status', 'version', 'tenant', 'updatedAt']
+    },
+    fields
+  }
+
+  return config.collectionOverrides ? config.collectionOverrides(base) : base
+}

--- a/packages/payload-agents-core/src/collections/search-profiles.ts
+++ b/packages/payload-agents-core/src/collections/search-profiles.ts
@@ -68,6 +68,12 @@ export interface CreateSearchProfilesCollectionConfig {
    * generated config and override only what you need.
    */
   collectionOverrides?: (config: CollectionConfig) => CollectionConfig
+
+  /**
+   * Slug of the Learned Heads collection the `learnedHead` relationship points
+   * to. Default: `'learned-heads'`.
+   */
+  learnedHeadsSlug?: string
 }
 
 /**
@@ -89,6 +95,7 @@ const rerankerKindOptions: Array<{ label: string; value: SearchProfileRerankerKi
 
 export function createSearchProfilesCollection(config: CreateSearchProfilesCollectionConfig): CollectionConfig {
   const collectionSlug = config.collectionSlug ?? 'search-profiles'
+  const learnedHeadsSlug = config.learnedHeadsSlug ?? 'learned-heads'
   const filterFields = (config.filters ?? []).map(buildFilterField)
 
   const filtersTab =
@@ -204,6 +211,22 @@ export function createSearchProfilesCollection(config: CreateSearchProfilesColle
                   }
                 }
               ]
+            }
+          ]
+        },
+        {
+          label: 'Lente',
+          description:
+            'Optional learned head ("lente") applied as a soft re-ranker after retrieval. Lentes are trained and managed in their own collection and can be reused across profiles.',
+          fields: [
+            {
+              name: 'learnedHead',
+              type: 'relationship',
+              relationTo: learnedHeadsSlug,
+              admin: {
+                description:
+                  'Trained lente. When set and status is "ready", it re-scores the top candidates by dot(weights, embedding) before the reranker. Leave empty for no learned re-ranking.'
+              }
             }
           ]
         }

--- a/packages/payload-agents-core/src/index.ts
+++ b/packages/payload-agents-core/src/index.ts
@@ -1,6 +1,10 @@
 // Plugin
 
 export {
+  type CreateLearnedHeadsCollectionConfig,
+  createLearnedHeadsCollection
+} from './collections/learned-heads'
+export {
   type CreateSearchProfilesCollectionConfig,
   createSearchProfilesCollection,
   SEARCH_PROFILE_RERANKER_KINDS,


### PR DESCRIPTION
## What

Introduces **Learned Heads ("lentes")** — tenant-owned, reusable logistic-regression re-rankers over frozen BGE-M3 embeddings, trained from labeled positive/negative example chunks. A trained lente re-orders retrieval candidates toward a learned "register" (e.g. economic vs spiritual) without touching the encoder or the index.

### `payload-agents-core`
- New `createLearnedHeadsCollection` factory: `LearnedHeads` collection with `status`/`version`/`weights`/`metrics`, an `examples[]` array (each `positive`/`negative`), and a UI builder slot.
- `createSearchProfilesCollection`: the embedded head fields are replaced by an optional **N:1 `learnedHead` relation** — a lente can be reused across profiles. Opt-in: a profile with no lente behaves exactly as before.

### `mcp-typesense`
- `search_collections` applies the head as a dot-product re-ranker (`dot(w, embedding) + b`) over the top candidates when the proxy forwards a base64 `x-learned-head` header. Keeps the `embedding` field only when a head is present; otherwise unchanged.

## Why

Lets a tenant steer retrieval with ~15-40 labeled examples per lente, decoupled from the encoder/index. Validated end-to-end against the production corpus (98,985 chunks): a lente trained on 40 examples re-orders the full corpus toward the trained register.

## Notes

- Consumer wiring (the LearnedHeads collection instance, training endpoint, admin builder, MCP proxy header) lives in the ZetesisPortal PR.
- Two commits, one per scope (`payload-agents-core`, `mcp-typesense`) for release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)