### PR TITLE
chore: revive devcontainer (LiteLLM gateway + Debian/Python) and fix playground boot

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,27 +1,26 @@
-FROM node:25-alpine
+FROM node:24-bookworm-slim
 
-RUN apk add --no-cache \
-    git \
-    bash \
-    curl \
-    docker-cli docker-cli-buildx docker-cli-compose
+# Debian (glibc) base → paridad con el backend en prod (uv:python3.12-bookworm-slim)
+# y con CI (Node 24). Evita la fricción de musl con sharp/native deps y wheels Python.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git bash curl ca-certificates netcat-openbsd unzip \
+ && rm -rf /var/lib/apt/lists/*
 
 # Claude CLI (official installer)
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-# uv (Python package runner) — needed for MCP servers like mcpdoc
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv && \
-    ln -s /root/.local/bin/uvx /usr/local/bin/uvx
+# uv (binarios oficiales) + Python 3.12 gestionado por uv (glibc → wheels manylinux,
+# sin compilar desde source). Lo necesita el workspace backend/ (agno-agent, workers).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+RUN uv python install 3.12
 
-# Bun
+# Bun — lo usa apps/mcp (`bun --watch src/index.ts`)
 RUN curl -fsSL https://bun.sh/install | bash && \
     ln -s /root/.bun/bin/bun /usr/local/bin/bun && \
     ln -s /root/.bun/bin/bunx /usr/local/bin/bunx
 
-# pnpm via corepack (--force needed on Node 25 due to yarn conflicts)
-RUN npm install -g corepack --force && \
-    corepack enable && \
+# pnpm via corepack (Node 24 ya incluye corepack → sin --force)
+RUN corepack enable && \
     corepack prepare pnpm@10.14.0 --activate
 
 WORKDIR /workspace

--- a/.devcontainer/check-services.sh
+++ b/.devcontainer/check-services.sh
@@ -16,29 +16,19 @@ echo ""
 echo "Checking service connectivity..."
 echo "---------------------------------"
 
-# PostgreSQL
-if ping -c 1 db >/dev/null 2>&1; then
-    echo "PostgreSQL (db): Reachable"
-    if nc -z db 5432 2>/dev/null; then
-        echo "PostgreSQL port 5432: Open"
+check_service() {
+    local name="$1" host="$2" port="$3"
+    if nc -z "$host" "$port" 2>/dev/null; then
+        echo "$name ($host:$port): Open"
     else
-        echo "PostgreSQL port 5432: Closed"
+        echo "$name ($host:$port): Closed"
     fi
-else
-    echo "PostgreSQL (db): Unreachable"
-fi
+}
 
-# Typesense
-if ping -c 1 typesense >/dev/null 2>&1; then
-    echo "Typesense: Reachable"
-    if nc -z typesense 8108 2>/dev/null; then
-        echo "Typesense port 8108: Open"
-    else
-        echo "Typesense port 8108: Closed"
-    fi
-else
-    echo "Typesense: Unreachable"
-fi
+check_service "PostgreSQL" db 5432
+check_service "Typesense" typesense 8108
+check_service "Redis" redis 6379
+check_service "LiteLLM" litellm 4000
 
 echo ""
 echo "System info..."
@@ -46,13 +36,17 @@ echo "--------------"
 echo "Docker available: $(which docker >/dev/null && echo "Yes" || echo "No")"
 echo "Node version: $(node --version 2>/dev/null || echo "Not found")"
 echo "pnpm version: $(pnpm --version 2>/dev/null || echo "Not found")"
+echo "uv version: $(uv --version 2>/dev/null || echo "Not found")"
+echo "Python (uv): $(uv run python --version 2>/dev/null || echo "Not found")"
 
 echo ""
 echo "Open ports..."
 echo "-------------"
-netstat -tuln 2>/dev/null | grep -E ":3000|:5432|:8108" || echo "No service ports found open yet"
+netstat -tuln 2>/dev/null | grep -E ":3000|:3030|:4000|:5432|:6379|:8000|:8001|:8108" || echo "No service ports found open yet"
 
 echo ""
-echo "To rebuild the devcontainer:"
-echo "  Ctrl+Shift+P -> 'Codespaces: Rebuild Container'"
-echo "  Or use 'Rebuild and Reopen in Container' from VS Code"
+echo "Next steps..."
+echo "------------"
+echo "  Full stack:  Run & Debug -> 'Launch' (Server + MCP + Agent Runtime + Workers)"
+echo "  TS only:     pnpm dev     (Server :3000 + MCP :3030)"
+echo "  LiteLLM UI:  http://localhost:4000/ui/  (admin/admin)"

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -11,12 +11,31 @@ TYPESENSE_PROTOCOL=http
 # MCP
 MCP_PORT=3030
 
-# Agent Runtime
+# Agent Runtime (Agno) — corre dentro del container app via launch.json "Agent Runtime"
 AGENT_RUNTIME_URL=http://localhost:8000
 AGNO_INTERNAL_SECRET=dev
 INTERNAL_SECRET=dev
 
-# Worker (taskiq + redis)
+# LiteLLM proxy (LLM gateway, servicio docker-compose `litellm`). El Agent Runtime
+# enruta TODOS los agentes por aquí; es REQUERIDO (agno-agent hace raise sin
+# LITELLM_PROXY_URL). Admin UI: http://localhost:4000/ui/ (admin/admin).
+LITELLM_PROXY_URL=http://litellm:4000/v1
+LITELLM_MASTER_KEY=sk-poc-local-1234
+LITELLM_SALT_KEY=sk-local-litellm-salt-key-change-me
+UI_USERNAME=admin
+UI_PASSWORD=admin
+# Catálogo de modelos para el admin de Payload (select + validación). Sin esto,
+# llmModel queda como texto libre.
+LITELLM_GATEWAY_URL=http://litellm:4000
+
+# Langfuse — OPT-IN, no provisto por el devcontainer. Para tracing/coste, apunta
+# estas vars a tu instancia en devcontainer.env.local (gitignored). Sin ellas el
+# gateway funciona igual (telemetría desactivada).
+# LANGFUSE_HOST=
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+
+# Worker (taskiq + redis) — corre dentro del container app via launch.json
 REDIS_URL=redis://redis:6379
 PAYLOAD_WORKER_URL=http://localhost:8001
 PAYLOAD_SERVICE_TOKEN=PAYLOAD_SERVICE_TOKEN_SECRET

--- a/.devcontainer/devcontainer.env.example
+++ b/.devcontainer/devcontainer.env.example
@@ -1,1 +1,52 @@
-GITHUB_TOKEN=XXXXXXXX
+# Plantilla de variables del devcontainer. El fichero real `devcontainer.env`
+# está committeado con valores de DEV (no son secretos reales). Para overrides y
+# tus propias API keys crea `devcontainer.env.local` (gitignored).
+
+# --- Postgres ---
+POSTGRES_USER=db_admin
+POSTGRES_PASSWORD=devsecret
+POSTGRES_DB=payload_agents
+DATABASE_URL=postgresql://db_admin:devsecret@db/payload_agents
+
+# --- Payload ---
+PAYLOAD_SECRET=change-me
+
+# --- Typesense ---
+TYPESENSE_API_KEY=xyz
+TYPESENSE_HOST=typesense
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=http
+
+# --- MCP ---
+MCP_PORT=3030
+
+# --- Agent Runtime (Agno) ---
+AGENT_RUNTIME_URL=http://localhost:8000
+INTERNAL_SECRET=dev
+
+# --- LiteLLM gateway (REQUERIDO por el Agent Runtime) ---
+LITELLM_PROXY_URL=http://litellm:4000/v1
+LITELLM_MASTER_KEY=sk-poc-local-1234
+LITELLM_SALT_KEY=change-me
+LITELLM_GATEWAY_URL=http://litellm:4000
+UI_USERNAME=admin
+UI_PASSWORD=admin
+
+# --- Worker (taskiq + redis) ---
+REDIS_URL=redis://redis:6379
+PAYLOAD_WORKER_URL=http://localhost:8001
+PAYLOAD_SERVICE_TOKEN=change-me
+DOCUMENTS_COLLECTION_SLUG=documents
+
+# --- API keys de proveedores (aporta las tuyas) ---
+# IMPORTANTE: pon OPENAI/GEMINI en devcontainer.env.local (gitignored), NO en el
+# containerEnv de devcontainer.json. containerEnv tiene prioridad sobre este
+# env_file y, si tu host no exporta la var, la inyecta VACÍA y pisa la de aquí.
+#   OPENAI_API_KEY=     # embeddings (Typesense) + BYOK del gateway
+#   GEMINI_API_KEY=     # modelos económicos (BYOK)
+# ANTHROPIC_API_KEY sí llega del host via containerEnv (lo usa Claude CLI).
+
+# --- Langfuse (opt-in, tracing/coste) ---
+# LANGFUSE_HOST=
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,21 @@
   "dockerComposeFile": "docker-compose.yml",
   "service": "app",
   "workspaceFolder": "/workspace",
-  "runServices": ["db", "typesense", "app"],
-  "forwardPorts": [3000, 3030, 5432, 8000, 8108],
+  "runServices": ["db", "typesense", "redis", "litellm", "typesense-dashboard", "app"],
+  "forwardPorts": [3000, 3030, 4000, 5432, 6379, 8000, 8001, 8081, 8108],
   "portsAttributes": {
     "3000": { "label": "Payload CMS", "onAutoForward": "openPreview" },
     "3030": { "label": "MCP Server", "onAutoForward": "ignore" },
+    "4000": { "label": "LiteLLM Admin UI", "onAutoForward": "notify" },
     "5432": { "label": "PostgreSQL", "onAutoForward": "ignore" },
+    "6379": { "label": "Redis", "onAutoForward": "ignore" },
     "8000": { "label": "Agent Runtime", "onAutoForward": "ignore" },
+    "8001": { "label": "Documents Worker", "onAutoForward": "ignore" },
+    "8081": { "label": "Typesense Dashboard", "onAutoForward": "ignore" },
     "8108": { "label": "Typesense", "onAutoForward": "ignore" }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
   },
   "customizations": {
     "vscode": {
@@ -20,7 +27,8 @@
         "bradlc.vscode-tailwindcss",
         "ms-azuretools.vscode-docker",
         "github.vscode-github-actions",
-        "unifiedjs.vscode-mdx"
+        "unifiedjs.vscode-mdx",
+        "ms-python.python"
       ],
       "settings": {
         "editor.formatOnSave": true,
@@ -34,8 +42,8 @@
       }
     }
   },
-  "postCreateCommand": "pnpm install && echo 'Checking services...' && .devcontainer/check-services.sh",
-  "postStartCommand": "echo 'Waiting for services to be ready...' && sleep 5 && echo 'To start the dev server, run: pnpm dev'",
+  "postCreateCommand": "pnpm install && (cd backend && uv sync --all-packages) && echo 'Checking services...' && .devcontainer/check-services.sh",
+  "postStartCommand": "echo 'Services starting. Stack completo: Run & Debug → \"Launch\". Solo TS: pnpm dev (Server + MCP).'",
   "otherPortsAttributes": {
     "onAutoForward": "notify"
   },

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,34 @@ services:
       timeout: 5s
       retries: 5
 
+  # Crea la base `litellm_db` (LiteLLM corre en modo DB, separado de Payload).
+  # Idempotente: cubre volúmenes nuevos y existentes por igual.
+  litellm-db-init:
+    image: postgres:17-alpine
+    restart: "no"
+    env_file:
+      - devcontainer.env
+      - path: devcontainer.env.local
+        required: false
+    command:
+      - sh
+      - -lc
+      - |
+        export PGPASSWORD="$${POSTGRES_PASSWORD}"
+        psql \
+          -h db \
+          -U "$${POSTGRES_USER}" \
+          -d "$${POSTGRES_DB}" \
+          -v ON_ERROR_STOP=1 \
+          -f /init-litellm-db.sql
+    volumes:
+      - ./litellm/init-litellm-db.sql:/init-litellm-db.sql:ro
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - default_network
+
   typesense:
     image: typesense/typesense:30.1
     restart: unless-stopped
@@ -26,6 +54,16 @@ services:
     volumes:
       - typesense_data:/data
     command: ["--data-dir", "/data", "--api-key=xyz", "--enable-cors"]
+    networks:
+      - default_network
+
+  typesense-dashboard:
+    image: ghcr.io/bfritscher/typesense-dashboard:latest
+    restart: unless-stopped
+    ports:
+      - "8081:80"
+    depends_on:
+      - typesense
     networks:
       - default_network
 
@@ -45,6 +83,68 @@ services:
       timeout: 3s
       retries: 5
 
+  # LiteLLM proxy — gateway OpenAI-compatible que calcula el coste REAL por
+  # llamada. Reachable in-network como http://litellm:4000 y en el host por
+  # http://localhost:4000 (Admin UI en /ui/, admin/admin).
+  # Langfuse es OPT-IN: el devcontainer NO lo provee. Si quieres reporting de
+  # coste, define LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY/LANGFUSE_HOST en
+  # devcontainer.env.local apuntando a tu propia instancia.
+  # DB mode: cargamos devcontainer.env para compartir la master key con Payload,
+  # pero sobreescribimos DATABASE_URL para que LiteLLM use su propia DB.
+  litellm:
+    image: ghcr.io/berriai/litellm:v1.82.0-stable
+    restart: unless-stopped
+    command: ["--config", "/app/config.yaml", "--port", "4000"]
+    env_file:
+      - devcontainer.env
+      - path: devcontainer.env.local
+        required: false
+    environment:
+      DATABASE_URL: postgresql://db_admin:devsecret@db:5432/litellm_db
+    volumes:
+      - ./litellm/litellm_config.yaml:/app/config.yaml:ro
+      # Pre-call hook: copia el traceparent del runtime a metadata.existing_trace_id
+      # para que la generation de Langfuse (con coste) se anide en el trace de Agno.
+      - ./litellm/custom_callbacks.py:/app/custom_callbacks.py:ro
+    depends_on:
+      litellm-db-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"from urllib.request import urlopen; urlopen('http://localhost:4000/health/readiness', timeout=2)\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 24
+    ports:
+      - "4000:4000"
+    networks:
+      - default_network
+
+  # Siembra idempotente del catálogo de modelos en la DB de LiteLLM.
+  litellm-bootstrap:
+    image: ghcr.io/berriai/litellm:v1.82.0-stable
+    restart: "no"
+    env_file:
+      - devcontainer.env
+      - path: devcontainer.env.local
+        required: false
+    environment:
+      LITELLM_URL: http://litellm:4000
+      LITELLM_CATALOG_JSON: >-
+        [{"name":"chat-estandar","model":"openai/gpt-4o-mini","description":"Chat general — rápido y económico","requiresKey":"openai","tier":"standard"},{"name":"chat-premium","model":"anthropic/claude-sonnet-4-6","description":"Máxima calidad para agentes de cara al cliente","requiresKey":"anthropic","tier":"premium"},{"name":"razonador","model":"openai/o4-mini","description":"Razonamiento y análisis","requiresKey":"openai","tier":"standard"},{"name":"economico","model":"gemini/gemini-2.5-flash","description":"Volúmenes altos a mínimo coste","requiresKey":"google","tier":"economy"}]
+    entrypoint: ["python"]
+    command: ["/app/bootstrap_catalog.py"]
+    volumes:
+      - ./litellm/bootstrap_catalog.py:/app/bootstrap_catalog.py:ro
+    depends_on:
+      litellm:
+        condition: service_healthy
+    networks:
+      - default_network
+
   app:
     build:
       context: .
@@ -52,6 +152,9 @@ services:
     volumes:
       - ..:/workspace:cached
       - node_modules:/workspace/node_modules:delegated
+      # Volumen propio para el venv de Python: evita que el .venv del host (macOS)
+      # se monte dentro del container Linux y rompa uv.
+      - backend_venv:/workspace/backend/.venv:delegated
       - claude_memory:/root/.claude
       - /var/run/docker.sock:/var/run/docker.sock
     command: sleep infinity
@@ -66,11 +169,14 @@ services:
         condition: service_started
       redis:
         condition: service_healthy
+      litellm-bootstrap:
+        condition: service_completed_successfully
     networks:
       - default_network
 
 volumes:
   node_modules:
+  backend_venv:
   claude_memory:
   postgres_data:
   typesense_data:

--- a/.devcontainer/litellm/bootstrap_catalog.py
+++ b/.devcontainer/litellm/bootstrap_catalog.py
@@ -1,0 +1,71 @@
+"""Idempotently seed LiteLLM DB model catalog for local dev."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+from typing import Any
+
+
+def _json_request(method: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(  # noqa: S310 - internal LiteLLM URL from compose env.
+        f"{BASE_URL}{path}",
+        data=body,
+        method=method,
+        headers={
+            "Authorization": f"Bearer {MASTER_KEY}",
+            "Content-Type": "application/json",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:  # noqa: S310
+        raw = response.read().decode("utf-8")
+    return json.loads(raw) if raw else {}
+
+
+def _existing_model_names() -> set[str]:
+    last_error: Exception | None = None
+    for _ in range(60):
+        try:
+            body = _json_request("GET", "/model/info")
+            return {
+                item["model_name"]
+                for item in body.get("data", [])
+                if isinstance(item, dict) and isinstance(item.get("model_name"), str)
+            }
+        except Exception as exc:  # pragma: no cover - exercised by compose startup
+            last_error = exc
+            time.sleep(2)
+
+    raise RuntimeError(f"LiteLLM did not become ready for catalog bootstrap: {last_error}")
+
+
+def _model_payload(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model_name": item["name"],
+        "litellm_params": {"model": item["model"]},
+        "model_info": {
+            "description": item.get("description", ""),
+            "requires_key": item.get("requiresKey", ""),
+            "catalog_tier": item.get("tier", ""),
+        },
+    }
+
+
+BASE_URL = os.environ["LITELLM_URL"].rstrip("/")
+MASTER_KEY = os.environ["LITELLM_MASTER_KEY"]
+CATALOG = json.loads(os.environ["LITELLM_CATALOG_JSON"])
+
+existing = _existing_model_names()
+created = 0
+
+for catalog_item in CATALOG:
+    name = catalog_item["name"]
+    if name in existing:
+        continue
+    _json_request("POST", "/model/new", _model_payload(catalog_item))
+    created += 1
+
+print(f"LiteLLM catalog bootstrap complete: created={created}, existing={len(existing)}")

--- a/.devcontainer/litellm/custom_callbacks.py
+++ b/.devcontainer/litellm/custom_callbacks.py
@@ -1,0 +1,49 @@
+"""Pre-call hook del proxy: enlaza la generation de Langfuse al trace OTel del runtime.
+
+El callback clásico `langfuse` calcula el coste real pero crea su propia traza
+salvo que la request lleve `metadata.existing_trace_id`. El runtime no puede
+mandarlo (el extra_body del builder es estático y el trace nace en cada run),
+pero SÍ propaga el header W3C `traceparent` (HTTPXClientInstrumentor). Este hook
+copia el trace_id del traceparent a `metadata.existing_trace_id`, de modo que la
+generation del proxy — con su coste — se anida bajo el MISMO trace que exporta
+Agno via OTLP.
+
+Nota: el callback `langfuse_otel` haría esto de serie, pero en v1.82.0 descarta
+deliberadamente el traceparent (integrations/langfuse/langfuse_otel.py +
+opentelemetry.py::_handle_success "is_langfuse_otel → parent_span = None"), así
+que cada llamada acababa como traza raíz suelta y sin anidar.
+"""
+
+from litellm.integrations.custom_logger import CustomLogger
+
+_TRACEPARENT_PARTS = 4
+_TRACE_ID_LEN = 32
+_NULL_TRACE_ID = "0" * _TRACE_ID_LEN
+
+
+def _trace_id_from_traceparent(traceparent: str) -> str | None:
+    """Extrae el trace-id de un header W3C `traceparent` (00-<32hex>-<16hex>-<flags>)."""
+    parts = traceparent.split("-")
+    if len(parts) != _TRACEPARENT_PARTS:
+        return None
+    trace_id = parts[1].lower()
+    if len(trace_id) != _TRACE_ID_LEN or trace_id == _NULL_TRACE_ID:
+        return None
+    return trace_id
+
+
+class TraceparentToLangfuse(CustomLogger):
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data: dict, call_type: str):
+        headers = (data.get("proxy_server_request") or {}).get("headers") or {}
+        traceparent = headers.get("traceparent")
+        if not traceparent:
+            return data
+        trace_id = _trace_id_from_traceparent(traceparent)
+        if not trace_id:
+            return data
+        metadata = data.setdefault("metadata", {})
+        metadata.setdefault("existing_trace_id", trace_id)
+        return data
+
+
+proxy_handler_instance = TraceparentToLangfuse()

--- a/.devcontainer/litellm/init-litellm-db.sql
+++ b/.devcontainer/litellm/init-litellm-db.sql
@@ -1,0 +1,6 @@
+-- LiteLLM DB mode uses a separate database from Payload.
+-- This file is run by the idempotent litellm-db-init compose service, so fresh
+-- and existing dev volumes are covered the same way.
+
+SELECT 'CREATE DATABASE "litellm_db"'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'litellm_db')\gexec

--- a/.devcontainer/litellm/litellm_config.yaml
+++ b/.devcontainer/litellm/litellm_config.yaml
@@ -1,0 +1,40 @@
+# LiteLLM gateway para el devcontainer de PayloadAgents en modo DB.
+# Los agentes referencian el NOMBRE del preset; el gateway lo resuelve. La clave
+# del proveedor del agente viaja por request (BYOK via extra_body.api_key).
+# Payload lee el catálogo vivo via GET /model/info y las virtual keys por agente
+# se gestionan con la Admin API.
+#
+# El catálogo inicial se siembra de forma idempotente desde
+# bootstrap_catalog.py. Después manda LiteLLM DB/Admin UI.
+
+litellm_settings:
+  # Reporting de coste a Langfuse — OPT-IN. El devcontainer no provee Langfuse:
+  # define LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY/LANGFUSE_HOST en
+  # devcontainer.env.local (apuntando a tu instancia).
+  #
+  # Callback clásico `langfuse` (coste real calculado por LiteLLM) + pre-call
+  # hook (custom_callbacks.py) que copia el trace-id del header W3C
+  # `traceparent` a metadata.existing_trace_id → la generation del proxy se
+  # anida bajo el MISMO trace OTel que emite Agno.
+  #
+  # Descartados: `langfuse_otel` ignora el traceparent a propósito en v1.82.0
+  # (cada llamada = traza raíz suelta); el `otel` genérico sí anida pero emite
+  # el ALIAS como modelo (Langfuse no puede calcular coste en no-streaming) y
+  # añade spans internos de ruido (auth/router/proxy_pre_call) a cada traza.
+  success_callback: ["langfuse"]
+  callbacks: custom_callbacks.proxy_handler_instance
+  #
+  # Permite que el cliente sobreescriba api_key por request (BYOK).
+  drop_params: true
+  #
+  # Inyecta el coste real (calculado por LiteLLM) en el `usage` del chunk de
+  # streaming. Agno lo lee como `usage.cost` → RunMetrics.cost → el evento
+  # `agno_run_completed` → payload-agents-metrics lo persiste como costUsd real
+  # (costSource: gateway) en vez de estimarlo con su tabla de precios estática.
+  include_cost_in_streaming_usage: true
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+  store_model_in_db: true
+  supported_db_objects: ["models"]
+  allow_client_side_credentials: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-TypeScript monorepo (pnpm workspaces + Turborepo) with 5 publishable npm packages under `@zetesis/`.
+TypeScript monorepo (pnpm workspaces + Turborepo) with 10 publishable npm packages under `@zetesis/` plus a Python backend (uv workspace) for the agent runtime and workers.
 
 Open-source Payload CMS plugins extracted from ZetesisPortal.
 
@@ -48,13 +48,31 @@ To audit types of a package, follow the playbook manually.
 
 ## Packages
 
+### npm packages (`packages/*`)
+
 | Package | Entry points | Internal deps |
 |---------|-------------|---------------|
 | `payload-indexer` | `.` `.client` | -- |
 | `payload-typesense` | `.` | payload-indexer |
-| `payload-lexical-blocks-builder` | `.` `.builder` `.renderer` | -- |
 | `payload-taxonomies` | `.` `.constants` | -- |
-| `chat-agent` | `.` `.styles.css` | -- |
+| `payload-lexical-blocks-builder` | `.` `.builder` `.renderer` | -- |
+| `payload-agents-core` | `.` `.client` | -- |
+| `payload-agents-metrics` | `.` `.client` | agent-ui, payload-agents-core |
+| `payload-documents` | `.` `.client` | nexus-queue |
+| `agent-ui` | `.` `.styles.css` | -- |
+| `mcp-typesense` | `.` | -- |
+| `nexus-queue` | `.` | -- |
+
+### Apps (`apps/*`, private)
+
+- `server` -- Payload CMS playground (Next.js)
+- `mcp` -- MCP server (Bun), wraps `@zetesis/mcp-typesense`
+
+### Python backend (`backend/*`, uv workspace)
+
+- `agno-agent-builder` / `agno-agent` -- Agno agent runtime (routed through the LiteLLM gateway)
+- `nexus-queue` -- Taskiq + Redis Streams worker base
+- `payload-documents-worker-builder` / `payload-documents-worker` -- LlamaParse PDF parser
 
 ## Commands
 
@@ -87,7 +105,7 @@ pnpm test
 - **No `as any`** -- always use a typed alternative
 - **No `eslint-disable` / `biome-ignore`** -- fix the cause, not the symptom
 - **pnpm** as package manager (v10)
-- **Node 22.x+**
+- **Node 24** (matches CI; the Dev Container ships it). `engines` allow 22–25.
 - **Conventional commits drive releases** -- release-please opens/updates a release PR (`chore(main): release ...`) automatically. No manual `.changeset/*.md` files.
 
   **Valid scopes** (must match `component` in `release-please-config.json`):

--- a/README.md
+++ b/README.md
@@ -1,110 +1,123 @@
 # PayloadAgents
 
-Open-source [Payload CMS](https://payloadcms.com) plugins for **semantic search, RAG-powered chat, taxonomy management, and content rendering** — extracted from [Zetesis Portal](https://zetesis.xyz), a production platform that turns organizational knowledge into accessible, AI-powered experiences.
+Open-source [Payload CMS](https://payloadcms.com) plugins for **semantic search, RAG-powered chat, AI agents, taxonomy management, and content rendering** — extracted from [Zetesis Portal](https://zetesis.xyz), a production platform that turns organizational knowledge into accessible, AI-powered experiences.
 
 > **ζήτησις** (zḗtēsis) — _inquiry_. Zetesis builds systems that make company expertise searchable and conversational through semantic search, AI agents, and structured content. These packages are the open-source core of that work.
 
 ## Packages
 
+### npm packages (`packages/*`) — `@zetesis/*`
+
 | Package | Description |
 |---------|-------------|
-| [`@zetesis/payload-indexer`](packages/payload-indexer) | Collection sync & embedding pipeline — hooks into Payload lifecycle to extract, chunk, embed, and push documents to a search backend |
-| [`@zetesis/payload-typesense`](packages/payload-typesense) | Typesense adapter with search endpoints, vector/hybrid search, and RAG chat integration |
-| [`@zetesis/payload-taxonomies`](packages/payload-taxonomies) | Hierarchical taxonomies with breadcrumb navigation and relationship field builders |
-| [`@zetesis/payload-lexical-blocks-builder`](packages/payload-lexical-blocks-builder) | Lexical editor blocks builder & server-side renderer |
-| [`@zetesis/chat-agent`](packages/chat-agent) | Floating chat UI with streaming responses, session management, and agent selection |
+| [`payload-indexer`](packages/payload-indexer) | Collection sync & embedding pipeline — hooks into the Payload lifecycle to extract, chunk, embed, and push documents to a search backend |
+| [`payload-typesense`](packages/payload-typesense) | Typesense adapter with search endpoints, vector/hybrid search, and RAG chat integration |
+| [`payload-taxonomies`](packages/payload-taxonomies) | Hierarchical taxonomies with breadcrumb navigation and relationship field builders |
+| [`payload-lexical-blocks-builder`](packages/payload-lexical-blocks-builder) | Lexical editor blocks builder & server-side renderer |
+| [`payload-agents-core`](packages/payload-agents-core) | AI agents in Payload — agent collections, LiteLLM gateway admin, per-agent virtual keys (BYOK) |
+| [`payload-agents-metrics`](packages/payload-agents-metrics) | Agent run & cost metrics (real gateway cost or static estimate) |
+| [`payload-documents`](packages/payload-documents) | Documents collection with PDF parsing (LlamaParse) via the queue worker |
+| [`agent-ui`](packages/agent-ui) | Floating chat UI (AG-UI based) with streaming responses, session management, and agent selection |
+| [`mcp-typesense`](packages/mcp-typesense) | MCP server exposing the indexed content over the Model Context Protocol |
+| [`nexus-queue`](packages/nexus-queue) | Taskiq + Redis Streams queue helpers (TypeScript side) |
+
+### Python services (`backend/*`)
+
+uv workspace for the agent runtime and workers — published to PyPI by release-please.
+
+| Package | Description |
+|---------|-------------|
+| `agno-agent-builder` | Agno-based agent runtime factory (FastAPI), routed through the LiteLLM gateway |
+| `agno-agent` | Thin runtime that wires `agno-agent-builder` to Payload as the agent source |
+| `nexus-queue` | Taskiq + Redis Streams worker base |
+| `payload-documents-worker-builder` / `payload-documents-worker` | LlamaParse PDF parser running on the queue |
+
+### Apps (`apps/*`, private)
+
+| App | Description |
+|-----|-------------|
+| `server` | Payload CMS playground (Next.js) that wires every package together |
+| `mcp` | MCP server — thin wrapper around `@zetesis/mcp-typesense` (runs on Bun) |
 
 ## Quick start
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org) 22+
-- [pnpm](https://pnpm.io) 10+
-- [Docker](https://www.docker.com) (for PostgreSQL & Typesense)
+- [Node.js](https://nodejs.org) 24 (matches CI; the Dev Container ships it)
+- [pnpm](https://pnpm.io) 10
+- [Docker](https://www.docker.com) (PostgreSQL, Typesense, Redis, LiteLLM)
+- For the Python backend outside the Dev Container: [uv](https://docs.astral.sh/uv/) + Python 3.12
 
 ### Option A — Dev Container (recommended)
 
-The repo includes a full Dev Container setup with PostgreSQL, Typesense, and all tooling pre-configured.
+A full Dev Container ships PostgreSQL, Typesense, Redis, the **LiteLLM gateway**, all JS/Python tooling (Node 24, pnpm, uv + Python 3.12, Bun) and the dev env vars pre-configured in `.devcontainer/devcontainer.env` — **no env copying needed**.
 
-1. Open the repo in VS Code / Cursor
-2. **Reopen in Container** when prompted (or via the command palette)
-3. Copy the env file and add your API keys:
-
-   ```bash
-   cp apps/server/.env.example apps/server/.env
-   # Edit .env and set OPENAI_API_KEY (required for embeddings)
-   ```
-
-4. Start the dev server:
+1. Open the repo in VS Code / Cursor and **Reopen in Container**.
+2. (Optional) Provide your own provider keys for real LLM/embeddings calls: export `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / `GEMINI_API_KEY` on your host (injected via `containerEnv`) or add them to `.devcontainer/devcontainer.env.local` (gitignored).
+3. Start the stack from **Run & Debug → "Launch"** (Server + MCP + Agent Runtime + Workers), or for just the TS side run:
 
    ```bash
-   cd apps/server
-   pnpm run dev
+   pnpm dev        # Server (:3000) + MCP (:3030)
    ```
 
-5. Open [localhost:3000](http://localhost:3000) for the playground or [localhost:3000/admin](http://localhost:3000/admin) for the Payload admin panel.
+4. Open:
+   - [localhost:3000/admin](http://localhost:3000/admin) — Payload admin
+   - [localhost:3000](http://localhost:3000) — playground
+   - [localhost:4000/ui/](http://localhost:4000/ui/) — LiteLLM Admin UI (`admin` / `admin`)
+   - [localhost:8081](http://localhost:8081) — Typesense Dashboard
 
 ### Option B — Manual setup
 
 1. **Clone & install:**
 
    ```bash
-   git clone https://github.com/Zetesis-Labs/PayloadAgents.git
-   cd PayloadAgents
+   git clone https://github.com/Zetesis-Labs/payload-agents.git
+   cd payload-agents
    pnpm install
    ```
 
-2. **Start infrastructure** (PostgreSQL + Typesense):
+2. **Start infrastructure** (PostgreSQL + Typesense + Redis + LiteLLM):
 
    ```bash
-   docker compose -f .devcontainer/docker-compose.yml up -d db typesense
+   docker compose -f .devcontainer/docker-compose.yml up -d db typesense redis litellm
    ```
 
-3. **Configure environment:**
+3. **Configure environment:** the playground reads `apps/server/.env` (see `apps/server/.env.example`). At minimum set `DATABASE_URL`, `PAYLOAD_SECRET`, `TYPESENSE_*`, and `OPENAI_API_KEY` (embeddings).
+
+4. **Run the playground:**
 
    ```bash
-   cp apps/server/.env.example apps/server/.env
+   cd apps/server && pnpm run dev
    ```
 
-   Edit `apps/server/.env` and set:
-
-   | Variable | Required | Description |
-   |----------|----------|-------------|
-   | `DATABASE_URL` | Yes | PostgreSQL connection string |
-   | `PAYLOAD_SECRET` | Yes | Secret for Payload auth |
-   | `TYPESENSE_API_KEY` | Yes | Typesense API key (default: `xyz` for local dev) |
-   | `TYPESENSE_HOST` | Yes | Typesense host (default: `localhost`) |
-   | `TYPESENSE_PORT` | Yes | Typesense port (default: `8108`) |
-   | `OPENAI_API_KEY` | Yes | OpenAI key for generating embeddings |
-
-4. **Run:**
+5. **Run the Python backend** (agent runtime + workers):
 
    ```bash
-   cd apps/server
-   pnpm run dev
+   cd backend
+   cp .env.example .env   # set ANTHROPIC_API_KEY / OPENAI_API_KEY for BYOK
+   uv sync --all-packages
+   uv run --package agno-agent uvicorn agno_agent.main:app --reload --host 0.0.0.0 --port 8000
    ```
 
 ## Project structure
 
 ```
-PayloadAgents/
+payload-agents/
 ├── apps/
-│   └── server/          # Payload CMS playground (Next.js)
-├── packages/
-│   ├── payload-indexer/
-│   ├── payload-typesense/
-│   ├── payload-taxonomies/
-│   ├── payload-lexical-blocks-builder/
-│   └── chat-agent/
-├── .devcontainer/       # Dev Container (Docker Compose + Dockerfile)
+│   ├── server/          # Payload CMS playground (Next.js)
+│   └── mcp/             # MCP server (Bun) — wraps @zetesis/mcp-typesense
+├── packages/            # 10 publishable @zetesis/* npm packages
+├── backend/             # Python uv workspace — agent runtime + workers
+├── .devcontainer/       # Dev Container (compose + Dockerfile + LiteLLM config)
+├── .vscode/launch.json  # Run & Debug configs (compound "Launch" = full stack)
 └── docs/                # Architecture docs & decision records
 ```
 
 ## Commands
 
 ```bash
-# Dev server
-cd apps/server && pnpm run dev
+# Dev (Server + MCP) — Python backend runs via Run & Debug "Launch"
+pnpm dev
 
 # Build all packages
 pnpm build
@@ -112,10 +125,8 @@ pnpm build
 # Type-check (solution-style)
 pnpm tsc --noEmit
 
-# Lint
+# Lint / autofix
 pnpm lint
-
-# Lint with autofix
 pnpm lint:fix
 
 # Test
@@ -137,7 +148,7 @@ Key design decisions are documented in [`docs/architecture/`](docs/architecture/
 - **ESM only** — all packages use `"type": "module"`
 - **Biome** for linting and formatting
 - **Conventional commits** in English
-- **release-please drives releases** — your conventional commits open the release PR automatically (no manual changeset files)
+- **release-please drives releases** — your conventional commits open the release PR automatically (no manual changeset files); the same tool publishes the npm packages and the PyPI backend builders
 
 ## License
 

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -1,6 +1,35 @@
+# Playground env (apps/server). Copy to `.env` for local dev.
+# Inside the Dev Container these are already provided by
+# .devcontainer/devcontainer.env — you only need this for a manual setup.
+
+# --- Database ---
 DATABASE_URL=postgresql://db_admin:devsecret@db/payload_agents
+
+# --- Payload ---
 PAYLOAD_SECRET=devcontainer-payload-secret-change-in-production
+
+# --- Typesense ---
 TYPESENSE_API_KEY=xyz
 TYPESENSE_HOST=typesense
 TYPESENSE_PORT=8108
 TYPESENSE_PROTOCOL=http
+
+# --- Embeddings (REQUIRED) ---
+# Typesense calls OpenAI to embed the posts_chunk collection. Without a valid
+# key, collection init fails with "OpenAI API error: You didn't provide an API key".
+OPENAI_API_KEY=
+
+# --- LiteLLM gateway (REQUIRED by the agent plugin's modelCatalog) ---
+# gatewayUrl + masterKey: the admin key mints one virtual key per agent and
+# reads the model catalog (/model/info). Boot fails without them.
+LITELLM_GATEWAY_URL=http://litellm:4000
+LITELLM_MASTER_KEY=sk-poc-local-1234
+
+# --- Agent Runtime (Agno) ---
+AGENT_RUNTIME_URL=http://localhost:8000
+INTERNAL_SECRET=dev
+
+# --- Documents worker (opt-in; leave empty for inline LlamaParse) ---
+# REDIS_URL=redis://redis:6379
+# PAYLOAD_WORKER_URL=http://localhost:8001
+# PAYLOAD_SERVICE_TOKEN=PAYLOAD_SERVICE_TOKEN_SECRET

--- a/apps/server/src/app/(payload)/admin/importMap.js
+++ b/apps/server/src/app/(payload)/admin/importMap.js
@@ -27,6 +27,7 @@ import { SyncStatusField as SyncStatusField_4a514ff607eb05ca6255fb0fd04affc3 } f
 import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { default as default_2b626bed1026074d9f37e7a587a41216 } from '@/modules/payload-admin/sync-typesense-button'
+import { ModelSelectField as ModelSelectField_047e71d7ff94958b70084ef0e8629920 } from '@zetesis/payload-agents-core/client'
 import { ParseButtonField as ParseButtonField_30958b88b838a01c37745f7d84cf8cbf } from '@zetesis/payload-documents/client'
 import { FolderTypeField as FolderTypeField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
 import { default as default_b239c58bd1b8e1388209632203a98c7d } from '../../../views/LlmUsageView'
@@ -62,6 +63,7 @@ export const importMap = {
   "@payloadcms/next/rsc#FolderTableCell": FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@/modules/payload-admin/sync-typesense-button#default": default_2b626bed1026074d9f37e7a587a41216,
+  "@zetesis/payload-agents-core/client#ModelSelectField": ModelSelectField_047e71d7ff94958b70084ef0e8629920,
   "@zetesis/payload-documents/client#ParseButtonField": ParseButtonField_30958b88b838a01c37745f7d84cf8cbf,
   "@payloadcms/next/client#FolderTypeField": FolderTypeField_2b8867833a34864a02ddf429b0728a40,
   "/views/LlmUsageView#default": default_b239c58bd1b8e1388209632203a98c7d,

--- a/apps/server/src/components/floating-chat-wrapper.tsx
+++ b/apps/server/src/components/floating-chat-wrapper.tsx
@@ -1,80 +1,63 @@
 'use client'
 
-import { AgentChatProvider, AgentThread, AgentThreadList } from '@zetesis/agent-ui'
-import { AnimatePresence, motion } from 'framer-motion'
-import { Sparkles, X } from 'lucide-react'
+import {
+  type AgentChatDataSource,
+  type AgentInfo,
+  FloatingChatWrapper as AgentFloatingChat,
+  type SessionSummary
+} from '@zetesis/agent-ui'
+import Image from 'next/image'
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 
-interface AgentInfo {
-  slug: string
-  name: string
-  welcomeTitle?: string
-  welcomeSubtitle?: string
-  suggestedQuestions?: Array<{ prompt: string; title: string; description: string }>
+// Concrete AgentChatDataSource backed by the agent plugin's /api/chat/* endpoints
+// (registered by `agentPlugin` with basePath '/chat'). Mirrors the ZetesisPortal
+// wiring; the playground has no tenant roles, so access is granted to any
+// authenticated user (the endpoints themselves enforce auth → 401 when logged out).
+const dataSource: AgentChatDataSource = {
+  getAgents: async () => {
+    const res = await fetch('/api/chat/agents')
+    if (!res.ok) throw new Error('Failed to load agents')
+    const data = (await res.json()) as { agents?: AgentInfo[] }
+    return data.agents ?? []
+  },
+  getRecentSessions: async (agentSlug, limit = 10) => {
+    const params = new URLSearchParams()
+    if (agentSlug) params.set('agentSlug', agentSlug)
+    params.set('limit', String(limit))
+    const res = await fetch(`/api/chat/sessions?${params.toString()}`)
+    if (!res.ok) throw new Error('Failed to load sessions')
+    const data = (await res.json()) as { sessions?: SessionSummary[] }
+    return data.sessions ?? []
+  },
+  getSession: async conversationId => {
+    const res = await fetch(`/api/chat/session?conversationId=${encodeURIComponent(conversationId)}`)
+    if (!res.ok) throw new Error('Failed to load session')
+    return await res.json()
+  },
+  renameSession: async (conversationId, title) => {
+    const res = await fetch(`/api/chat/session?conversationId=${encodeURIComponent(conversationId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title })
+    })
+    if (!res.ok) throw new Error('Failed to rename session')
+  },
+  deleteSession: async conversationId => {
+    const res = await fetch(`/api/chat/session?conversationId=${encodeURIComponent(conversationId)}`, {
+      method: 'DELETE'
+    })
+    if (!res.ok) throw new Error('Failed to delete session')
+  }
 }
 
 export function FloatingChatWrapper() {
-  const [open, setOpen] = useState(false)
-  const [agent, setAgent] = useState<AgentInfo | null>(null)
-
-  useEffect(() => {
-    let cancelled = false
-    fetch('/api/chat/agents')
-      .then(r => (r.ok ? (r.json() as Promise<{ agents?: AgentInfo[] }>) : null))
-      .then(data => {
-        if (!cancelled) setAgent(data?.agents?.[0] ?? null)
-      })
-      .catch(() => {})
-    return () => {
-      cancelled = true
-    }
-  }, [])
-
-  if (!agent) return null
-
   return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(o => !o)}
-        className="fixed bottom-6 right-6 z-40 inline-flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg"
-        aria-label={open ? 'Cerrar chat' : 'Abrir chat'}
-      >
-        {open ? <X className="h-6 w-6" /> : <Sparkles className="h-6 w-6" />}
-      </button>
-      <AnimatePresence>
-        {open && (
-          <motion.div
-            initial={{ opacity: 0, y: 20, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: 20, scale: 0.95 }}
-            transition={{ duration: 0.18 }}
-            className="fixed bottom-24 right-6 z-40 flex h-[600px] w-[420px] max-w-[calc(100vw-3rem)] flex-col overflow-hidden rounded-2xl border border-border bg-background shadow-2xl"
-          >
-            <AgentChatProvider
-              endpoint="/api/chat"
-              agentSlug={agent.slug}
-              agentName={agent.name}
-              generateHref={({ type, value }) => `/${type}/${value.slug || value.id}`}
-              LinkComponent={Link}
-            >
-              <div className="grid flex-1 grid-cols-[180px_1fr] overflow-hidden">
-                <aside className="overflow-y-auto border-r border-border bg-muted/20">
-                  <AgentThreadList />
-                </aside>
-                <main className="overflow-hidden">
-                  <AgentThread
-                    welcomeTitle={agent.welcomeTitle}
-                    welcomeSubtitle={agent.welcomeSubtitle}
-                    suggestedQuestions={agent.suggestedQuestions}
-                  />
-                </main>
-              </div>
-            </AgentChatProvider>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </>
+    <AgentFloatingChat
+      hasAccess
+      dataSource={dataSource}
+      chatEndpoint="/api/chat"
+      LinkComponent={Link}
+      ImageComponent={Image}
+    />
   )
 }

--- a/apps/server/src/payload-types.ts
+++ b/apps/server/src/payload-types.ts
@@ -76,6 +76,7 @@ export interface Config {
     'llm-usage-events': LlmUsageEvent;
     documents: Document;
     'payload-kv': PayloadKv;
+    'payload-jobs': PayloadJob;
     'payload-folders': FolderInterface;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -96,6 +97,7 @@ export interface Config {
     'llm-usage-events': LlmUsageEventsSelect<false> | LlmUsageEventsSelect<true>;
     documents: DocumentsSelect<false> | DocumentsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
+    'payload-jobs': PayloadJobsSelect<false> | PayloadJobsSelect<true>;
     'payload-folders': PayloadFoldersSelect<false> | PayloadFoldersSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -113,7 +115,13 @@ export interface Config {
   };
   user: User;
   jobs: {
-    tasks: unknown;
+    tasks: {
+      syncLiteLlmVirtualKey: TaskSyncLiteLlmVirtualKey;
+      inline: {
+        input: unknown;
+        output: unknown;
+      };
+    };
     workflows: unknown;
   };
 }
@@ -320,7 +328,7 @@ export interface Agent {
    */
   allowGuestAccess?: boolean | null;
   /**
-   * LLM model to use (e.g., openai/gpt-4o, anthropic/claude-sonnet-4-20250514)
+   * Model preset from the gateway catalog
    */
   llmModel: string;
   /**
@@ -340,29 +348,42 @@ export interface Agent {
    */
   toolCallLimit?: number | null;
   /**
-   * Collections to search for RAG context
+   * Optional LiteLLM max budget for this agent virtual key, in USD.
    */
-  searchCollections?: 'posts_chunk'[] | null;
+  maxBudgetUsd?: number | null;
   /**
-   * Taxonomies that filter the RAG content. REQUIRED: if empty, agent will not search any content.
+   * Optional LiteLLM budget reset window, e.g. 1d, 30d, 1mo.
    */
-  taxonomies?: (number | Taxonomy)[] | null;
+  budgetDuration?: string | null;
   /**
-   * Folders that scope the RAG content. Optional: if set, the agent only sees documents inside these folders (and their descendants, since the slug chain mirrors the breadcrumb).
+   * Optional LiteLLM requests-per-minute limit for this agent.
    */
-  folders?: (number | FolderInterface)[] | null;
+  rpmLimit?: number | null;
   /**
-   * Number of chunks to retrieve for RAG context
+   * Optional LiteLLM tokens-per-minute limit for this agent.
    */
-  kResults?: number | null;
+  tpmLimit?: number | null;
+  litellmVirtualKey?: string | null;
   /**
-   * Maximum context size in bytes (default: 64KB)
+   * LiteLLM key alias managed by Payload.
    */
-  maxContextBytes?: number | null;
+  litellmVirtualKeyAlias?: string | null;
   /**
-   * TTL for conversation history in seconds (default: 24h)
+   * Last 4 characters of the LiteLLM virtual key.
    */
-  ttl?: number | null;
+  litellmVirtualKeyFingerprint?: string | null;
+  /**
+   * Last LiteLLM virtual key sync status.
+   */
+  litellmVirtualKeySyncStatus?: ('pending' | 'synced' | 'blocked' | 'disabled' | 'error') | null;
+  /**
+   * Last successful LiteLLM virtual key sync.
+   */
+  litellmVirtualKeySyncedAt?: string | null;
+  /**
+   * Last LiteLLM virtual key sync error, if any.
+   */
+  litellmVirtualKeySyncError?: string | null;
   /**
    * Avatar image for the agent
    */
@@ -436,6 +457,10 @@ export interface LlmUsageEvent {
   cachedInputTokens?: number | null;
   totalTokens: number;
   costUsd: number;
+  /**
+   * Whether costUsd is the LiteLLM gateway's real figure or the static table estimate
+   */
+  costSource?: ('gateway' | 'table') | null;
   startedAt?: string | null;
   completedAt: string;
   latencyMs?: number | null;
@@ -511,6 +536,102 @@ export interface PayloadKv {
     | number
     | boolean
     | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs".
+ */
+export interface PayloadJob {
+  id: number;
+  /**
+   * Input data provided to the job
+   */
+  input?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  taskStatus?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  completedAt?: string | null;
+  totalTried?: number | null;
+  /**
+   * If hasError is true this job will not be retried
+   */
+  hasError?: boolean | null;
+  /**
+   * If hasError is true, this is the error that caused it
+   */
+  error?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Task execution log
+   */
+  log?:
+    | {
+        executedAt: string;
+        completedAt: string;
+        taskSlug: 'inline' | 'syncLiteLlmVirtualKey';
+        taskID: string;
+        input?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        output?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        state: 'failed' | 'succeeded';
+        error?:
+          | {
+              [k: string]: unknown;
+            }
+          | unknown[]
+          | string
+          | number
+          | boolean
+          | null;
+        id?: string | null;
+      }[]
+    | null;
+  taskSlug?: ('inline' | 'syncLiteLlmVirtualKey') | null;
+  queue?: string | null;
+  waitUntil?: string | null;
+  processing?: boolean | null;
+  /**
+   * Used for concurrency control. Jobs with the same key are subject to exclusive/supersedes rules.
+   */
+  concurrencyKey?: string | null;
+  updatedAt: string;
+  createdAt: string;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -694,12 +815,16 @@ export interface AgentsSelect<T extends boolean = true> {
   apiKeyFingerprint?: T;
   systemPrompt?: T;
   toolCallLimit?: T;
-  searchCollections?: T;
-  taxonomies?: T;
-  folders?: T;
-  kResults?: T;
-  maxContextBytes?: T;
-  ttl?: T;
+  maxBudgetUsd?: T;
+  budgetDuration?: T;
+  rpmLimit?: T;
+  tpmLimit?: T;
+  litellmVirtualKey?: T;
+  litellmVirtualKeyAlias?: T;
+  litellmVirtualKeyFingerprint?: T;
+  litellmVirtualKeySyncStatus?: T;
+  litellmVirtualKeySyncedAt?: T;
+  litellmVirtualKeySyncError?: T;
   avatar?: T;
   welcomeTitle?: T;
   welcomeSubtitle?: T;
@@ -733,6 +858,7 @@ export interface LlmUsageEventsSelect<T extends boolean = true> {
   cachedInputTokens?: T;
   totalTokens?: T;
   costUsd?: T;
+  costSource?: T;
   startedAt?: T;
   completedAt?: T;
   latencyMs?: T;
@@ -773,6 +899,38 @@ export interface DocumentsSelect<T extends boolean = true> {
 export interface PayloadKvSelect<T extends boolean = true> {
   key?: T;
   data?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "payload-jobs_select".
+ */
+export interface PayloadJobsSelect<T extends boolean = true> {
+  input?: T;
+  taskStatus?: T;
+  completedAt?: T;
+  totalTried?: T;
+  hasError?: T;
+  error?: T;
+  log?:
+    | T
+    | {
+        executedAt?: T;
+        completedAt?: T;
+        taskSlug?: T;
+        taskID?: T;
+        input?: T;
+        output?: T;
+        state?: T;
+        error?: T;
+        id?: T;
+      };
+  taskSlug?: T;
+  queue?: T;
+  waitUntil?: T;
+  processing?: T;
+  concurrencyKey?: T;
+  updatedAt?: T;
+  createdAt?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -827,6 +985,18 @@ export interface CollectionsWidget {
     [k: string]: unknown;
   };
   width: 'full';
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "TaskSyncLiteLlmVirtualKey".
+ */
+export interface TaskSyncLiteLlmVirtualKey {
+  input: {
+    agentId?: string | null;
+    blockEncryptedKey?: string | null;
+    slug?: string | null;
+  };
+  output?: unknown;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/apps/server/src/payload.config.ts
+++ b/apps/server/src/payload.config.ts
@@ -60,6 +60,13 @@ export default buildConfig({
       agentPlugin({
         runtimeUrl: process.env.AGENT_RUNTIME_URL || 'http://localhost:8000',
         runtimeSecret: process.env.INTERNAL_SECRET,
+        // Curated model catalog served by the LiteLLM gateway (hard dependency):
+        // llmModel is a preset select in admin, writes are validated against the
+        // catalog, and Payload mints one virtual key per agent.
+        modelCatalog: {
+          gatewayUrl: process.env.LITELLM_GATEWAY_URL || 'http://litellm:4000',
+          masterKey: process.env.LITELLM_MASTER_KEY
+        },
         getDailyLimit,
         encryptionKey: process.env.PAYLOAD_SECRET,
         basePath: '/chat',

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,9 +13,16 @@ DATABASE_SCHEMA=agno
 INTERNAL_SECRET=dev
 PAYLOAD_SERVICE_TOKEN=
 
-LANGFUSE_HOST=http://langfuse-web:3000
-LANGFUSE_PUBLIC_KEY=pk-lf-zetesis-dev
-LANGFUSE_SECRET_KEY=sk-lf-zetesis-dev
+# LiteLLM gateway — REQUIRED. The runtime routes every agent through it;
+# agno-agent refuses to boot without LITELLM_PROXY_URL.
+LITELLM_PROXY_URL=http://litellm:4000/v1
 
+# Langfuse — OPT-IN (tracing/cost). The devcontainer does NOT ship Langfuse.
+# Point these at your own instance to enable, or leave unset to disable tracing.
+# LANGFUSE_HOST=
+# LANGFUSE_PUBLIC_KEY=
+# LANGFUSE_SECRET_KEY=
+
+# Provider keys for BYOK tests
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -100,7 +100,7 @@ requires-dist = [
 
 [[package]]
 name = "agno-agent-builder"
-version = "0.1.12"
+version = "0.1.14"
 source = { editable = "agno-agent-builder" }
 dependencies = [
     { name = "ag-ui-protocol" },
@@ -1590,7 +1590,7 @@ wheels = [
 
 [[package]]
 name = "nexus-queue"
-version = "0.1.3"
+version = "0.1.4"
 source = { editable = "nexus-queue" }
 dependencies = [
     { name = "fastapi" },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "turbo run build --continue",
+    "dev": "turbo run dev",
     "lint": "biome check packages/*/src --no-errors-on-unmatched",
     "lint:fix": "biome check --write packages/*/src --no-errors-on-unmatched",
     "format": "biome format --write packages/*/src --no-errors-on-unmatched",


### PR DESCRIPTION
## Why

The devcontainer had drifted for ~50 days and was non-functional. The Agno agent runtime refuses to boot without `LITELLM_PROXY_URL`, but compose had no `litellm` service and the image (`node:25-alpine`) shipped no Python for the `backend/` uv workspace. The Payload playground also crashed on boot (the agent plugin's required `modelCatalog` was never wired) and the in-app chat used an incomplete hand-rolled wrapper instead of the package's official one.

## What

### Devcontainer
- Base image → **`node:24-bookworm-slim`** + uv-managed **Python 3.12** (glibc parity with the prod backend image `uv:python3.12-bookworm-slim` and CI Node 24). Adds `unzip` (Bun's installer needs it on slim).
- Ports the full **LiteLLM gateway**: `litellm` + `litellm-db-init` + `litellm-bootstrap` services and their config under `.devcontainer/litellm/`, seeding the model catalog (gpt-4o-mini, claude-sonnet-4-6, o4-mini, gemini-2.5-flash).
- Adds `redis` to `runServices`, a `backend_venv` volume (isolates the host macOS venv from the Linux container), the `typesense-dashboard` service, a root `dev` script (`turbo run dev`), and refreshes `check-services.sh` + env files.
- Kept to an autonomous OSS subset — no keycloak/traefik (the playground uses Payload-native auth and direct ports).

### Playground (`apps/server`)
- **fix**: wire `modelCatalog.{gatewayUrl,masterKey}` into `agentPlugin` from `LITELLM_GATEWAY_URL`/`LITELLM_MASTER_KEY` (it crashed with `Cannot read properties of undefined (reading 'gatewayUrl')`).
- **fix**: replace the hand-rolled chat with the package's official `FloatingChatWrapper` (agent selector, session history, maximize) so it matches ZetesisPortal. The old one mounted `AgentThreadList` without its required `dataSource`.
- Regenerated `payload-types.ts` + `importMap.js` now that the plugin registers.

### Backend + docs
- `backend/.env.example`: document the required `LITELLM_PROXY_URL`; make Langfuse opt-in.
- `README.md` / `CLAUDE.md`: 10 real `@zetesis/*` packages + Python backend (drop removed `chat-agent`), devcontainer/launch.json flow, Node 24.

## Verification

- Image builds end-to-end (validated inside: node v24.17, pnpm 10.14.0, bun 1.3.14, uv 0.11.23, python 3.12.13).
- `pnpm lint` + `pnpm tsc --noEmit` green in the devcontainer.
- Full stack boots: Server :3000, MCP :3030, LiteLLM :4000 (UI lists the 4 catalog models), Agent Runtime :8000 (no longer raises on `LITELLM_PROXY_URL`). Playground admin, embeddings and chat operational.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
