### PR TITLE
feat: agent-selectable retrieval lentes + LiteLLM key self-heal

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -14,6 +14,7 @@ from agno_agent_builder.exceptions import (
     MissingLiteLlmVirtualKeyError,
 )
 from agno_agent_builder.instructions import compose_instructions
+from agno_agent_builder.retrieval_headers import build_retrieval_profile_headers
 from agno_agent_builder.sources.types import AgentConfig
 
 
@@ -115,6 +116,10 @@ def build_mcp_tools(mcp_url: str, cfg: AgentConfig) -> MCPTools:
         headers["x-top-k"] = str(cfg.top_k)
     if cfg.rewrite_template:
         headers["x-query-rewrite-template"] = cfg.rewrite_template
+    # Multi-profile (lente) catalog: the default's lente plus, when the agent has
+    # more than one profile, the full catalog + per-profile config so the LLM can
+    # pick one per query. The fields above already reflect the default profile.
+    headers.update(build_retrieval_profile_headers(cfg.retrieval_profiles))
     if headers:
         params = StreamableHTTPClientParams(url=mcp_url, headers=headers)
         return MCPTools(server_params=params, transport="streamable-http")

--- a/backend/agno-agent-builder/agno_agent_builder/instructions.py
+++ b/backend/agno-agent-builder/agno_agent_builder/instructions.py
@@ -98,6 +98,10 @@ def compose_instructions(
     if rag_parts:
         sections.append(f"<RAG_CONFIG>\n{chr(10).join(rag_parts)}\n</RAG_CONFIG>")
 
+    profiles_block = _compose_retrieval_profiles(cfg)
+    if profiles_block:
+        sections.append(profiles_block)
+
     limit_line = f"\nMax {cfg.tool_call_limit} tool calls per turn." if cfg.tool_call_limit else ""
     sections.append(
         f"<TOOL_PROTOCOL>\n{tool_protocol or DEFAULT_TOOL_PROTOCOL}{limit_line}\n</TOOL_PROTOCOL>"
@@ -105,3 +109,29 @@ def compose_instructions(
     sections.append(f"<OUTPUT_FORMAT>\n{output_format or DEFAULT_OUTPUT_FORMAT}\n</OUTPUT_FORMAT>")
 
     return "\n\n".join(sections)
+
+
+def _compose_retrieval_profiles(cfg: AgentConfig) -> str | None:
+    """When the agent exposes 2+ retrieval profiles (lentes), tell the LLM it
+    MUST pick one per search. With 0-1 profiles there's nothing to choose, so
+    the block is omitted and the MCP profile-selection guard stays off.
+    """
+    profiles = cfg.retrieval_profiles
+    if len(profiles) < 2:
+        return None
+    lines = [
+        f"- {p.slug}: {p.name}" + (f" — {p.description}" if p.description else "") for p in profiles
+    ]
+    catalog = "\n".join(lines)
+    return (
+        "<RETRIEVAL_PROFILES>\n"
+        "You have multiple retrieval profiles (lentes). Each biases search toward a\n"
+        "different register or perspective. You MUST select one for every retrieval:\n"
+        f"{catalog}\n\n"
+        'Pass `retrieval_profile: "<slug>"` in EVERY search_collections call (and in\n'
+        "each group of compare_perspectives). Pick the profile that best fits the\n"
+        "question; when in doubt call list_retrieval_profiles first. Searching without\n"
+        "a profile is rejected. To compare registers, run compare_perspectives with a\n"
+        "different retrieval_profile per group.\n"
+        "</RETRIEVAL_PROFILES>"
+    )

--- a/backend/agno-agent-builder/agno_agent_builder/retrieval_headers.py
+++ b/backend/agno-agent-builder/agno_agent_builder/retrieval_headers.py
@@ -1,0 +1,86 @@
+"""Encode multi-profile retrieval state into MCP forward headers.
+
+Mirrors the ZetesisPortal token proxy (`apps/server/.../api/search/mcp/route.ts`):
+the agent connects to the MCP server with FIXED connection headers (it can't
+peek each request like the proxy), so when an agent exposes more than one
+retrieval profile we forward the WHOLE catalog up front:
+
+- ``x-learned-head``     — the default profile's lente (base64 Float32LE [...w, b]).
+- ``x-retrieval-profiles`` — base64 JSON catalog (slug/name/description, no weights)
+  powering ``list_retrieval_profiles`` and the profile-selection guard.
+- ``x-group-profiles``   — base64 JSON map slug → {filters, retrieval(+lente)} so the
+  MCP ``search_collections``/``compare_perspectives`` tools resolve whichever
+  profile the LLM picks per query.
+
+Decoded MCP-side by ``auth/resolve.ts`` (``readAvailableProfiles`` /
+``readGroupProfiles`` / ``decodeLearnedHead``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import struct
+
+from agno_agent_builder.sources.types import LearnedHead, RetrievalProfile
+
+
+def encode_learned_head(head: LearnedHead) -> str:
+    """Base64 of a little-endian Float32 ``[...w, b]`` blob (compact, binary)."""
+    floats = [*head.w, head.b]
+    packed = struct.pack(f"<{len(floats)}f", *floats)
+    return base64.b64encode(packed).decode("ascii")
+
+
+def _encode_b64_json(value: object) -> str:
+    return base64.b64encode(json.dumps(value, separators=(",", ":")).encode("utf-8")).decode(
+        "ascii"
+    )
+
+
+def _retrieval_payload(p: RetrievalProfile) -> dict[str, object]:
+    return {
+        "rerankerKind": p.reranker_kind,
+        "rerankerModel": p.reranker_model,
+        "inputK": p.input_k,
+        "topK": p.top_k,
+        "hybridAlpha": p.hybrid_alpha,
+        "rewriteTemplate": p.rewrite_template,
+        "learnedHead": encode_learned_head(p.learned_head) if p.learned_head else None,
+    }
+
+
+def build_retrieval_profile_headers(profiles: list[RetrievalProfile]) -> dict[str, str]:
+    """Headers carrying the agent's multi-profile retrieval catalog.
+
+    - 0 profiles → ``{}`` (legacy single-profile fields, set by the caller, stand).
+    - 1 profile  → just its lente (``x-learned-head``); no catalog, so the MCP
+      profile-selection guard stays off and the agent searches as before.
+    - 2+ profiles → full catalog + per-profile config, so the agent must pick one
+      per query and each pick applies its own lente/filters.
+    """
+    headers: dict[str, str] = {}
+    if not profiles:
+        return headers
+
+    default = profiles[0]
+    if default.learned_head:
+        headers["x-learned-head"] = encode_learned_head(default.learned_head)
+
+    if len(profiles) < 2:
+        return headers
+
+    catalog = [{"slug": p.slug, "name": p.name, "description": p.description} for p in profiles]
+    headers["x-retrieval-profiles"] = _encode_b64_json(catalog)
+
+    group = {
+        p.slug: {
+            "taxonomySlugs": p.taxonomy_slugs,
+            "folderSlugs": p.folder_slugs,
+            "retrieval": _retrieval_payload(p),
+        }
+        for p in profiles
+        if p.slug
+    }
+    headers["x-group-profiles"] = _encode_b64_json(group)
+    return headers

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -16,7 +16,7 @@ import httpx
 from pydantic import SecretStr
 
 from agno_agent_builder.logging import get_logger
-from agno_agent_builder.sources.types import AgentConfig
+from agno_agent_builder.sources.types import AgentConfig, LearnedHead, RetrievalProfile
 
 logger = get_logger(__name__)
 
@@ -79,29 +79,37 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
     tenant = doc.get("tenant")
     tenant_slug = tenant.get("slug") if isinstance(tenant, dict) else None
 
-    profile = (
-        doc.get("defaultRetrievalProfile")
-        if isinstance(doc.get("defaultRetrievalProfile"), dict)
-        else None
+    # The agent can carry several retrieval profiles (`retrievalProfiles`, the
+    # multi-lente catalog). Fall back to a legacy single `defaultRetrievalProfile`
+    # during the transition. The first profile is the default: its filters /
+    # reranker / collections populate the legacy single-profile fields so
+    # non-search tools and the RAG_CONFIG block stay scoped to it.
+    raw_profiles = doc.get("retrievalProfiles")
+    profile_dicts = (
+        [p for p in raw_profiles if isinstance(p, dict)]
+        if isinstance(raw_profiles, list)
+        else [p for p in [doc.get("defaultRetrievalProfile")] if isinstance(p, dict)]
     )
-    if profile:
-        taxonomy_slugs = _extract_taxonomy_slugs(profile.get("taxonomyFilters"))
-        folder_slugs = _extract_folder_slugs(profile.get("folderFilters"))
-        reranker = profile.get("reranker") if isinstance(profile.get("reranker"), dict) else None
+    retrieval_profiles = [_to_retrieval_profile(p) for p in profile_dicts]
+    default = profile_dicts[0] if profile_dicts else None
+    if default:
+        taxonomy_slugs = _extract_taxonomy_slugs(default.get("taxonomyFilters"))
+        folder_slugs = _extract_folder_slugs(default.get("folderFilters"))
+        reranker = default.get("reranker") if isinstance(default.get("reranker"), dict) else None
         reranker_kind = (
             reranker.get("kind") if reranker and isinstance(reranker.get("kind"), str) else None
         )
         reranker_model = (
             reranker.get("model") if reranker and isinstance(reranker.get("model"), str) else None
         )
-        hybrid_alpha = _coerce_float(profile.get("hybridAlpha"))
-        input_k = _coerce_int(profile.get("inputK"))
-        top_k = _coerce_int(profile.get("topK"))
-        raw_rewrite = profile.get("queryRewrite")
+        hybrid_alpha = _coerce_float(default.get("hybridAlpha"))
+        input_k = _coerce_int(default.get("inputK"))
+        top_k = _coerce_int(default.get("topK"))
+        raw_rewrite = default.get("queryRewrite")
         rewrite_template = (
             raw_rewrite.strip() if isinstance(raw_rewrite, str) and raw_rewrite.strip() else None
         )
-        raw_collections = profile.get("searchCollections")
+        raw_collections = default.get("searchCollections")
         search_collections = (
             [s for s in raw_collections if isinstance(s, str)]
             if isinstance(raw_collections, list)
@@ -151,7 +159,58 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         input_k=input_k,
         top_k=top_k,
         rewrite_template=rewrite_template,
+        retrieval_profiles=retrieval_profiles,
     )
+
+
+def _to_retrieval_profile(profile: dict[str, Any]) -> RetrievalProfile:
+    """Map one populated SearchProfile doc into a normalized `RetrievalProfile`."""
+    reranker = profile.get("reranker") if isinstance(profile.get("reranker"), dict) else None
+    raw_rewrite = profile.get("queryRewrite")
+    slug = profile.get("slug")
+    return RetrievalProfile(
+        slug=slug if isinstance(slug, str) and slug else "",
+        name=profile.get("name") if isinstance(profile.get("name"), str) else (slug or ""),
+        description=profile.get("description")
+        if isinstance(profile.get("description"), str)
+        else "",
+        taxonomy_slugs=_extract_taxonomy_slugs(profile.get("taxonomyFilters")),
+        folder_slugs=_extract_folder_slugs(profile.get("folderFilters")),
+        reranker_kind=(
+            reranker.get("kind") if reranker and isinstance(reranker.get("kind"), str) else None
+        ),
+        reranker_model=(
+            reranker.get("model") if reranker and isinstance(reranker.get("model"), str) else None
+        ),
+        hybrid_alpha=_coerce_float(profile.get("hybridAlpha")),
+        input_k=_coerce_int(profile.get("inputK")),
+        top_k=_coerce_int(profile.get("topK")),
+        rewrite_template=(
+            raw_rewrite.strip() if isinstance(raw_rewrite, str) and raw_rewrite.strip() else None
+        ),
+        learned_head=_extract_learned_head(profile.get("learnedHead")),
+    )
+
+
+def _extract_learned_head(head: Any) -> LearnedHead | None:
+    """Pull trained weights off a populated `learnedHead` relation.
+
+    Only applied when the lente is trained (``status == 'ready'``) and carries
+    a valid ``weights`` blob. A bare id (unpopulated) or a draft/failed head
+    yields None — the profile then ranks on cosine + reranker alone.
+    """
+    if not isinstance(head, dict) or head.get("status") != "ready":
+        return None
+    weights = head.get("weights")
+    if not isinstance(weights, dict):
+        return None
+    w = weights.get("w")
+    b = weights.get("b")
+    if not isinstance(w, list) or not all(isinstance(x, (int, float)) for x in w):
+        return None
+    if not isinstance(b, (int, float)):
+        return None
+    return LearnedHead(w=[float(x) for x in w], b=float(b))
 
 
 def _coerce_float(value: Any) -> float | None:

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -167,13 +167,14 @@ def _to_retrieval_profile(profile: dict[str, Any]) -> RetrievalProfile:
     """Map one populated SearchProfile doc into a normalized `RetrievalProfile`."""
     reranker = profile.get("reranker") if isinstance(profile.get("reranker"), dict) else None
     raw_rewrite = profile.get("queryRewrite")
-    slug = profile.get("slug")
+    raw_slug = profile.get("slug")
+    slug = raw_slug if isinstance(raw_slug, str) and raw_slug else ""
+    raw_name = profile.get("name")
+    raw_description = profile.get("description")
     return RetrievalProfile(
-        slug=slug if isinstance(slug, str) and slug else "",
-        name=profile.get("name") if isinstance(profile.get("name"), str) else (slug or ""),
-        description=profile.get("description")
-        if isinstance(profile.get("description"), str)
-        else "",
+        slug=slug,
+        name=raw_name if isinstance(raw_name, str) and raw_name else slug,
+        description=raw_description if isinstance(raw_description, str) else "",
         taxonomy_slugs=_extract_taxonomy_slugs(profile.get("taxonomyFilters")),
         folder_slugs=_extract_folder_slugs(profile.get("folderFilters")),
         reranker_kind=(

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -5,6 +5,42 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, SecretStr
 
 
+class LearnedHead(BaseModel):
+    """Trained soft re-ranker (lente) weights over frozen embeddings.
+
+    ``score(x) = w·embedding(x) + b``. ``w`` has the embedding's
+    dimensionality (BGE-M3 → 1024). Forwarded to the MCP server so it can
+    bias retrieval toward the profile's learned register.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    w: list[float]
+    b: float
+
+
+class RetrievalProfile(BaseModel):
+    """One selectable retrieval profile: hard filters + retrieval params + an
+    optional lente. An agent may expose several; the LLM picks one per query
+    via the MCP ``retrieval_profile`` argument.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    slug: str
+    name: str
+    description: str = ""
+    taxonomy_slugs: list[str] = []
+    folder_slugs: list[str] = []
+    reranker_kind: str | None = None
+    reranker_model: str | None = None
+    hybrid_alpha: float | None = None
+    input_k: int | None = None
+    top_k: int | None = None
+    rewrite_template: str | None = None
+    learned_head: LearnedHead | None = None
+
+
 class AgentConfig(BaseModel):
     """Per-agent configuration consumed by `build_agent`.
 
@@ -38,3 +74,9 @@ class AgentConfig(BaseModel):
     # Mustache template applied to the user query before retrieval. Supported
     # variables (resolved MCP-side): ``{{query}}``, ``{{tenant_slug}}``.
     rewrite_template: str | None = None
+    # All retrieval profiles the agent can choose between. When >1, the builder
+    # forwards the full catalog (+ each profile's lente) to the MCP server and
+    # the agent selects one per query. The first entry is the default; its
+    # filters/reranker populate the legacy single-profile fields above so
+    # non-search tools and the RAG_CONFIG block stay scoped to it.
+    retrieval_profiles: list[RetrievalProfile] = []

--- a/backend/agno-agent-builder/tests/test_instructions.py
+++ b/backend/agno-agent-builder/tests/test_instructions.py
@@ -1,0 +1,36 @@
+"""Tests for the RETRIEVAL_PROFILES guidance block."""
+
+from __future__ import annotations
+
+from agno_agent_builder.instructions import compose_instructions
+from agno_agent_builder.sources.types import AgentConfig, RetrievalProfile
+
+
+def _cfg(profiles: list[RetrievalProfile]) -> AgentConfig:
+    return AgentConfig(
+        slug="a",
+        name="A",
+        llm_model="openai/gpt-4o",
+        api_key="k",  # type: ignore[arg-type]
+        retrieval_profiles=profiles,
+    )
+
+
+def _profile(slug: str, desc: str = "") -> RetrievalProfile:
+    return RetrievalProfile(slug=slug, name=slug.title(), description=desc)
+
+
+def test_no_block_with_zero_or_one_profile() -> None:
+    assert "<RETRIEVAL_PROFILES>" not in compose_instructions(_cfg([]))
+    assert "<RETRIEVAL_PROFILES>" not in compose_instructions(_cfg([_profile("global")]))
+
+
+def test_block_lists_profiles_and_mandates_selection() -> None:
+    prompt = compose_instructions(
+        _cfg([_profile("global", "cosine"), _profile("neoplatonismo", "lente neoplatónica")])
+    )
+    assert "<RETRIEVAL_PROFILES>" in prompt
+    assert "- global: Global — cosine" in prompt
+    assert "- neoplatonismo: Neoplatonismo — lente neoplatónica" in prompt
+    assert "MUST select one" in prompt
+    assert "retrieval_profile" in prompt

--- a/backend/agno-agent-builder/tests/test_payload_source.py
+++ b/backend/agno-agent-builder/tests/test_payload_source.py
@@ -124,6 +124,65 @@ class TestPayloadDocToAgentConfig:
         assert cfg.folder_slugs == []
         assert cfg.reranker_kind is None
 
+    def test_legacy_default_profile_becomes_single_retrieval_profile(self) -> None:
+        # A doc with only `defaultRetrievalProfile` still yields one entry in the
+        # new catalog, so the builder sends no multi-profile headers (guard off).
+        doc = self._doc()
+        doc["defaultRetrievalProfile"] = {
+            **doc["defaultRetrievalProfile"],
+            "slug": "bastos-default",
+        }
+        cfg = payload_doc_to_agent_config(doc)
+        assert len(cfg.retrieval_profiles) == 1
+        assert cfg.retrieval_profiles[0].slug == "bastos-default"
+        assert cfg.retrieval_profiles[0].hybrid_alpha == 0.5
+
+    def test_maps_multiple_retrieval_profiles_with_lente(self) -> None:
+        doc = self._doc(
+            retrievalProfiles=[
+                {
+                    "slug": "global",
+                    "name": "Global",
+                    "description": "cosine, no lente",
+                    "taxonomyFilters": [],
+                    "searchCollections": ["books_chunk"],
+                },
+                {
+                    "slug": "neoplatonismo",
+                    "name": "Neoplatonismo",
+                    "description": "lente neoplatónica",
+                    "taxonomyFilters": [{"slug": "plotino"}],
+                    "hybridAlpha": 0.7,
+                    "learnedHead": {"status": "ready", "weights": {"w": [0.1, 0.2], "b": 0.3}},
+                },
+            ]
+        )
+        cfg = payload_doc_to_agent_config(doc)
+        assert [p.slug for p in cfg.retrieval_profiles] == ["global", "neoplatonismo"]
+        # Legacy fields mirror the first (default) profile.
+        assert cfg.search_collections == ["books_chunk"]
+        # Lente only on the trained profile.
+        assert cfg.retrieval_profiles[0].learned_head is None
+        assert cfg.retrieval_profiles[1].learned_head is not None
+        assert cfg.retrieval_profiles[1].learned_head.w == [0.1, 0.2]
+        assert cfg.retrieval_profiles[1].learned_head.b == 0.3
+        assert cfg.retrieval_profiles[1].taxonomy_slugs == ["plotino"]
+
+    def test_untrained_lente_is_dropped(self) -> None:
+        doc = self._doc(
+            retrievalProfiles=[
+                {
+                    "slug": "a",
+                    "name": "A",
+                    "learnedHead": {"status": "draft", "weights": {"w": [1.0], "b": 0.0}},
+                },
+                {"slug": "b", "name": "B", "learnedHead": 99},
+            ]
+        )
+        cfg = payload_doc_to_agent_config(doc)
+        assert cfg.retrieval_profiles[0].learned_head is None
+        assert cfg.retrieval_profiles[1].learned_head is None
+
     @pytest.mark.parametrize("missing", ["slug", "llmModel", "apiKey"])
     def test_raises_on_required_missing(self, missing: str) -> None:
         doc = self._doc()

--- a/backend/agno-agent-builder/tests/test_retrieval_headers.py
+++ b/backend/agno-agent-builder/tests/test_retrieval_headers.py
@@ -1,0 +1,98 @@
+"""Tests for multi-profile retrieval header encoding.
+
+The decode side lives in `@zetesis/mcp-typesense` (auth/resolve.ts); here we
+assert the wire shape those decoders expect: base64 Float32LE for the lente and
+base64 JSON for the catalog / group map.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import struct
+
+from agno_agent_builder.retrieval_headers import (
+    build_retrieval_profile_headers,
+    encode_learned_head,
+)
+from agno_agent_builder.sources.types import LearnedHead, RetrievalProfile
+
+
+def _decode_learned_head(blob: str) -> tuple[list[float], float]:
+    buf = base64.b64decode(blob)
+    floats = list(struct.unpack(f"<{len(buf) // 4}f", buf))
+    return floats[:-1], floats[-1]
+
+
+def _decode_b64_json(blob: str) -> object:
+    return json.loads(base64.b64decode(blob).decode("utf-8"))
+
+
+def _profile(slug: str, *, lente: LearnedHead | None = None, **kw: object) -> RetrievalProfile:
+    return RetrievalProfile(slug=slug, name=slug.title(), learned_head=lente, **kw)
+
+
+class TestEncodeLearnedHead:
+    def test_round_trips_weights_and_bias(self) -> None:
+        head = LearnedHead(w=[0.5, -0.25, 1.0], b=0.125)
+        w, b = _decode_learned_head(encode_learned_head(head))
+        assert b == 0.125
+        assert w == [0.5, -0.25, 1.0]
+
+    def test_blob_is_four_bytes_per_float(self) -> None:
+        head = LearnedHead(w=[1.0] * 1024, b=0.0)
+        buf = base64.b64decode(encode_learned_head(head))
+        assert len(buf) == (1024 + 1) * 4
+
+
+class TestBuildRetrievalProfileHeaders:
+    def test_no_profiles_yields_no_headers(self) -> None:
+        assert build_retrieval_profile_headers([]) == {}
+
+    def test_single_profile_forwards_only_its_lente(self) -> None:
+        headers = build_retrieval_profile_headers(
+            [_profile("a", lente=LearnedHead(w=[1.0], b=0.0))]
+        )
+        assert "x-learned-head" in headers
+        # No catalog/guard for a single profile.
+        assert "x-retrieval-profiles" not in headers
+        assert "x-group-profiles" not in headers
+
+    def test_single_profile_without_lente_is_empty(self) -> None:
+        assert build_retrieval_profile_headers([_profile("a")]) == {}
+
+    def test_multi_profile_forwards_catalog_and_group_map(self) -> None:
+        profiles = [
+            _profile("global", description="cosine"),
+            _profile(
+                "neoplatonismo",
+                description="lente neoplatónica",
+                taxonomy_slugs=["plotino"],
+                hybrid_alpha=0.7,
+                lente=LearnedHead(w=[0.1, 0.2], b=0.3),
+            ),
+        ]
+        headers = build_retrieval_profile_headers(profiles)
+
+        catalog = _decode_b64_json(headers["x-retrieval-profiles"])
+        assert [p["slug"] for p in catalog] == ["global", "neoplatonismo"]
+        assert catalog[1]["description"] == "lente neoplatónica"
+
+        group = _decode_b64_json(headers["x-group-profiles"])
+        assert set(group) == {"global", "neoplatonismo"}
+        assert group["neoplatonismo"]["taxonomySlugs"] == ["plotino"]
+        assert group["neoplatonismo"]["retrieval"]["hybridAlpha"] == 0.7
+        # Lente stays binary (base64) inside the JSON; global has none.
+        assert isinstance(group["neoplatonismo"]["retrieval"]["learnedHead"], str)
+        assert group["global"]["retrieval"]["learnedHead"] is None
+
+    def test_multi_profile_default_lente_is_forwarded_flat(self) -> None:
+        # profiles[0] (the default) also gets its lente as x-learned-head so
+        # non-search tools stay scoped to it.
+        profiles = [
+            _profile("a", lente=LearnedHead(w=[1.0], b=0.0)),
+            _profile("b"),
+        ]
+        headers = build_retrieval_profile_headers(profiles)
+        assert "x-learned-head" in headers
+        assert "x-group-profiles" in headers

--- a/packages/mcp-typesense/src/auth/profile-scope.spec.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { McpAuthContext } from '../types'
+import { applyProfileScope } from './profile-scope'
+
+const lente = { w: [0.1, 0.2], b: 0.5 }
+
+const auth: McpAuthContext = {
+  tenantSlug: 't',
+  taxonomySlugs: ['base'],
+  retrieval: { hybridAlpha: 0.5 },
+  availableProfiles: [
+    { slug: 'a', name: 'A', description: '' },
+    { slug: 'b', name: 'B', description: '' }
+  ],
+  groupProfiles: {
+    a: { taxonomySlugs: ['mises'], folderSlugs: ['f1'], retrieval: { hybridAlpha: 0.8, learnedHead: lente } },
+    b: { taxonomySlugs: ['hayek'], retrieval: { rerankerKind: 'cohere' } }
+  }
+}
+
+describe('applyProfileScope', () => {
+  it('returns auth unchanged when no slug', () => {
+    expect(applyProfileScope(auth, undefined)).toBe(auth)
+  })
+
+  it('returns auth unchanged when slug not in groupProfiles (token route)', () => {
+    expect(applyProfileScope(auth, 'zzz')).toBe(auth)
+    expect(applyProfileScope({ tenantSlug: 't' }, 'a')).toEqual({ tenantSlug: 't' })
+  })
+
+  it('applies the chosen profile filters + lente over the base auth', () => {
+    const scoped = applyProfileScope(auth, 'a')
+    expect(scoped?.taxonomySlugs).toEqual(['mises'])
+    expect(scoped?.folderSlugs).toEqual(['f1'])
+    expect(scoped?.retrieval?.learnedHead).toEqual(lente)
+    expect(scoped?.retrieval?.hybridAlpha).toBe(0.8)
+    // tenant + catalog are preserved
+    expect(scoped?.tenantSlug).toBe('t')
+    expect(scoped?.availableProfiles).toBe(auth.availableProfiles)
+  })
+
+  it('replaces retrieval wholesale — a profile without a lente clears it', () => {
+    const scoped = applyProfileScope(auth, 'b')
+    expect(scoped?.taxonomySlugs).toEqual(['hayek'])
+    expect(scoped?.retrieval?.learnedHead).toBeUndefined()
+    expect(scoped?.retrieval?.rerankerKind).toBe('cohere')
+  })
+
+  it('returns null auth as-is', () => {
+    expect(applyProfileScope(null, 'a')).toBeNull()
+  })
+})

--- a/packages/mcp-typesense/src/auth/profile-scope.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.ts
@@ -1,0 +1,28 @@
+/**
+ * Resolve a caller-chosen retrieval profile's scope from the request's
+ * group-profile catalog.
+ *
+ * When the caller selected a profile by slug AND the upstream forwarded that
+ * profile's fully-resolved config in `groupProfiles`, return an auth context
+ * with that profile's filters + lente applied on top of the base auth.
+ * Otherwise return the auth unchanged.
+ *
+ * Two callers rely on this:
+ * - `compare_perspectives` applies it per group, so each group can run the same
+ *   query under a different lente.
+ * - `search_collections` applies it to the chosen `retrieval_profile`. This is
+ *   what lets the Agno agent — which receives the FULL profile catalog as fixed
+ *   connection headers, not a per-request proxy resolution — pick a lente per
+ *   query. The single-profile token route doesn't send `groupProfiles` for
+ *   search, so this is a no-op there (the proxy already resolved the chosen
+ *   profile into `retrieval`).
+ */
+
+import type { McpAuthContext } from '../types'
+
+export function applyProfileScope(auth: McpAuthContext | null, slug: string | undefined): McpAuthContext | null {
+  if (!auth || !slug) return auth
+  const scope = auth.groupProfiles?.[slug]
+  if (!scope) return auth
+  return { ...auth, taxonomySlugs: scope.taxonomySlugs, folderSlugs: scope.folderSlugs, retrieval: scope.retrieval }
+}

--- a/packages/mcp-typesense/src/tools/compare-perspectives.ts
+++ b/packages/mcp-typesense/src/tools/compare-perspectives.ts
@@ -8,6 +8,7 @@
  */
 
 import { z } from 'zod'
+import { applyProfileScope } from '../auth/profile-scope'
 import type { ToolContext } from '../context'
 import type { McpAuthContext } from '../types'
 import { searchCollections } from './search-collections'
@@ -76,19 +77,6 @@ export const comparePerspectivesSchema = z.object({
 
 export type ComparePerspectivesInput = z.infer<typeof comparePerspectivesSchema>
 
-/**
- * Build the auth context a group runs under. When the group names a profile and
- * the proxy resolved it (groupProfiles), apply that profile's filters + lente;
- * otherwise fall back to the request's default auth. This is what lets two
- * groups run the same query under different lentes.
- */
-function authForGroup(auth: McpAuthContext | null, slug: string | undefined): McpAuthContext | null {
-  if (!auth || !slug) return auth
-  const gp = auth.groupProfiles?.[slug]
-  if (!gp) return auth
-  return { ...auth, taxonomySlugs: gp.taxonomySlugs, folderSlugs: gp.folderSlugs, retrieval: gp.retrieval }
-}
-
 export async function comparePerspectives(
   input: ComparePerspectivesInput,
   ctx: ToolContext,
@@ -100,7 +88,7 @@ export async function comparePerspectives(
   const groupResults = await Promise.all(
     input.groups.map(async g => {
       const filters = g.taxonomy_slugs ? { taxonomy_slugs: g.taxonomy_slugs } : undefined
-      const groupAuth = authForGroup(auth, g.retrieval_profile ?? input.retrieval_profile)
+      const groupAuth = applyProfileScope(auth, g.retrieval_profile ?? input.retrieval_profile)
 
       const result = await searchCollections(
         {

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -16,6 +16,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { z } from 'zod'
 import { getCurrentAuth } from '../auth/context'
+import { applyProfileScope } from '../auth/profile-scope'
 import type { ToolContext } from '../context'
 import { type OutputFormat, toolResult } from '../format'
 import type { FeaturesConfig, ToolNameOverrides } from '../types'
@@ -167,7 +168,11 @@ export function registerTools(opts: RegisterToolsOptions): void {
       const auth = getCurrentAuth()
       const guard = requireProfileSelection(auth, input.retrieval_profile)
       if (guard) return toolResult(guard, input.format as OutputFormat)
-      const result = await searchCollections(input, ctx, auth)
+      // Resolve the chosen profile's lente+filters from the group catalog when
+      // present (Agno route: full catalog forwarded as fixed headers). No-op on
+      // the token route, where the proxy already resolved `auth.retrieval`.
+      const scoped = applyProfileScope(auth, input.retrieval_profile)
+      const result = await searchCollections(input, ctx, scoped)
       return toolResult(result, input.format as OutputFormat)
     }
   )

--- a/packages/payload-agents-core/src/lib/litellm-admin.spec.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.spec.ts
@@ -54,6 +54,69 @@ describe('LiteLlmAdminClient', () => {
     )
   })
 
+  it('self-heals an alias collision: deletes the orphan and regenerates', async () => {
+    const conflictBody = {
+      error: { message: "Key with alias 'agent/bastos' already exists.", param: 'key_alias', code: '400' }
+    }
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: () => Promise.resolve(conflictBody),
+        text: () => Promise.resolve(JSON.stringify(conflictBody))
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ deleted_keys: ['agent/bastos'] }),
+        text: () => Promise.resolve('')
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ key: 'sk-fresh' }),
+        text: () => Promise.resolve('')
+      })
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await expect(client.generateKey(PAYLOAD)).resolves.toEqual({ key: 'sk-fresh' })
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('http://litellm:4000/key/generate')
+    expect(fetchMock.mock.calls[1]?.[0]).toBe('http://litellm:4000/key/delete')
+    expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).toEqual({ key_aliases: ['agent/bastos'] })
+    expect(fetchMock.mock.calls[2]?.[0]).toBe('http://litellm:4000/key/generate')
+  })
+
+  it('does not retry a 400 that is not an alias collision', async () => {
+    const badReq = { error: { message: 'models is required', param: 'models', code: '400' } }
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve(badReq),
+      text: () => Promise.resolve(JSON.stringify(badReq))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await expect(client.generateKey(PAYLOAD)).rejects.toThrow('HTTP 400')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('deletes keys by alias via /key/delete', async () => {
+    const fetchMock = stubFetch({ deleted_keys: ['agent/bastos'] })
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })
+
+    await client.deleteKeysByAlias(['agent/bastos'])
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://litellm:4000/key/delete',
+      expect.objectContaining({ body: JSON.stringify({ key_aliases: ['agent/bastos'] }) })
+    )
+  })
+
   it('updates an existing key by key value', async () => {
     const fetchMock = stubFetch({})
     const client = new LiteLlmAdminClient({ gatewayUrl: 'http://litellm:4000', masterKey: 'sk-master' })

--- a/packages/payload-agents-core/src/lib/litellm-admin.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.ts
@@ -23,6 +23,29 @@ export interface LiteLlmModelPayload {
   modelInfo?: Record<string, unknown>
 }
 
+/** Error carrying the HTTP status + raw body so callers can react to specific failures. */
+export class LiteLlmRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+    message: string
+  ) {
+    super(message)
+    this.name = 'LiteLlmRequestError'
+  }
+}
+
+/**
+ * True when a `/key/generate` failed because the alias is already taken. LiteLLM
+ * answers 400 with a body like `Key with alias 'agent/x' already exists. Unique
+ * key aliases across all keys are required.` This is the divergence signal
+ * (Payload has no key, LiteLLM does) that `generateKey` self-heals.
+ */
+function isAliasConflict(error: unknown): boolean {
+  if (!(error instanceof LiteLlmRequestError) || error.status !== 400) return false
+  return /already exists/i.test(error.body) && /alias/i.test(error.body)
+}
+
 function toApiPayload(payload: LiteLlmVirtualKeyPayload, key?: string): Record<string, unknown> {
   const isUpdate = key !== undefined
   const result: Record<string, unknown> = {
@@ -76,16 +99,45 @@ export class LiteLlmAdminClient {
     })
     if (!res.ok) {
       const message = await res.text().catch(() => '')
-      throw new Error(`LiteLLM ${path} failed: HTTP ${res.status}${message ? ` ${message}` : ''}`)
+      throw new LiteLlmRequestError(
+        res.status,
+        message,
+        `LiteLLM ${path} failed: HTTP ${res.status}${message ? ` ${message}` : ''}`
+      )
     }
     return (await res.json()) as T
   }
 
+  /**
+   * Mint a virtual key. Self-heals the one non-retryable failure mode: an alias
+   * collision. When Payload has no key for this agent but LiteLLM already holds
+   * one under `agent/<slug>` (DB restore, agent recreated with the same slug, or
+   * a prior generate whose persist failed leaving a blocked key), `/key/generate`
+   * 400s forever. The alias uniquely identifies one agent (slug is unique), so
+   * the colliding key is necessarily an orphan — reclaim the alias by deleting it
+   * and regenerate. Bounded to a single retry so a genuine error still surfaces.
+   */
   async generateKey(payload: LiteLlmVirtualKeyPayload): Promise<LiteLlmGeneratedKey> {
+    try {
+      return await this.generateKeyOnce(payload)
+    } catch (error) {
+      if (!isAliasConflict(error)) throw error
+      await this.deleteKeysByAlias([payload.keyAlias])
+      return await this.generateKeyOnce(payload)
+    }
+  }
+
+  private async generateKeyOnce(payload: LiteLlmVirtualKeyPayload): Promise<LiteLlmGeneratedKey> {
     const body = await this.request<Record<string, unknown>>('/key/generate', toApiPayload(payload))
     const key = body.key
     if (typeof key !== 'string' || !key) throw new Error('LiteLLM /key/generate did not return a key')
     return { key }
+  }
+
+  /** Delete keys by their aliases (used to reclaim an orphaned alias before regenerating). */
+  async deleteKeysByAlias(aliases: string[]): Promise<void> {
+    if (aliases.length === 0) return
+    await this.request<Record<string, unknown>>('/key/delete', { key_aliases: aliases })
   }
 
   async updateKey(key: string, payload: LiteLlmVirtualKeyPayload): Promise<void> {


### PR DESCRIPTION
## What

Lets an **Agno agent choose between multiple lentes (learned heads) per query**, closing the gap where the agent path only ever forwarded a single SearchProfile and never the lente.

### `mcp-typesense`
- Extracts the per-group profile resolution `compare_perspectives` already did into a shared `applyProfileScope`, and applies it in `search_collections`: a caller-chosen `retrieval_profile` now resolves its lente + filters from the `x-group-profiles` catalog. No-op on the token route (the proxy already resolved `auth.retrieval`).

### `agno-agent-builder`
- `AgentConfig.retrieval_profiles` (each with its trained `LearnedHead`, applied only when `status=ready`).
- `payload.py` maps `retrievalProfiles` (falls back to the legacy single `defaultRetrievalProfile`); the first profile drives the legacy single-profile fields.
- New `retrieval_headers` module emits `x-learned-head` + `x-retrieval-profiles` + `x-group-profiles` when 2+ profiles exist — **byte-identical** binary encoding to the token proxy.
- `instructions.py` adds a `RETRIEVAL_PROFILES` block telling the LLM to pick a profile per search.

### `payload-agents-core` (fix)
- `generateKey` self-heals LiteLLM alias collisions (DB restore, agent recreated with same slug, persist-after-generate failure): reclaims the orphaned `agent/<slug>` alias via `/key/delete` and regenerates, bounded to one retry. Adds `deleteKeysByAlias` + a status-carrying `LiteLlmRequestError`.

## Testing
- `mcp-typesense`: build + 16 tests (incl. new `profile-scope.spec.ts`), Biome clean.
- `agno-agent-builder`: 35 tests (headers round-trip, multi-profile mapping, instructions), ruff clean.
- `payload-agents-core`: 24 tests (incl. 3 new self-heal cases), build + Biome clean.
- Python↔TS lente weight encoding verified byte-for-byte.

Paired with a ZetesisPortal PR that flips the `agents` collection to `retrievalProfiles` (hasMany) with a data-preserving migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)