### PR TITLE
feat: pgvector indexer backend + thin MCP (A/B vs Typesense)

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
+  # Imagen pgvector (Debian/glibc) en vez de postgres:17-alpine: provee la
+  # extensión `vector` para probar payload-pgvector. Sigue siendo un Postgres
+  # normal — el `litellm_db` convive sin cambios. La extensión se habilita por
+  # base via migración (`CREATE EXTENSION vector`), aquí solo queda disponible.
   db:
-    image: postgres:17-alpine
+    image: pgvector/pgvector:pg17
     restart: always
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -134,7 +138,7 @@ services:
     environment:
       LITELLM_URL: http://litellm:4000
       LITELLM_CATALOG_JSON: >-
-        [{"name":"chat-estandar","model":"openai/gpt-4o-mini","description":"Chat general — rápido y económico","requiresKey":"openai","tier":"standard"},{"name":"chat-premium","model":"anthropic/claude-sonnet-4-6","description":"Máxima calidad para agentes de cara al cliente","requiresKey":"anthropic","tier":"premium"},{"name":"razonador","model":"openai/o4-mini","description":"Razonamiento y análisis","requiresKey":"openai","tier":"standard"},{"name":"economico","model":"gemini/gemini-2.5-flash","description":"Volúmenes altos a mínimo coste","requiresKey":"google","tier":"economy"}]
+        [{"name":"chat-estandar","model":"openai/gpt-4o-mini","description":"Chat general — rápido y económico","requiresKey":"openai","tier":"standard"},{"name":"chat-premium","model":"anthropic/claude-sonnet-4-6","description":"Máxima calidad para agentes de cara al cliente","requiresKey":"anthropic","tier":"premium"},{"name":"razonador","model":"openai/o4-mini","description":"Razonamiento y análisis","requiresKey":"openai","tier":"standard"},{"name":"economico","model":"gemini/gemini-2.5-flash","description":"Volúmenes altos a mínimo coste","requiresKey":"google","tier":"economy"},{"name":"embeddings-dev","model":"openai/text-embedding-3-small","description":"Embeddings para retrieval vectorial (payload-pgvector). Alias estable: pinéalo en index y query","requiresKey":"openai","tier":"standard"}]
     entrypoint: ["python"]
     command: ["/app/bootstrap_catalog.py"]
     volumes:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,6 +7,7 @@
   "packages/payload-documents": "0.5.4",
   "packages/payload-indexer": "0.4.1",
   "packages/payload-lexical-blocks-builder": "0.2.2",
+  "packages/payload-pgvector": "0.0.0",
   "packages/payload-taxonomies": "0.2.2",
   "packages/payload-typesense": "0.4.1",
   "backend/agno-agent-builder": "0.1.14",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,13 @@
       "cwd": "${workspaceFolder}/apps/mcp"
     },
     {
+      "name": "MCP pgvector",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "MCP_PGVECTOR_PORT=3041 bun --watch src/standalone.ts",
+      "cwd": "${workspaceFolder}/packages/mcp-pgvector"
+    },
+    {
       "name": "Agent Runtime",
       "type": "node-terminal",
       "request": "launch",
@@ -61,7 +68,7 @@
   "compounds": [
     {
       "name": "Launch",
-      "configurations": ["Server", "MCP", "Agent Runtime", "Worker (kicker)", "Worker (taskiq)"],
+      "configurations": ["Server", "MCP", "MCP pgvector", "Agent Runtime", "Worker (kicker)", "Worker (taskiq)"],
       "stopAll": true
     },
     {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,6 +24,7 @@
     "@zetesis/payload-documents": "workspace:*",
     "@zetesis/payload-indexer": "workspace:*",
     "@zetesis/payload-lexical-blocks-builder": "workspace:*",
+    "@zetesis/payload-pgvector": "workspace:*",
     "@zetesis/payload-taxonomies": "workspace:*",
     "@zetesis/payload-typesense": "workspace:*",
     "@toon-format/toon": "^2.1.0",

--- a/apps/server/src/app/(payload)/admin/importMap.js
+++ b/apps/server/src/app/(payload)/admin/importMap.js
@@ -28,6 +28,7 @@ import { FolderTableCell as FolderTableCell_f9c02e79a4aed9a3924487c0cd4cafb1 } f
 import { FolderField as FolderField_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 import { default as default_2b626bed1026074d9f37e7a587a41216 } from '@/modules/payload-admin/sync-typesense-button'
 import { ModelSelectField as ModelSelectField_047e71d7ff94958b70084ef0e8629920 } from '@zetesis/payload-agents-core/client'
+import { McpServerSelectField as McpServerSelectField_047e71d7ff94958b70084ef0e8629920 } from '@zetesis/payload-agents-core/client'
 import { ParseButtonField as ParseButtonField_30958b88b838a01c37745f7d84cf8cbf } from '@zetesis/payload-documents/client'
 import { FolderTypeField as FolderTypeField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
 import { default as default_b239c58bd1b8e1388209632203a98c7d } from '../../../views/LlmUsageView'
@@ -64,6 +65,7 @@ export const importMap = {
   "@payloadcms/next/rsc#FolderField": FolderField_f9c02e79a4aed9a3924487c0cd4cafb1,
   "@/modules/payload-admin/sync-typesense-button#default": default_2b626bed1026074d9f37e7a587a41216,
   "@zetesis/payload-agents-core/client#ModelSelectField": ModelSelectField_047e71d7ff94958b70084ef0e8629920,
+  "@zetesis/payload-agents-core/client#McpServerSelectField": McpServerSelectField_047e71d7ff94958b70084ef0e8629920,
   "@zetesis/payload-documents/client#ParseButtonField": ParseButtonField_30958b88b838a01c37745f7d84cf8cbf,
   "@payloadcms/next/client#FolderTypeField": FolderTypeField_2b8867833a34864a02ddf429b0728a40,
   "/views/LlmUsageView#default": default_b239c58bd1b8e1388209632203a98c7d,

--- a/apps/server/src/app/api/search/mcp/route.ts
+++ b/apps/server/src/app/api/search/mcp/route.ts
@@ -11,14 +11,20 @@ export const maxDuration = 60
 
 const MCP_INTERNAL_URL = process.env.MCP_INTERNAL_URL || 'http://localhost:3030/mcp'
 const LITELLM_GATEWAY_URL = (process.env.LITELLM_GATEWAY_URL || 'http://litellm:4000').replace(/\/$/, '')
+// The backend MCP_INTERNAL_URL serves directly. The legacy direct fallback is
+// ONLY valid for this backend — falling back for any other would cross backends
+// (e.g. serve a pgvector token from Typesense).
+const DIRECT_MCP_ALIAS = process.env.MCP_DIRECT_ALIAS || 'typesense_search'
+
+type Upstream = { url: string; authHeaders: Record<string, string> } | { notReady: true }
 
 /**
- * Resolve the upstream MCP URL + auth headers for a token. When the token has a
- * synced LiteLLM virtual key, route through the gateway at `/{alias}/mcp` with
- * that key (traceability + backend access control enforced by LiteLLM). Without
- * a key, fall back to the direct MCP URL (legacy, non-breaking).
+ * Resolve the upstream MCP URL + auth headers for a token. With a synced LiteLLM
+ * virtual key, route through the gateway at `/{alias}/mcp` with that key. Without
+ * a key, fall back to the direct MCP URL ONLY for the direct backend; any other
+ * backend fails closed rather than cross to the wrong index.
  */
-function resolveUpstream(auth: TokenAuth): { url: string; authHeaders: Record<string, string> } {
+function resolveUpstream(auth: TokenAuth): Upstream {
   if (auth.virtualKey && auth.mcpAlias) {
     return {
       url: `${LITELLM_GATEWAY_URL}/${auth.mcpAlias}/mcp`,
@@ -28,7 +34,14 @@ function resolveUpstream(auth: TokenAuth): { url: string; authHeaders: Record<st
       },
     }
   }
-  return { url: MCP_INTERNAL_URL, authHeaders: {} }
+  // No virtual key. For the direct backend this is the normal path; it also
+  // covers the degraded case where a direct-backend token HAS a key that failed
+  // to decrypt (rotated PAYLOAD_SECRET) — it serves direct, trading gateway
+  // traceability for availability. Any OTHER alias fails closed below.
+  if (!auth.mcpAlias || auth.mcpAlias === DIRECT_MCP_ALIAS) {
+    return { url: MCP_INTERNAL_URL, authHeaders: {} }
+  }
+  return { notReady: true }
 }
 
 interface TokenAuth {
@@ -88,9 +101,16 @@ async function authenticateRequest(hdrs: Headers, request: Request): Promise<Tok
     : []
 
   // Decrypt the internal per-token LiteLLM key (set by the collection sync hook).
+  // A decrypt failure (rotated PAYLOAD_SECRET, corrupt ciphertext) must not 500
+  // — treat it as "no key" so resolveUpstream decides the safe path.
   const encKey = process.env.PAYLOAD_SECRET
   const stored = typeof doc.litellmVirtualKey === 'string' ? doc.litellmVirtualKey : null
-  const virtualKey = stored && encKey ? decrypt(stored, encKey) : null
+  let virtualKey: string | null = null
+  try {
+    virtualKey = stored && encKey ? decrypt(stored, encKey) : null
+  } catch {
+    virtualKey = null
+  }
   const mcpAlias = typeof doc.mcpServer === 'string' ? doc.mcpServer : null
 
   updateTokenLastUsed(payload, tokenDoc.id as number | string)
@@ -102,7 +122,27 @@ async function proxyToMcp(request: Request): Promise<Response> {
   const auth = await authenticateRequest(hdrs, request)
   if (auth instanceof NextResponse) return auth
 
-  const { url: upstreamUrl, authHeaders } = resolveUpstream(auth)
+  // Deny-by-default: a token with no taxonomy scope must NOT read the whole
+  // corpus. Scope is injected downstream only when non-empty (and the MCP applies
+  // no taxonomy filter without it), so an unscoped token would fail open. Refuse
+  // here — the proxy is the single source of truth for token permissions. A
+  // deliberately broad token would need an explicit opt-in field, not the absence
+  // of a scope.
+  if (auth.taxonomySlugs.length === 0) {
+    return NextResponse.json(
+      { error: 'Token has no taxonomy scope; refusing to serve (assign at least one taxonomy to the token)' },
+      { status: 403 }
+    )
+  }
+
+  const target = resolveUpstream(auth)
+  if ('notReady' in target) {
+    return NextResponse.json(
+      { error: 'Token not ready — its gateway key has not finished syncing' },
+      { status: 503 }
+    )
+  }
+  const { url: upstreamUrl, authHeaders } = target
 
   const forwardHeaders: Record<string, string> = {
     'Content-Type': hdrs.get('content-type') || 'application/json',

--- a/apps/server/src/app/api/search/mcp/route.ts
+++ b/apps/server/src/app/api/search/mcp/route.ts
@@ -1,3 +1,4 @@
+import { decrypt } from '@zetesis/payload-agents-core'
 import { headers as nextHeaders } from 'next/headers'
 import { NextResponse } from 'next/server'
 import type { BasePayload } from 'payload'
@@ -9,6 +10,32 @@ export const dynamic = 'force-dynamic'
 export const maxDuration = 60
 
 const MCP_INTERNAL_URL = process.env.MCP_INTERNAL_URL || 'http://localhost:3030/mcp'
+const LITELLM_GATEWAY_URL = (process.env.LITELLM_GATEWAY_URL || 'http://litellm:4000').replace(/\/$/, '')
+
+/**
+ * Resolve the upstream MCP URL + auth headers for a token. When the token has a
+ * synced LiteLLM virtual key, route through the gateway at `/{alias}/mcp` with
+ * that key (traceability + backend access control enforced by LiteLLM). Without
+ * a key, fall back to the direct MCP URL (legacy, non-breaking).
+ */
+function resolveUpstream(auth: TokenAuth): { url: string; authHeaders: Record<string, string> } {
+  if (auth.virtualKey && auth.mcpAlias) {
+    return {
+      url: `${LITELLM_GATEWAY_URL}/${auth.mcpAlias}/mcp`,
+      authHeaders: {
+        'x-litellm-api-key': `Bearer ${auth.virtualKey}`,
+        Authorization: `Bearer ${auth.virtualKey}`,
+      },
+    }
+  }
+  return { url: MCP_INTERNAL_URL, authHeaders: {} }
+}
+
+interface TokenAuth {
+  taxonomySlugs: string[]
+  mcpAlias: string | null
+  virtualKey: string | null
+}
 
 async function findTokenByHash(payload: BasePayload, tokenHash: string) {
   const { docs } = await payload.find({
@@ -31,10 +58,7 @@ function updateTokenLastUsed(payload: BasePayload, tokenId: number | string): vo
     .catch(() => {})
 }
 
-async function authenticateRequest(
-  hdrs: Headers,
-  request: Request
-): Promise<{ taxonomySlugs: string[] } | NextResponse> {
+async function authenticateRequest(hdrs: Headers, request: Request): Promise<TokenAuth | NextResponse> {
   const authorization = hdrs.get('authorization')
   const url = new URL(request.url)
   const queryToken = url.searchParams.get('token')
@@ -50,15 +74,27 @@ async function authenticateRequest(
     return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
   }
 
-  const rawTaxonomies = (tokenDoc as unknown as { taxonomies?: unknown }).taxonomies
+  const doc = tokenDoc as unknown as {
+    taxonomies?: unknown
+    mcpServer?: unknown
+    litellmVirtualKey?: unknown
+  }
+
+  const rawTaxonomies = doc.taxonomies
   const taxonomySlugs: string[] = Array.isArray(rawTaxonomies)
     ? rawTaxonomies
         .map(t => (typeof t === 'object' && t !== null ? (t as { slug?: unknown }).slug : null))
         .filter((s): s is string => typeof s === 'string' && s.length > 0)
     : []
 
+  // Decrypt the internal per-token LiteLLM key (set by the collection sync hook).
+  const encKey = process.env.PAYLOAD_SECRET
+  const stored = typeof doc.litellmVirtualKey === 'string' ? doc.litellmVirtualKey : null
+  const virtualKey = stored && encKey ? decrypt(stored, encKey) : null
+  const mcpAlias = typeof doc.mcpServer === 'string' ? doc.mcpServer : null
+
   updateTokenLastUsed(payload, tokenDoc.id as number | string)
-  return { taxonomySlugs }
+  return { taxonomySlugs, mcpAlias, virtualKey }
 }
 
 async function proxyToMcp(request: Request): Promise<Response> {
@@ -66,10 +102,14 @@ async function proxyToMcp(request: Request): Promise<Response> {
   const auth = await authenticateRequest(hdrs, request)
   if (auth instanceof NextResponse) return auth
 
+  const { url: upstreamUrl, authHeaders } = resolveUpstream(auth)
+
   const forwardHeaders: Record<string, string> = {
     'Content-Type': hdrs.get('content-type') || 'application/json',
     Accept: 'application/json, text/event-stream',
+    ...authHeaders,
   }
+  // Scope is injected here (trusted): the client cannot set it themselves.
   if (auth.taxonomySlugs.length > 0) {
     forwardHeaders['x-taxonomy-slugs'] = auth.taxonomySlugs.join(',')
   }
@@ -81,7 +121,7 @@ async function proxyToMcp(request: Request): Promise<Response> {
 
   let upstream: globalThis.Response
   try {
-    upstream = await fetch(MCP_INTERNAL_URL, {
+    upstream = await fetch(upstreamUrl, {
       method: request.method,
       headers: forwardHeaders,
       body,

--- a/apps/server/src/app/api/search/mcp/route.ts
+++ b/apps/server/src/app/api/search/mcp/route.ts
@@ -122,18 +122,9 @@ async function proxyToMcp(request: Request): Promise<Response> {
   const auth = await authenticateRequest(hdrs, request)
   if (auth instanceof NextResponse) return auth
 
-  // Deny-by-default: a token with no taxonomy scope must NOT read the whole
-  // corpus. Scope is injected downstream only when non-empty (and the MCP applies
-  // no taxonomy filter without it), so an unscoped token would fail open. Refuse
-  // here — the proxy is the single source of truth for token permissions. A
-  // deliberately broad token would need an explicit opt-in field, not the absence
-  // of a scope.
-  if (auth.taxonomySlugs.length === 0) {
-    return NextResponse.json(
-      { error: 'Token has no taxonomy scope; refusing to serve (assign at least one taxonomy to the token)' },
-      { status: 403 }
-    )
-  }
+  // A token without taxonomies is intentionally broad: it reads the whole corpus
+  // (within its tenant). Scope is forwarded only when present, so the MCP simply
+  // applies no taxonomy filter. No deny-by-default here — broad tokens are allowed.
 
   const target = resolveUpstream(auth)
   if ('notReady' in target) {

--- a/apps/server/src/collections/McpSearchTokens/hooks.ts
+++ b/apps/server/src/collections/McpSearchTokens/hooks.ts
@@ -34,11 +34,13 @@ function liteLlmClient(): LiteLlmAdminClient | null {
 }
 
 /**
- * Mint/update a per-token LiteLLM virtual key scoped (via object_permission) to
- * the token's selected MCP backend. Routing through LiteLLM gives the external
- * token traceability + backend access control; the key is internal (the proxy
- * uses it upstream, the user never sees it). Best-effort: failures set an error
- * status but never block token creation.
+ * Mint/update a per-token LiteLLM virtual key for the token's selected MCP
+ * backend. Routing through LiteLLM gives the external token traceability (and a
+ * place to hang budgets/rate limits); the key is internal (the proxy uses it
+ * upstream, the user never sees it). Which backend the token reaches is enforced
+ * by the proxy, which builds the upstream URL from the token's `mcpServer` field
+ * — NOT by per-key object_permission, which the gateway's allow_all_keys servers
+ * do not honour. Best-effort: failures set an error status, never block creation.
  */
 export const syncMcpTokenKeyAfterChange: CollectionAfterChangeHook = async ({ context, doc, previousDoc, req }) => {
   if (context?.[SKIP_KEY_SYNC]) return doc
@@ -69,8 +71,12 @@ export const syncMcpTokenKeyAfterChange: CollectionAfterChangeHook = async ({ co
     const keyPayload: LiteLlmVirtualKeyPayload = {
       keyAlias: `mcp-token/${record.id}`,
       models: [],
-      metadata: { source: 'payload', mcpTokenId: String(record.id), userId: String(record.user ?? '') },
-      objectPermission: { mcpServers: [mcpServer] },
+      metadata: {
+        source: 'payload',
+        mcpTokenId: String(record.id),
+        mcpServer,
+        userId: String(record.user ?? ''),
+      },
     }
     const existing = record.litellmVirtualKey ? decrypt(record.litellmVirtualKey, encKey) : undefined
     let plaintextKey: string

--- a/apps/server/src/collections/McpSearchTokens/hooks.ts
+++ b/apps/server/src/collections/McpSearchTokens/hooks.ts
@@ -1,6 +1,114 @@
-import type { CollectionBeforeChangeHook, CollectionBeforeValidateHook } from 'payload'
+import {
+  decrypt,
+  encrypt,
+  LiteLlmAdminClient,
+  type LiteLlmVirtualKeyPayload,
+} from '@zetesis/payload-agents-core'
+import type {
+  CollectionAfterChangeHook,
+  CollectionAfterDeleteHook,
+  CollectionBeforeChangeHook,
+  CollectionBeforeValidateHook,
+} from 'payload'
 
 const MAX_TOKENS_PER_USER = 10
+
+// Context flag set when the sync hook writes the key fields back, so its own
+// update does not re-trigger the afterChange sync.
+const SKIP_KEY_SYNC = 'skipMcpTokenKeySync'
+
+interface TokenRecord {
+  id: number | string
+  mcpServer?: string
+  user?: unknown
+  litellmVirtualKey?: string | null
+  litellmVirtualKeySyncStatus?: string | null
+}
+
+/** LiteLLM admin client from env, or null when the gateway is not configured. */
+function liteLlmClient(): LiteLlmAdminClient | null {
+  const gatewayUrl = process.env.LITELLM_GATEWAY_URL
+  const masterKey = process.env.LITELLM_MASTER_KEY
+  if (!gatewayUrl || !masterKey) return null
+  return new LiteLlmAdminClient({ gatewayUrl, masterKey })
+}
+
+/**
+ * Mint/update a per-token LiteLLM virtual key scoped (via object_permission) to
+ * the token's selected MCP backend. Routing through LiteLLM gives the external
+ * token traceability + backend access control; the key is internal (the proxy
+ * uses it upstream, the user never sees it). Best-effort: failures set an error
+ * status but never block token creation.
+ */
+export const syncMcpTokenKeyAfterChange: CollectionAfterChangeHook = async ({ context, doc, previousDoc, req }) => {
+  if (context?.[SKIP_KEY_SYNC]) return doc
+  const record = doc as TokenRecord
+  const mcpServer = record.mcpServer
+  if (!mcpServer) return doc
+
+  const prev = previousDoc as TokenRecord | undefined
+  const needsSync =
+    !record.litellmVirtualKey || record.litellmVirtualKeySyncStatus !== 'synced' || mcpServer !== prev?.mcpServer
+  if (!needsSync) return doc
+
+  const client = liteLlmClient()
+  const encKey = process.env.PAYLOAD_SECRET
+  if (!client || !encKey) return doc
+
+  const persist = (data: Record<string, unknown>) =>
+    req.payload.update({
+      collection: 'mcp-search-tokens',
+      id: record.id,
+      data,
+      overrideAccess: true,
+      req,
+      context: { [SKIP_KEY_SYNC]: true },
+    })
+
+  try {
+    const keyPayload: LiteLlmVirtualKeyPayload = {
+      keyAlias: `mcp-token/${record.id}`,
+      models: [],
+      metadata: { source: 'payload', mcpTokenId: String(record.id), userId: String(record.user ?? '') },
+      objectPermission: { mcpServers: [mcpServer] },
+    }
+    const existing = record.litellmVirtualKey ? decrypt(record.litellmVirtualKey, encKey) : undefined
+    let plaintextKey: string
+    if (existing) {
+      await client.updateKey(existing, keyPayload)
+      plaintextKey = existing
+    } else {
+      plaintextKey = (await client.generateKey(keyPayload)).key
+    }
+    await persist({
+      litellmVirtualKey: encrypt(plaintextKey, encKey),
+      litellmVirtualKeyAlias: keyPayload.keyAlias,
+      litellmVirtualKeyFingerprint: plaintextKey.slice(-4),
+      litellmVirtualKeySyncStatus: 'synced',
+      litellmVirtualKeySyncError: null,
+    })
+  } catch (error) {
+    await persist({
+      litellmVirtualKeySyncStatus: 'error',
+      litellmVirtualKeySyncError: error instanceof Error ? error.message : 'Unknown error',
+    }).catch(() => {})
+  }
+  return doc
+}
+
+/** Block the token's LiteLLM virtual key when the token is deleted. */
+export const blockMcpTokenKeyAfterDelete: CollectionAfterDeleteHook = async ({ doc }) => {
+  const record = doc as TokenRecord
+  const client = liteLlmClient()
+  const encKey = process.env.PAYLOAD_SECRET
+  if (!client || !encKey || !record.litellmVirtualKey) return doc
+  try {
+    await client.blockKey(decrypt(record.litellmVirtualKey, encKey))
+  } catch {
+    // best-effort — the token is gone either way
+  }
+  return doc
+}
 
 export const setUserBeforeChange: CollectionBeforeChangeHook = ({ data, req, operation }) => {
   if (operation === 'create' && req.user) {

--- a/apps/server/src/collections/McpSearchTokens/index.ts
+++ b/apps/server/src/collections/McpSearchTokens/index.ts
@@ -1,6 +1,11 @@
 import type { CollectionConfig } from 'payload'
 import { createAccess, deleteAccess, readAccess, updateAccess } from './access'
-import { enforceMaxTokens, setUserBeforeChange } from './hooks'
+import {
+  blockMcpTokenKeyAfterDelete,
+  enforceMaxTokens,
+  setUserBeforeChange,
+  syncMcpTokenKeyAfterChange,
+} from './hooks'
 
 export const McpSearchTokens: CollectionConfig = {
   slug: 'mcp-search-tokens',
@@ -13,6 +18,8 @@ export const McpSearchTokens: CollectionConfig = {
   hooks: {
     beforeChange: [setUserBeforeChange],
     beforeValidate: [enforceMaxTokens],
+    afterChange: [syncMcpTokenKeyAfterChange],
+    afterDelete: [blockMcpTokenKeyAfterDelete],
   },
   admin: {
     useAsTitle: 'label',
@@ -57,9 +64,46 @@ export const McpSearchTokens: CollectionConfig = {
       admin: { readOnly: true, description: 'First chars of the token for identification.' },
     },
     {
+      name: 'mcpServer',
+      type: 'select',
+      required: true,
+      defaultValue: 'typesense_search',
+      options: [
+        { label: 'Typesense', value: 'typesense_search' },
+        { label: 'pgvector', value: 'pgvector_search' },
+      ],
+      admin: {
+        description: 'Which search backend (MCP server) this token reaches, enforced via LiteLLM.',
+      },
+    },
+    {
       name: 'lastUsedAt',
       type: 'date',
       admin: { readOnly: true, description: 'Last time this token authenticated a request.' },
+    },
+    {
+      type: 'collapsible',
+      label: 'LiteLLM Virtual Key',
+      admin: { initCollapsed: true },
+      fields: [
+        { name: 'litellmVirtualKey', type: 'text', admin: { hidden: true } },
+        {
+          name: 'litellmVirtualKeyAlias',
+          type: 'text',
+          admin: { readOnly: true, description: 'Internal per-token key alias in LiteLLM.' },
+        },
+        { name: 'litellmVirtualKeyFingerprint', type: 'text', admin: { readOnly: true } },
+        {
+          name: 'litellmVirtualKeySyncStatus',
+          type: 'select',
+          admin: { readOnly: true },
+          options: [
+            { label: 'Synced', value: 'synced' },
+            { label: 'Error', value: 'error' },
+          ],
+        },
+        { name: 'litellmVirtualKeySyncError', type: 'textarea', admin: { readOnly: true } },
+      ],
     },
   ],
 }

--- a/apps/server/src/collections/McpSearchTokens/index.ts
+++ b/apps/server/src/collections/McpSearchTokens/index.ts
@@ -40,7 +40,7 @@ export const McpSearchTokens: CollectionConfig = {
       hasMany: true,
       admin: {
         description:
-          'Optional. If set, every search made with this token is auto-scoped to these taxonomy slugs (forwarded as `x-taxonomy-slugs` to the MCP server).',
+          'Optional. If set, every search made with this token is auto-scoped to these taxonomy slugs (forwarded as `x-taxonomy-slugs` to the MCP server). Left empty, the token reads the whole corpus (within its tenant).',
       },
     },
     {

--- a/apps/server/src/collections/McpSearchTokens/index.ts
+++ b/apps/server/src/collections/McpSearchTokens/index.ts
@@ -68,9 +68,11 @@ export const McpSearchTokens: CollectionConfig = {
       type: 'select',
       required: true,
       defaultValue: 'typesense_search',
+      // pgvector is only offered when the experimental backend is enabled, so the
+      // picker stays consistent with what's actually deployed.
       options: [
         { label: 'Typesense', value: 'typesense_search' },
-        { label: 'pgvector', value: 'pgvector_search' },
+        ...(process.env.ENABLE_PGVECTOR === 'true' ? [{ label: 'pgvector', value: 'pgvector_search' }] : []),
       ],
       admin: {
         description: 'Which search backend (MCP server) this token reaches, enforced via LiteLLM.',

--- a/apps/server/src/payload-types.ts
+++ b/apps/server/src/payload-types.ts
@@ -349,6 +349,10 @@ export interface Agent {
    */
   toolCallLimit?: number | null;
   /**
+   * Search backends (MCP servers) this agent can use, routed through the LiteLLM gateway. Empty = none.
+   */
+  mcpServers?: ('typesense_search' | 'pgvector_search')[] | null;
+  /**
    * Optional LiteLLM max budget for this agent virtual key, in USD.
    */
   maxBudgetUsd?: number | null;
@@ -817,6 +821,7 @@ export interface AgentsSelect<T extends boolean = true> {
   apiKeyFingerprint?: T;
   systemPrompt?: T;
   toolCallLimit?: T;
+  mcpServers?: T;
   maxBudgetUsd?: T;
   budgetDuration?: T;
   rpmLimit?: T;

--- a/apps/server/src/payload-types.ts
+++ b/apps/server/src/payload-types.ts
@@ -300,9 +300,21 @@ export interface McpSearchToken {
    */
   tokenPrefix: string;
   /**
+   * Which search backend (MCP server) this token reaches, enforced via LiteLLM.
+   */
+  mcpServer: 'typesense_search' | 'pgvector_search';
+  /**
    * Last time this token authenticated a request.
    */
   lastUsedAt?: string | null;
+  litellmVirtualKey?: string | null;
+  /**
+   * Internal per-token key alias in LiteLLM.
+   */
+  litellmVirtualKeyAlias?: string | null;
+  litellmVirtualKeyFingerprint?: string | null;
+  litellmVirtualKeySyncStatus?: ('synced' | 'error') | null;
+  litellmVirtualKeySyncError?: string | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -803,7 +815,13 @@ export interface McpSearchTokensSelect<T extends boolean = true> {
   label?: T;
   tokenHash?: T;
   tokenPrefix?: T;
+  mcpServer?: T;
   lastUsedAt?: T;
+  litellmVirtualKey?: T;
+  litellmVirtualKeyAlias?: T;
+  litellmVirtualKeyFingerprint?: T;
+  litellmVirtualKeySyncStatus?: T;
+  litellmVirtualKeySyncError?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/apps/server/src/payload-types.ts
+++ b/apps/server/src/payload-types.ts
@@ -360,10 +360,7 @@ export interface Agent {
    * Max tool calls per turn. Leave empty for no limit.
    */
   toolCallLimit?: number | null;
-  /**
-   * Search backends (MCP servers) this agent can use, routed through the LiteLLM gateway. Empty = none.
-   */
-  mcpServers?: ('typesense_search' | 'pgvector_search')[] | null;
+  mcpServers?: string[] | null;
   /**
    * Optional LiteLLM max budget for this agent virtual key, in USD.
    */

--- a/apps/server/src/payload-types.ts
+++ b/apps/server/src/payload-types.ts
@@ -220,7 +220,8 @@ export interface Post {
    */
   text_transforms?: ('strip-urls' | 'strip-mentions' | 'normalize-whitespace')[] | null;
   categories?: (number | Taxonomy)[] | null;
-  _syncStatus?: ('synced' | 'outdated' | 'not-indexed' | 'error') | null;
+  _syncStatus_typesense?: ('synced' | 'outdated' | 'not-indexed' | 'error') | null;
+  _syncStatus_pgvector?: ('synced' | 'outdated' | 'not-indexed' | 'error') | null;
   folder?: (number | null) | FolderInterface;
   updatedAt: string;
   createdAt: string;
@@ -770,7 +771,8 @@ export interface PostsSelect<T extends boolean = true> {
   content?: T;
   text_transforms?: T;
   categories?: T;
-  _syncStatus?: T;
+  _syncStatus_typesense?: T;
+  _syncStatus_pgvector?: T;
   folder?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/apps/server/src/payload.config.ts
+++ b/apps/server/src/payload.config.ts
@@ -29,13 +29,23 @@ async function getDailyLimit(_payload: Payload, _userId: string | number): Promi
 }
 
 /**
+ * pgvector is an EXPERIMENTAL second backend, opt-in via ENABLE_PGVECTOR=true.
+ * When enabled it indexes in parallel with Typesense (a synchronous dual-write —
+ * see plugins/pgvector) and exposes its own MCP for A/B comparison. Off by
+ * default so the speculative probe never couples content saves to a second engine.
+ */
+const PGVECTOR_ENABLED = process.env.ENABLE_PGVECTOR === 'true'
+
+/**
  * MCP descriptors for the configured search backends. The app supplies the
  * deployment URLs; agentPlugin registers them in LiteLLM on boot so agents can
- * select them. Both backends index in parallel, so both MCPs are exposed.
+ * select them.
  */
 const mcpDescriptors: McpDescriptor[] = [
   createTypesenseMcpDescriptor({ url: process.env.MCP_TYPESENSE_URL || 'http://app:3030/mcp' }),
-  createPgvectorMcpDescriptor({ url: process.env.MCP_PGVECTOR_URL || 'http://app:3041/mcp' })
+  ...(PGVECTOR_ENABLED
+    ? [createPgvectorMcpDescriptor({ url: process.env.MCP_PGVECTOR_URL || 'http://app:3041/mcp' })]
+    : [])
 ]
 const mcpServers = mcpDescriptors.map(descriptor => ({
   alias: descriptor.id,
@@ -80,7 +90,7 @@ export default buildConfig({
     const metrics = metricsPlugin({ multiTenant: false, basePath: '/metrics' })
     return [
       typesensePlugin,
-      pgvectorPlugin,
+      ...(PGVECTOR_ENABLED ? [pgvectorPlugin] : []),
       agentPlugin({
         runtimeUrl: process.env.AGENT_RUNTIME_URL || 'http://localhost:8000',
         runtimeSecret: process.env.INTERNAL_SECRET,
@@ -92,6 +102,9 @@ export default buildConfig({
           masterKey: process.env.LITELLM_MASTER_KEY
         },
         mcpServers,
+        // Tag managed MCP servers by environment so a shared LiteLLM across
+        // deployments doesn't prune across them (prune defaults on, scoped here).
+        mcpServerSync: { environment: process.env.MCP_MANAGED_ENV },
         getDailyLimit,
         encryptionKey: process.env.PAYLOAD_SECRET,
         basePath: '/chat',

--- a/apps/server/src/payload.config.ts
+++ b/apps/server/src/payload.config.ts
@@ -14,6 +14,7 @@ import { Posts } from './collections/Posts'
 import { Taxonomies } from './collections/Taxonomies'
 import { Users } from './collections/Users'
 import { defaultLocale, locales } from './i18n/locales'
+import { pgvectorPlugin } from './plugins/pgvector'
 import { typesensePlugin } from './plugins/typesense'
 
 const filename = fileURLToPath(import.meta.url)
@@ -57,6 +58,7 @@ export default buildConfig({
     const metrics = metricsPlugin({ multiTenant: false, basePath: '/metrics' })
     return [
       typesensePlugin,
+      pgvectorPlugin,
       agentPlugin({
         runtimeUrl: process.env.AGENT_RUNTIME_URL || 'http://localhost:8000',
         runtimeSecret: process.env.INTERNAL_SECRET,

--- a/apps/server/src/payload.config.ts
+++ b/apps/server/src/payload.config.ts
@@ -4,6 +4,9 @@ import { fileURLToPath } from 'node:url'
 import { agentPlugin } from '@zetesis/payload-agents-core'
 import { metricsPlugin } from '@zetesis/payload-agents-metrics'
 import { createDocumentsPlugin } from '@zetesis/payload-documents'
+import type { McpDescriptor } from '@zetesis/payload-indexer'
+import { createPgvectorMcpDescriptor } from '@zetesis/payload-pgvector'
+import { createTypesenseMcpDescriptor } from '@zetesis/payload-typesense'
 import { postgresAdapter } from '@payloadcms/db-postgres'
 import { lexicalEditor } from '@payloadcms/richtext-lexical'
 import type { Payload } from 'payload'
@@ -24,6 +27,25 @@ const dirname = path.dirname(filename)
 async function getDailyLimit(_payload: Payload, _userId: string | number): Promise<number> {
   return 500_000_000
 }
+
+/**
+ * MCP descriptors for the configured search backends. The app supplies the
+ * deployment URLs; agentPlugin registers them in LiteLLM on boot so agents can
+ * select them. Both backends index in parallel, so both MCPs are exposed.
+ */
+const mcpDescriptors: McpDescriptor[] = [
+  createTypesenseMcpDescriptor({ url: process.env.MCP_TYPESENSE_URL || 'http://app:3030/mcp' }),
+  createPgvectorMcpDescriptor({ url: process.env.MCP_PGVECTOR_URL || 'http://app:3041/mcp' })
+]
+const mcpServers = mcpDescriptors.map(descriptor => ({
+  alias: descriptor.id,
+  serverName: descriptor.id,
+  description: descriptor.displayName,
+  transport: descriptor.transport,
+  url: descriptor.url,
+  extraHeaders: descriptor.forwardHeaders,
+  allowAllKeys: true
+}))
 
 export default buildConfig({
   folders: {},
@@ -69,6 +91,7 @@ export default buildConfig({
           gatewayUrl: process.env.LITELLM_GATEWAY_URL || 'http://litellm:4000',
           masterKey: process.env.LITELLM_MASTER_KEY
         },
+        mcpServers,
         getDailyLimit,
         encryptionKey: process.env.PAYLOAD_SECRET,
         basePath: '/chat',

--- a/apps/server/src/plugins/pgvector/collections.ts
+++ b/apps/server/src/plugins/pgvector/collections.ts
@@ -1,0 +1,42 @@
+import type { IndexableCollectionConfig } from '@zetesis/payload-indexer'
+import type { PgvectorFieldMapping } from '@zetesis/payload-pgvector'
+import { createDynamicContentTransform, transformCategories } from '../typesense/transforms'
+
+/**
+ * pgvector indexing config — mirrors the Typesense `posts_chunk` table so both
+ * backends index the same content in parallel. Only the chunked table is
+ * configured (it's the one that gets embedded + vector-searched). Field `type`
+ * is the SQL column type; the standard chunk columns (parent_doc_id,
+ * chunk_text, timestamps, ...) and the `embedding vector(N)` column are added
+ * automatically by the schema derivation.
+ */
+export const pgvectorCollections: IndexableCollectionConfig<PgvectorFieldMapping> = {
+  posts: [
+    {
+      enabled: true,
+      tableName: 'posts_pgvector_chunk',
+      displayName: 'Posts (pgvector)',
+      syncDepth: 1,
+      embedding: {
+        fields: [{ field: 'content', transform: createDynamicContentTransform() }],
+        chunking: { strategy: 'markdown', size: 2000, overlap: 300 },
+        // pgvector embeds app-side via the adapter's EmbeddingProvider; this
+        // autoEmbed block is unused by the backend but required by the type.
+        autoEmbed: { from: ['chunk_text'], modelConfig: {} }
+      },
+      fields: [
+        { name: 'title', type: 'text' },
+        { name: 'slug', type: 'text', index: true },
+        { name: 'publishedAt', type: 'bigint', optional: true },
+        {
+          name: 'taxonomy_slugs',
+          type: 'text[]',
+          index: true,
+          optional: true,
+          transform: transformCategories,
+          payloadField: 'categories'
+        }
+      ]
+    }
+  ]
+}

--- a/apps/server/src/plugins/pgvector/config.ts
+++ b/apps/server/src/plugins/pgvector/config.ts
@@ -1,0 +1,17 @@
+import type { OpenAICompatibleEmbeddingConfig } from '@zetesis/payload-pgvector'
+
+/** Postgres connection for the pgvector tables (same DB as Payload). */
+export const pgvectorConnectionString = process.env.DATABASE_URL || ''
+
+/**
+ * Embedding routed through the LiteLLM gateway (OpenAI-compatible). The
+ * `embeddings-dev` alias is seeded in the devcontainer LiteLLM catalog and
+ * pins `text-embedding-3-small` (1536 dims). Index-time and query-time MUST use
+ * this same alias.
+ */
+export const pgvectorEmbedding: OpenAICompatibleEmbeddingConfig = {
+  baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
+  apiKey: process.env.LITELLM_MASTER_KEY || '',
+  model: 'embeddings-dev',
+  dimensions: 1536
+}

--- a/apps/server/src/plugins/pgvector/config.ts
+++ b/apps/server/src/plugins/pgvector/config.ts
@@ -19,5 +19,7 @@ export const pgvectorEmbedding: OpenAICompatibleEmbeddingConfig = {
   baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
   apiKey: process.env.LITELLM_MASTER_KEY || '',
   model: 'embeddings-dev',
-  dimensions: 1536
+  dimensions: 1536,
+  // text-embedding-3-small honours dimensionality reduction, so pin it explicitly.
+  sendDimensions: true
 }

--- a/apps/server/src/plugins/pgvector/config.ts
+++ b/apps/server/src/plugins/pgvector/config.ts
@@ -4,6 +4,12 @@ import type { OpenAICompatibleEmbeddingConfig } from '@zetesis/payload-pgvector'
 export const pgvectorConnectionString = process.env.DATABASE_URL || ''
 
 /**
+ * Dedicated Postgres schema for the pgvector tables. Keeps them OUT of `public`
+ * so Payload/Drizzle's schema push doesn't treat them as unmanaged and drop them.
+ */
+export const pgvectorSchema = 'pgvector'
+
+/**
  * Embedding routed through the LiteLLM gateway (OpenAI-compatible). The
  * `embeddings-dev` alias is seeded in the devcontainer LiteLLM catalog and
  * pins `text-embedding-3-small` (1536 dims). Index-time and query-time MUST use

--- a/apps/server/src/plugins/pgvector/index.ts
+++ b/apps/server/src/plugins/pgvector/index.ts
@@ -1,0 +1,39 @@
+import { createIndexerPlugin } from '@zetesis/payload-indexer'
+import { createPgvectorAdapter, createPgvectorPlugin } from '@zetesis/payload-pgvector'
+import type { Config } from 'payload'
+import { pgvectorCollections } from './collections'
+import { pgvectorConnectionString, pgvectorEmbedding } from './config'
+
+export { pgvectorCollections } from './collections'
+
+// Shared adapter instance: createIndexerPlugin uses it for document sync (hooks),
+// createPgvectorPlugin uses it for schema sync (onInit ensureCollection).
+const adapter = createPgvectorAdapter({
+  connectionString: pgvectorConnectionString,
+  embedding: pgvectorEmbedding
+})
+
+const { plugin: indexerPlugin } = createIndexerPlugin({
+  adapter,
+  features: {
+    sync: {
+      enabled: true,
+      // `adapter.name` ('pgvector') namespaces the sync-status field/endpoints,
+      // so it coexists with the Typesense indexer on the same `posts` collection.
+      defaultColumns: ['title', '_syncStatus_pgvector', 'slug']
+    }
+  },
+  collections: pgvectorCollections
+})
+
+const schemaPlugin = createPgvectorPlugin({
+  adapter,
+  collections: pgvectorCollections,
+  dimensions: pgvectorEmbedding.dimensions
+})
+
+export const pgvectorPlugin = (config: Config): Config => {
+  config = indexerPlugin(config)
+  config = schemaPlugin(config)
+  return config
+}

--- a/apps/server/src/plugins/pgvector/index.ts
+++ b/apps/server/src/plugins/pgvector/index.ts
@@ -2,7 +2,7 @@ import { createIndexerPlugin } from '@zetesis/payload-indexer'
 import { createPgvectorAdapter, createPgvectorPlugin } from '@zetesis/payload-pgvector'
 import type { Config } from 'payload'
 import { pgvectorCollections } from './collections'
-import { pgvectorConnectionString, pgvectorEmbedding } from './config'
+import { pgvectorConnectionString, pgvectorEmbedding, pgvectorSchema } from './config'
 
 export { pgvectorCollections } from './collections'
 
@@ -10,7 +10,8 @@ export { pgvectorCollections } from './collections'
 // createPgvectorPlugin uses it for schema sync (onInit ensureCollection).
 const adapter = createPgvectorAdapter({
   connectionString: pgvectorConnectionString,
-  embedding: pgvectorEmbedding
+  embedding: pgvectorEmbedding,
+  schema: pgvectorSchema
 })
 
 const { plugin: indexerPlugin } = createIndexerPlugin({

--- a/apps/server/src/plugins/typesense/index.ts
+++ b/apps/server/src/plugins/typesense/index.ts
@@ -17,7 +17,7 @@ const { plugin: indexerPlugin } = createIndexerPlugin({
   features: {
     sync: {
       enabled: true,
-      defaultColumns: ['title', '_syncStatus', 'slug']
+      defaultColumns: ['title', '_syncStatus_typesense', '_syncStatus_pgvector', 'slug']
     }
   },
   collections

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../../packages/chat-agent" },
     { "path": "../../packages/payload-indexer" },
     { "path": "../../packages/payload-lexical-blocks-builder" },
+    { "path": "../../packages/payload-pgvector" },
     { "path": "../../packages/payload-taxonomies" },
     { "path": "../../packages/payload-typesense" }
   ]

--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -121,17 +121,29 @@ def build_mcp_toolset(
     """
     if not cfg.mcp_servers:
         return [build_mcp_tools(mcp_url, cfg)]
+    # Multiple backends expose tools with identical names (search_collections, …);
+    # per-alias /{alias}/mcp routing does NOT namespace them, so Agno would collide
+    # and silently keep one. Prefix each toolset by its alias to disambiguate.
+    multi = len(cfg.mcp_servers) > 1
     return [
-        build_mcp_tools(f"{gateway_base}/{alias}/mcp", cfg, proxy_key=proxy_key)
+        build_mcp_tools(
+            f"{gateway_base}/{alias}/mcp",
+            cfg,
+            proxy_key=proxy_key,
+            tool_name_prefix=alias if multi else None,
+        )
         for alias in cfg.mcp_servers
     ]
 
 
-def build_mcp_tools(mcp_url: str, cfg: AgentConfig, *, proxy_key: str | None = None) -> MCPTools:
+def build_mcp_tools(
+    mcp_url: str, cfg: AgentConfig, *, proxy_key: str | None = None, tool_name_prefix: str | None = None
+) -> MCPTools:
     """Build an MCPTools instance, forwarding the agent's SearchProfile config as headers.
 
     When ``proxy_key`` is set the endpoint is the LiteLLM gateway, so the
-    per-agent virtual key authenticates the connection.
+    per-agent virtual key authenticates the connection. ``tool_name_prefix``
+    namespaces the tool names so multiple backends don't collide in one agent.
     """
     headers: dict[str, str] = {}
     if proxy_key:
@@ -161,5 +173,5 @@ def build_mcp_tools(mcp_url: str, cfg: AgentConfig, *, proxy_key: str | None = N
     headers.update(build_retrieval_profile_headers(cfg.retrieval_profiles))
     if headers:
         params = StreamableHTTPClientParams(url=mcp_url, headers=headers)
-        return MCPTools(server_params=params, transport="streamable-http")
-    return MCPTools(url=mcp_url, transport="streamable-http")
+        return MCPTools(server_params=params, transport="streamable-http", tool_name_prefix=tool_name_prefix)
+    return MCPTools(url=mcp_url, transport="streamable-http", tool_name_prefix=tool_name_prefix)

--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -47,7 +47,12 @@ def build_agent(
             cfg, tool_protocol=tool_protocol, output_format=output_format
         ),
         db=db,
-        tools=[build_mcp_tools(mcp_url, cfg)],
+        tools=build_mcp_toolset(
+            cfg,
+            mcp_url=mcp_url,
+            gateway_base=gateway_base_url(litellm_proxy_url),
+            proxy_key=proxy_key,
+        ),
         add_history_to_context=True,
         num_history_runs=5,
         # Reasoning scaffolding stays OFF through the gateway: the preset hides
@@ -95,9 +100,43 @@ def build_model(
     )
 
 
-def build_mcp_tools(mcp_url: str, cfg: AgentConfig) -> MCPTools:
-    """Build an MCPTools instance, forwarding the agent's SearchProfile config as headers."""
+def gateway_base_url(litellm_proxy_url: str) -> str:
+    """The LiteLLM gateway root (MCP endpoints live at ``/{alias}/mcp``, not under ``/v1``)."""
+    return litellm_proxy_url.removesuffix("/v1").rstrip("/")
+
+
+def build_mcp_toolset(
+    cfg: AgentConfig,
+    *,
+    mcp_url: str,
+    gateway_base: str,
+    proxy_key: str,
+) -> list[MCPTools]:
+    """Resolve the agent's MCP tools.
+
+    When the agent selects MCP servers, route each through the LiteLLM gateway
+    at ``/{alias}/mcp`` (authenticated with the per-agent virtual key); the
+    retrieval headers are forwarded to whichever server declares them. With no
+    selection, fall back to the single direct MCP URL (legacy behaviour).
+    """
+    if not cfg.mcp_servers:
+        return [build_mcp_tools(mcp_url, cfg)]
+    return [
+        build_mcp_tools(f"{gateway_base}/{alias}/mcp", cfg, proxy_key=proxy_key)
+        for alias in cfg.mcp_servers
+    ]
+
+
+def build_mcp_tools(mcp_url: str, cfg: AgentConfig, *, proxy_key: str | None = None) -> MCPTools:
+    """Build an MCPTools instance, forwarding the agent's SearchProfile config as headers.
+
+    When ``proxy_key`` is set the endpoint is the LiteLLM gateway, so the
+    per-agent virtual key authenticates the connection.
+    """
     headers: dict[str, str] = {}
+    if proxy_key:
+        headers["x-litellm-api-key"] = f"Bearer {proxy_key}"
+        headers["Authorization"] = f"Bearer {proxy_key}"
     if cfg.tenant_slug:
         headers["x-tenant-slug"] = cfg.tenant_slug
     if cfg.taxonomy_slugs:

--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -121,29 +121,21 @@ def build_mcp_toolset(
     """
     if not cfg.mcp_servers:
         return [build_mcp_tools(mcp_url, cfg)]
-    # Multiple backends expose tools with identical names (search_collections, …);
-    # per-alias /{alias}/mcp routing does NOT namespace them, so Agno would collide
-    # and silently keep one. Prefix each toolset by its alias to disambiguate.
-    multi = len(cfg.mcp_servers) > 1
+    # LiteLLM already namespaces each server's tools as `{alias}-{tool}` when routed
+    # through /{alias}/mcp (verified against v1.82: Context7 exposes
+    # `Context7-resolve-library-id`), so two backends sharing a tool name don't
+    # collide — adding our own prefix would only double it.
     return [
-        build_mcp_tools(
-            f"{gateway_base}/{alias}/mcp",
-            cfg,
-            proxy_key=proxy_key,
-            tool_name_prefix=alias if multi else None,
-        )
+        build_mcp_tools(f"{gateway_base}/{alias}/mcp", cfg, proxy_key=proxy_key)
         for alias in cfg.mcp_servers
     ]
 
 
-def build_mcp_tools(
-    mcp_url: str, cfg: AgentConfig, *, proxy_key: str | None = None, tool_name_prefix: str | None = None
-) -> MCPTools:
+def build_mcp_tools(mcp_url: str, cfg: AgentConfig, *, proxy_key: str | None = None) -> MCPTools:
     """Build an MCPTools instance, forwarding the agent's SearchProfile config as headers.
 
     When ``proxy_key`` is set the endpoint is the LiteLLM gateway, so the
-    per-agent virtual key authenticates the connection. ``tool_name_prefix``
-    namespaces the tool names so multiple backends don't collide in one agent.
+    per-agent virtual key authenticates the connection.
     """
     headers: dict[str, str] = {}
     if proxy_key:
@@ -173,5 +165,5 @@ def build_mcp_tools(
     headers.update(build_retrieval_profile_headers(cfg.retrieval_profiles))
     if headers:
         params = StreamableHTTPClientParams(url=mcp_url, headers=headers)
-        return MCPTools(server_params=params, transport="streamable-http", tool_name_prefix=tool_name_prefix)
-    return MCPTools(url=mcp_url, transport="streamable-http", tool_name_prefix=tool_name_prefix)
+        return MCPTools(server_params=params, transport="streamable-http")
+    return MCPTools(url=mcp_url, transport="streamable-http")

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -153,6 +153,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         search_collections=search_collections,
         tool_call_limit=tool_call_limit,
         allow_guest_access=bool(doc.get("allowGuestAccess")),
+        mcp_servers=[s for s in (doc.get("mcpServers") or []) if isinstance(s, str)],
         reranker_kind=reranker_kind,
         reranker_model=reranker_model,
         hybrid_alpha=hybrid_alpha,

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -62,6 +62,10 @@ class AgentConfig(BaseModel):
     search_collections: list[str] = []
     tool_call_limit: int | None = None
     allow_guest_access: bool = False
+    # MCP server aliases (registered in the LiteLLM gateway) this agent uses.
+    # When set, the builder routes each through the gateway `/{alias}/mcp`
+    # instead of a single direct MCP URL.
+    mcp_servers: list[str] = []
     # Retrieval params sourced from the agent's `defaultRetrievalProfile`.
     # Forwarded as headers to the MCP server so it can run two-stage retrieval
     # (Typesense → reranker). All optional; missing fields fall back to MCP

--- a/backend/agno-agent-builder/tests/test_builder.py
+++ b/backend/agno-agent-builder/tests/test_builder.py
@@ -120,7 +120,7 @@ class TestBuildAgent:
         # pure unit of build_agent's wiring.
         monkeypatch.setattr(
             "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: MagicMock(),
+            lambda mcp_url, cfg, proxy_key=None: MagicMock(),
         )
 
         agent = self._build(self._cfg())
@@ -151,11 +151,10 @@ class TestBuildMcpToolset:
         assert gateway_base_url("http://litellm:4000/") == "http://litellm:4000"
 
     def test_no_selection_uses_single_direct_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        seen: list[tuple[str, str | None]] = []
+        seen: list[str] = []
         monkeypatch.setattr(
             "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: seen.append((mcp_url, tool_name_prefix))
-            or MagicMock(),
+            lambda mcp_url, cfg, proxy_key=None: seen.append(mcp_url) or MagicMock(),
         )
         tools = build_mcp_toolset(
             self._cfg([]),
@@ -164,30 +163,15 @@ class TestBuildMcpToolset:
             proxy_key="sk-virtual",
         )
         assert len(tools) == 1
-        assert seen == [("http://mcp:9000", None)]
+        assert seen == ["http://mcp:9000"]
 
-    def test_single_selection_routes_through_gateway_unprefixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        seen: list[tuple[str, str | None]] = []
+    def test_selection_routes_each_through_gateway(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # LiteLLM namespaces tools as {alias}-{tool}, so we add no extra prefix —
+        # the toolset just routes each selected backend through /{alias}/mcp.
+        seen: list[str] = []
         monkeypatch.setattr(
             "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: seen.append((mcp_url, tool_name_prefix))
-            or MagicMock(),
-        )
-        build_mcp_toolset(
-            self._cfg(["typesense_search"]),
-            mcp_url="http://mcp:9000",
-            gateway_base="http://litellm:4000",
-            proxy_key="sk-virtual",
-        )
-        # A single backend keeps tool names unchanged (no collision to disambiguate).
-        assert seen == [("http://litellm:4000/typesense_search/mcp", None)]
-
-    def test_multi_selection_prefixes_each_by_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        seen: list[tuple[str, str | None]] = []
-        monkeypatch.setattr(
-            "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: seen.append((mcp_url, tool_name_prefix))
-            or MagicMock(),
+            lambda mcp_url, cfg, proxy_key=None: seen.append(mcp_url) or MagicMock(),
         )
         tools = build_mcp_toolset(
             self._cfg(["typesense_search", "pgvector_search"]),
@@ -196,9 +180,7 @@ class TestBuildMcpToolset:
             proxy_key="sk-virtual",
         )
         assert len(tools) == 2
-        # Each toolset is prefixed by its alias so the two backends' identically
-        # named tools (search_collections, …) don't collide in one agent.
         assert seen == [
-            ("http://litellm:4000/typesense_search/mcp", "typesense_search"),
-            ("http://litellm:4000/pgvector_search/mcp", "pgvector_search"),
+            "http://litellm:4000/typesense_search/mcp",
+            "http://litellm:4000/pgvector_search/mcp",
         ]

--- a/backend/agno-agent-builder/tests/test_builder.py
+++ b/backend/agno-agent-builder/tests/test_builder.py
@@ -120,7 +120,7 @@ class TestBuildAgent:
         # pure unit of build_agent's wiring.
         monkeypatch.setattr(
             "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None: MagicMock(),
+            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: MagicMock(),
         )
 
         agent = self._build(self._cfg())
@@ -151,10 +151,11 @@ class TestBuildMcpToolset:
         assert gateway_base_url("http://litellm:4000/") == "http://litellm:4000"
 
     def test_no_selection_uses_single_direct_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        seen: list[str] = []
+        seen: list[tuple[str, str | None]] = []
         monkeypatch.setattr(
             "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None: seen.append(mcp_url) or MagicMock(),
+            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: seen.append((mcp_url, tool_name_prefix))
+            or MagicMock(),
         )
         tools = build_mcp_toolset(
             self._cfg([]),
@@ -163,13 +164,30 @@ class TestBuildMcpToolset:
             proxy_key="sk-virtual",
         )
         assert len(tools) == 1
-        assert seen == ["http://mcp:9000"]
+        assert seen == [("http://mcp:9000", None)]
 
-    def test_selection_routes_each_through_gateway(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        seen: list[str] = []
+    def test_single_selection_routes_through_gateway_unprefixed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[tuple[str, str | None]] = []
         monkeypatch.setattr(
             "agno_agent_builder.builder.build_mcp_tools",
-            lambda mcp_url, cfg, proxy_key=None: seen.append(mcp_url) or MagicMock(),
+            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: seen.append((mcp_url, tool_name_prefix))
+            or MagicMock(),
+        )
+        build_mcp_toolset(
+            self._cfg(["typesense_search"]),
+            mcp_url="http://mcp:9000",
+            gateway_base="http://litellm:4000",
+            proxy_key="sk-virtual",
+        )
+        # A single backend keeps tool names unchanged (no collision to disambiguate).
+        assert seen == [("http://litellm:4000/typesense_search/mcp", None)]
+
+    def test_multi_selection_prefixes_each_by_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[tuple[str, str | None]] = []
+        monkeypatch.setattr(
+            "agno_agent_builder.builder.build_mcp_tools",
+            lambda mcp_url, cfg, proxy_key=None, tool_name_prefix=None: seen.append((mcp_url, tool_name_prefix))
+            or MagicMock(),
         )
         tools = build_mcp_toolset(
             self._cfg(["typesense_search", "pgvector_search"]),
@@ -178,7 +196,9 @@ class TestBuildMcpToolset:
             proxy_key="sk-virtual",
         )
         assert len(tools) == 2
+        # Each toolset is prefixed by its alias so the two backends' identically
+        # named tools (search_collections, …) don't collide in one agent.
         assert seen == [
-            "http://litellm:4000/typesense_search/mcp",
-            "http://litellm:4000/pgvector_search/mcp",
+            ("http://litellm:4000/typesense_search/mcp", "typesense_search"),
+            ("http://litellm:4000/pgvector_search/mcp", "pgvector_search"),
         ]

--- a/backend/agno-agent-builder/tests/test_builder.py
+++ b/backend/agno-agent-builder/tests/test_builder.py
@@ -7,7 +7,13 @@ from unittest.mock import MagicMock
 import pytest
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
-from agno_agent_builder.builder import build_agent, build_model, resolve_litellm_proxy_key
+from agno_agent_builder.builder import (
+    build_agent,
+    build_mcp_toolset,
+    build_model,
+    gateway_base_url,
+    resolve_litellm_proxy_key,
+)
 from agno_agent_builder.exceptions import InvalidModelError, MissingLiteLlmVirtualKeyError
 from agno_agent_builder.sources import AgentConfig
 from pydantic import SecretStr
@@ -113,7 +119,8 @@ class TestBuildAgent:
         # build_mcp_tools constructs a real MCPTools; stub it so the test stays a
         # pure unit of build_agent's wiring.
         monkeypatch.setattr(
-            "agno_agent_builder.builder.build_mcp_tools", lambda mcp_url, cfg: MagicMock()
+            "agno_agent_builder.builder.build_mcp_tools",
+            lambda mcp_url, cfg, proxy_key=None: MagicMock(),
         )
 
         agent = self._build(self._cfg())
@@ -123,3 +130,55 @@ class TestBuildAgent:
         assert agent.model.base_url == "http://litellm:4000/v1"
         assert agent.model.api_key == "sk-virtual"
         assert agent.model.extra_body == {"api_key": "sk-ant-agent"}
+
+
+class TestBuildMcpToolset:
+    """The agent's MCP selection drives which MCPs it connects to, routed through
+    the LiteLLM gateway; no selection keeps the single legacy direct URL."""
+
+    def _cfg(self, mcp_servers: list[str]) -> AgentConfig:
+        return AgentConfig(
+            slug="bastos",
+            name="Bastos",
+            llm_model="chat-premium",
+            api_key=SecretStr("sk-ant-agent"),
+            litellm_virtual_key=SecretStr("sk-virtual"),
+            mcp_servers=mcp_servers,
+        )
+
+    def test_gateway_base_strips_v1(self) -> None:
+        assert gateway_base_url("http://litellm:4000/v1") == "http://litellm:4000"
+        assert gateway_base_url("http://litellm:4000/") == "http://litellm:4000"
+
+    def test_no_selection_uses_single_direct_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "agno_agent_builder.builder.build_mcp_tools",
+            lambda mcp_url, cfg, proxy_key=None: seen.append(mcp_url) or MagicMock(),
+        )
+        tools = build_mcp_toolset(
+            self._cfg([]),
+            mcp_url="http://mcp:9000",
+            gateway_base="http://litellm:4000",
+            proxy_key="sk-virtual",
+        )
+        assert len(tools) == 1
+        assert seen == ["http://mcp:9000"]
+
+    def test_selection_routes_each_through_gateway(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: list[str] = []
+        monkeypatch.setattr(
+            "agno_agent_builder.builder.build_mcp_tools",
+            lambda mcp_url, cfg, proxy_key=None: seen.append(mcp_url) or MagicMock(),
+        )
+        tools = build_mcp_toolset(
+            self._cfg(["typesense_search", "pgvector_search"]),
+            mcp_url="http://mcp:9000",
+            gateway_base="http://litellm:4000",
+            proxy_key="sk-virtual",
+        )
+        assert len(tools) == 2
+        assert seen == [
+            "http://litellm:4000/typesense_search/mcp",
+            "http://litellm:4000/pgvector_search/mcp",
+        ]

--- a/packages/mcp-pgvector/package.json
+++ b/packages/mcp-pgvector/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@zetesis/mcp-pgvector",
+  "version": "0.0.0",
+  "description": "Thin MCP server over a pgvector-backed index (@zetesis/payload-pgvector). Built for A/B comparison against mcp-typesense — deliberately minimal, no shared search contract.",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./dist/index.d.mts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "start": "node dist/standalone.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@zetesis/payload-pgvector": "workspace:*",
+    "pg": "^8.13.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.4",
+    "@types/pg": "^8.11.10",
+    "rimraf": "3.0.2",
+    "tsdown": "^0.16.5",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=22",
+    "pnpm": "^9 || ^10"
+  }
+}

--- a/packages/mcp-pgvector/src/index.ts
+++ b/packages/mcp-pgvector/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @zetesis/mcp-pgvector
+ *
+ * Thin MCP server over a pgvector index, for A/B comparison against
+ * @zetesis/mcp-typesense. Intentionally minimal and pgvector-native — it does
+ * not emulate Typesense's retrieval semantics.
+ */
+
+export type {
+  PgvectorMcpCollection,
+  PgvectorMcpConfig,
+  PgvectorMcpHandle
+} from './server'
+export { createPgvectorMcpServer } from './server'

--- a/packages/mcp-pgvector/src/scope.spec.ts
+++ b/packages/mcp-pgvector/src/scope.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { parseScopeHeader, scopeDenied, scopeFilter } from './scope'
+
+describe('parseScopeHeader', () => {
+  it('splits, trims and drops empties', () => {
+    expect(parseScopeHeader(' bastos , mises ,,')).toEqual(['bastos', 'mises'])
+  })
+
+  it('joins an array header before parsing', () => {
+    expect(parseScopeHeader(['bastos', 'mises'])).toEqual(['bastos', 'mises'])
+  })
+
+  it('returns [] for missing or empty header', () => {
+    expect(parseScopeHeader(undefined)).toEqual([])
+    expect(parseScopeHeader('')).toEqual([])
+  })
+})
+
+describe('scopeFilter', () => {
+  it('forces taxonomy_slugs from the scope, overriding any client value', () => {
+    expect(scopeFilter({ taxonomy_slugs: ['mises'], parent_doc_id: '1' }, ['bastos'])).toEqual({
+      taxonomy_slugs: ['bastos'],
+      parent_doc_id: '1'
+    })
+  })
+
+  it('leaves the filter untouched when there is no scope', () => {
+    expect(scopeFilter({ parent_doc_id: '1' }, [])).toEqual({ parent_doc_id: '1' })
+  })
+})
+
+describe('scopeDenied (deny-by-default)', () => {
+  it('denies an unscoped request only when the server requires a scope', () => {
+    expect(scopeDenied([], true)).toBe(true)
+    expect(scopeDenied([], false)).toBe(false)
+  })
+
+  it('never denies a scoped request', () => {
+    expect(scopeDenied(['bastos'], true)).toBe(false)
+    expect(scopeDenied(['bastos'], false)).toBe(false)
+  })
+})

--- a/packages/mcp-pgvector/src/scope.ts
+++ b/packages/mcp-pgvector/src/scope.ts
@@ -1,0 +1,37 @@
+/**
+ * Trusted taxonomy-scope logic for mcp-pgvector, kept pure and unit-testable.
+ *
+ * The security-critical decision of WHAT a request may read lives here, not
+ * inline in the HTTP/tool handlers. The scope arrives via the trusted
+ * `x-taxonomy-slugs` header (injected by the Payload proxy / forwarded by
+ * LiteLLM); a client cannot widen it.
+ */
+
+/** Parse the `x-taxonomy-slugs` header into a clean slug list. */
+export function parseScopeHeader(raw: string | string[] | undefined): string[] {
+  const value = Array.isArray(raw) ? raw.join(',') : raw
+  if (!value) return []
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Force the scope onto a filter as a NON-overridable `taxonomy_slugs` filter —
+ * the scope always wins over any client-supplied `taxonomy_slugs`. With no
+ * scope the filter is returned unchanged (see {@link scopeDenied} for the
+ * deny-by-default guard that must gate this case).
+ */
+export function scopeFilter(filter: Record<string, unknown>, scope: string[]): Record<string, unknown> {
+  return scope.length > 0 ? { ...filter, taxonomy_slugs: scope } : filter
+}
+
+/**
+ * Deny-by-default guard. When the server is configured to require a scope and a
+ * request carries none, it must read NOTHING rather than the whole corpus.
+ * Callers check this before querying and short-circuit to an empty result.
+ */
+export function scopeDenied(scope: string[], requireScope: boolean): boolean {
+  return requireScope && scope.length === 0
+}

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -21,6 +21,7 @@ import {
   type PgvectorCollectionSchema
 } from '@zetesis/payload-pgvector'
 import { z } from 'zod'
+import { parseScopeHeader, scopeDenied, scopeFilter } from './scope'
 
 /** A searchable pgvector table exposed by the MCP. */
 export interface PgvectorMcpCollection {
@@ -47,6 +48,15 @@ export interface PgvectorMcpConfig {
   /** Embedding config (OpenAI-compatible, e.g. a LiteLLM gateway). */
   embedding: OpenAICompatibleEmbeddingConfig
   collections: PgvectorMcpCollection[]
+  /**
+   * Deny-by-default defense in depth: when true, a request that arrives WITHOUT
+   * an `x-taxonomy-slugs` scope reads nothing instead of the whole corpus. The
+   * Payload proxy already refuses unscoped tokens, so this guards the case where
+   * the MCP is reached directly. Default false to keep the package generic (a
+   * deployment where some callers are legitimately unscoped). Enable it whenever
+   * every caller is expected to be tenant-scoped.
+   */
+  requireScope?: boolean
 }
 
 export interface PgvectorMcpHandle {
@@ -78,16 +88,23 @@ const text = (value: unknown) => ({ content: [{ type: 'text' as const, text: JSO
 
 /**
  * Per-request taxonomy scope, read from the trusted `x-taxonomy-slugs` header
- * (injected by the Payload proxy / forwarded by LiteLLM). The MCP server applies
- * it as a NON-overridable filter so a scoped token cannot read outside it.
+ * (injected by the Payload proxy / forwarded by LiteLLM). The MCP applies it as a
+ * NON-overridable filter so a scoped caller cannot read outside it; `requireScope`
+ * additionally denies unscoped requests (see scope.ts).
  */
-const scopeStore = new AsyncLocalStorage<{ taxonomySlugs: string[] }>()
-const scopedTaxonomy = (): string[] => scopeStore.getStore()?.taxonomySlugs ?? []
+const scopeStore = new AsyncLocalStorage<{ taxonomySlugs: string[]; requireScope: boolean }>()
+const currentScope = (): { taxonomySlugs: string[]; requireScope: boolean } =>
+  scopeStore.getStore() ?? { taxonomySlugs: [], requireScope: false }
 
 /** Force the scope onto a filter object — the scope always wins over client input. */
 function applyScope(filter: Record<string, unknown>): Record<string, unknown> {
-  const scope = scopedTaxonomy()
-  return scope.length > 0 ? { ...filter, taxonomy_slugs: scope } : filter
+  return scopeFilter(filter, currentScope().taxonomySlugs)
+}
+
+/** Deny-by-default: true when this request must read nothing (no scope, scope required). */
+function denied(): boolean {
+  const { taxonomySlugs, requireScope } = currentScope()
+  return scopeDenied(taxonomySlugs, requireScope)
 }
 
 function registerTools(server: McpServer, adapter: PgvectorAdapter, collections: PgvectorMcpCollection[]): void {
@@ -112,6 +129,7 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
       }
     },
     async input => {
+      if (denied()) return text({ hits: [], total: 0 })
       const targets = input.collection ? [input.collection] : names
       const limit = input.limit ?? 10
       // Scope wins over client-supplied taxonomy_slugs — cannot be widened.
@@ -137,6 +155,7 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
       }
     },
     async input => {
+      if (denied()) return text({ chunks: [], total: 0 })
       const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
         input.collection,
         applyScope({ parent_doc_id: input.parent_doc_id })
@@ -157,6 +176,7 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
       }
     },
     async input => {
+      if (denied()) return text({ chunks: [], total: 0 })
       const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
         input.collection,
         applyScope({ id: input.ids })
@@ -180,6 +200,7 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
   const sessions = new Map<string, StreamableHTTPServerTransport>()
   const port = config.transport?.port ?? DEFAULT_PORT
   const host = config.transport?.host ?? DEFAULT_HOST
+  const requireScope = config.requireScope ?? false
 
   async function createSession(): Promise<StreamableHTTPServerTransport> {
     const server = new McpServer(
@@ -211,14 +232,8 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
     }
 
     // Trusted scope from the header, applied to every tool call this request makes.
-    const taxHeader = req.headers['x-taxonomy-slugs']
-    const taxonomySlugs =
-      typeof taxHeader === 'string' && taxHeader
-        ? taxHeader
-            .split(',')
-            .map(s => s.trim())
-            .filter(Boolean)
-        : []
+    const taxonomySlugs = parseScopeHeader(req.headers['x-taxonomy-slugs'])
+    const scope = { taxonomySlugs, requireScope }
 
     const sessionId = req.headers['mcp-session-id'] as string | undefined
     if (sessionId) {
@@ -229,11 +244,11 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
           .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }))
         return
       }
-      await scopeStore.run({ taxonomySlugs }, () => transport.handleRequest(req, res))
+      await scopeStore.run(scope, () => transport.handleRequest(req, res))
       return
     }
     const transport = await createSession()
-    await scopeStore.run({ taxonomySlugs }, () => transport.handleRequest(req, res))
+    await scopeStore.run(scope, () => transport.handleRequest(req, res))
   }
 
   let httpServer: HttpServer | null = null

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -7,6 +7,7 @@
  * search_collections, get_chunks_by_parent, get_chunks_by_ids.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
 import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
@@ -75,6 +76,20 @@ const buildSchema = (c: PgvectorMcpCollection, dimensions: number): PgvectorColl
 
 const text = (value: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] })
 
+/**
+ * Per-request taxonomy scope, read from the trusted `x-taxonomy-slugs` header
+ * (injected by the Payload proxy / forwarded by LiteLLM). The MCP server applies
+ * it as a NON-overridable filter so a scoped token cannot read outside it.
+ */
+const scopeStore = new AsyncLocalStorage<{ taxonomySlugs: string[] }>()
+const scopedTaxonomy = (): string[] => scopeStore.getStore()?.taxonomySlugs ?? []
+
+/** Force the scope onto a filter object — the scope always wins over client input. */
+function applyScope(filter: Record<string, unknown>): Record<string, unknown> {
+  const scope = scopedTaxonomy()
+  return scope.length > 0 ? { ...filter, taxonomy_slugs: scope } : filter
+}
+
 function registerTools(server: McpServer, adapter: PgvectorAdapter, collections: PgvectorMcpCollection[]): void {
   const names = collections.map(c => c.name)
   const nameList = names.join(', ')
@@ -99,9 +114,11 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
     async input => {
       const targets = input.collection ? [input.collection] : names
       const limit = input.limit ?? 10
+      // Scope wins over client-supplied taxonomy_slugs — cannot be widened.
+      const filter = applyScope({ ...(input.filters ?? {}) })
       const hits: Array<{ collection: string; id: string; score: number; document: Record<string, unknown> }> = []
       for (const name of targets) {
-        const results = await adapter.searchByText(name, input.query, { limit, filter: input.filters })
+        const results = await adapter.searchByText(name, input.query, { limit, filter })
         for (const r of results) hits.push({ collection: name, id: r.id, score: r.score, document: r.document })
       }
       hits.sort((a, b) => a.score - b.score)
@@ -120,9 +137,10 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
       }
     },
     async input => {
-      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(input.collection, {
-        parent_doc_id: input.parent_doc_id
-      })
+      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
+        input.collection,
+        applyScope({ parent_doc_id: input.parent_doc_id })
+      )
       rows.sort((a, b) => Number(a.chunk_index ?? 0) - Number(b.chunk_index ?? 0))
       return text({ chunks: rows, total: rows.length })
     }
@@ -139,7 +157,10 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
       }
     },
     async input => {
-      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(input.collection, { id: input.ids })
+      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
+        input.collection,
+        applyScope({ id: input.ids })
+      )
       return text({ chunks: rows, total: rows.length })
     }
   )
@@ -189,6 +210,16 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
       return
     }
 
+    // Trusted scope from the header, applied to every tool call this request makes.
+    const taxHeader = req.headers['x-taxonomy-slugs']
+    const taxonomySlugs =
+      typeof taxHeader === 'string' && taxHeader
+        ? taxHeader
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+        : []
+
     const sessionId = req.headers['mcp-session-id'] as string | undefined
     if (sessionId) {
       const transport = sessions.get(sessionId)
@@ -198,11 +229,11 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
           .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }))
         return
       }
-      await transport.handleRequest(req, res)
+      await scopeStore.run({ taxonomySlugs }, () => transport.handleRequest(req, res))
       return
     }
     const transport = await createSession()
-    await transport.handleRequest(req, res)
+    await scopeStore.run({ taxonomySlugs }, () => transport.handleRequest(req, res))
   }
 
   let httpServer: HttpServer | null = null

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -306,6 +306,7 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
       })
       httpServer = null
       sessions.clear()
+      await adapter.close()
     }
   }
 }

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -1,0 +1,244 @@
+/**
+ * createPgvectorMcpServer: a deliberately thin MCP server over a pgvector index.
+ *
+ * Built for A/B comparison against @zetesis/mcp-typesense. It does NOT share a
+ * search contract with it — semantics (score scale, total counts, no
+ * hybrid/RRF, no facets) are pgvector-native on purpose. Three read tools:
+ * search_collections, get_chunks_by_parent, get_chunks_by_ids.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import {
+  createPgvectorAdapter,
+  type OpenAICompatibleEmbeddingConfig,
+  type PgFieldSchema,
+  type PgFieldType,
+  type PgvectorAdapter,
+  type PgvectorCollectionSchema
+} from '@zetesis/payload-pgvector'
+import { z } from 'zod'
+
+/** A searchable pgvector table exposed by the MCP. */
+export interface PgvectorMcpCollection {
+  /** Table name, e.g. `posts_pgvector_chunk`. */
+  name: string
+  displayName?: string
+  /** Vector column. Defaults to `embedding`. */
+  embeddingField?: string
+  /** Distance metric (must match how the table was indexed). Defaults to `cosine`. */
+  distance?: 'cosine' | 'l2' | 'ip'
+  /** Primary key column. Defaults to `id`. */
+  idField?: string
+  /** Columns usable in `filters`, mapped to their SQL type (picks the operator). */
+  filterColumns?: Record<string, PgFieldType>
+}
+
+export interface PgvectorMcpConfig {
+  server: { name: string; version: string; instructions?: string }
+  transport?: { port?: number; host?: string }
+  /** Postgres connection string. */
+  connectionString: string
+  /** Embedding config (OpenAI-compatible, e.g. a LiteLLM gateway). */
+  embedding: OpenAICompatibleEmbeddingConfig
+  collections: PgvectorMcpCollection[]
+}
+
+export interface PgvectorMcpHandle {
+  readonly port: number
+  listen(): Promise<void>
+  close(): Promise<void>
+}
+
+const DEFAULT_PORT = 3041
+const DEFAULT_HOST = '0.0.0.0'
+
+const buildSchema = (c: PgvectorMcpCollection, dimensions: number): PgvectorCollectionSchema => {
+  const embeddingField = c.embeddingField ?? 'embedding'
+  const fields: PgFieldSchema[] = [
+    { name: embeddingField, type: 'vector', dimensions },
+    ...Object.entries(c.filterColumns ?? {}).map(([name, type]) => ({ name, type }))
+  ]
+  return {
+    name: c.name,
+    idField: c.idField ?? 'id',
+    embeddingField,
+    embedFrom: [],
+    fields,
+    hnsw: { distance: c.distance ?? 'cosine' }
+  }
+}
+
+const text = (value: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] })
+
+function registerTools(server: McpServer, adapter: PgvectorAdapter, collections: PgvectorMcpCollection[]): void {
+  const names = collections.map(c => c.name)
+  const nameList = names.join(', ')
+
+  server.registerTool(
+    'search_collections',
+    {
+      description:
+        `Semantic vector search over pgvector chunk tables (${nameList}). Embeds the query and orders by vector distance. ` +
+        'Scores are raw pgvector distances (lower = closer); do NOT threshold on them. Filters map to SQL WHERE ' +
+        '(array columns like taxonomy_slugs use overlap). No hybrid/lexical mode, no facets — this is a thin pgvector probe.',
+      inputSchema: {
+        query: z.string().describe('Concept query (will be embedded). Keep it to the concept, no author/meta words.'),
+        collection: z.string().optional().describe(`Single table to search. Defaults to all: ${nameList}`),
+        filters: z
+          .record(z.union([z.string(), z.array(z.string())]))
+          .optional()
+          .describe('SQL filters, e.g. { "taxonomy_slugs": ["bastos"] } (array=overlap) or { "parent_doc_id": "1" }.'),
+        limit: z.number().int().positive().max(100).optional().describe('Max hits (default 10).')
+      }
+    },
+    async input => {
+      const targets = input.collection ? [input.collection] : names
+      const limit = input.limit ?? 10
+      const hits: Array<{ collection: string; id: string; score: number; document: Record<string, unknown> }> = []
+      for (const name of targets) {
+        const results = await adapter.searchByText(name, input.query, { limit, filter: input.filters })
+        for (const r of results) hits.push({ collection: name, id: r.id, score: r.score, document: r.document })
+      }
+      hits.sort((a, b) => a.score - b.score)
+      return text({ hits: hits.slice(0, limit), total: hits.length })
+    }
+  )
+
+  server.registerTool(
+    'get_chunks_by_parent',
+    {
+      description:
+        'Fetch all chunks of a parent document, ordered by chunk_index. Use to read a full doc after search.',
+      inputSchema: {
+        collection: z.string().describe(`Chunk table: ${nameList}`),
+        parent_doc_id: z.string().describe('Parent document id')
+      }
+    },
+    async input => {
+      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(input.collection, {
+        parent_doc_id: input.parent_doc_id
+      })
+      rows.sort((a, b) => Number(a.chunk_index ?? 0) - Number(b.chunk_index ?? 0))
+      return text({ chunks: rows, total: rows.length })
+    }
+  )
+
+  server.registerTool(
+    'get_chunks_by_ids',
+    {
+      description:
+        'Fetch specific chunks by their ids. Use to read full content of chunks found via search_collections.',
+      inputSchema: {
+        collection: z.string().describe(`Chunk table: ${nameList}`),
+        ids: z.array(z.string()).min(1).describe('Chunk ids to fetch')
+      }
+    },
+    async input => {
+      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(input.collection, { id: input.ids })
+      return text({ chunks: rows, total: rows.length })
+    }
+  )
+}
+
+export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpHandle {
+  const adapter = createPgvectorAdapter({
+    connectionString: config.connectionString,
+    embedding: config.embedding
+  })
+  // Register metadata (no DDL) so filters + vectorSearch resolve correctly.
+  for (const c of config.collections) {
+    adapter.registerCollection(buildSchema(c, config.embedding.dimensions))
+  }
+
+  const sessions = new Map<string, StreamableHTTPServerTransport>()
+  const port = config.transport?.port ?? DEFAULT_PORT
+  const host = config.transport?.host ?? DEFAULT_HOST
+
+  async function createSession(): Promise<StreamableHTTPServerTransport> {
+    const server = new McpServer(
+      { name: config.server.name, version: config.server.version },
+      { instructions: config.server.instructions }
+    )
+    registerTools(server, adapter, config.collections)
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: id => sessions.set(id, transport),
+      onsessionclosed: id => sessions.delete(id)
+    })
+    await server.connect(transport)
+    return transport
+  }
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`)
+    if (url.pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ status: 'ok' }))
+      return
+    }
+    if (url.pathname !== '/mcp') {
+      res.writeHead(404)
+      res.end('Not Found')
+      return
+    }
+
+    const sessionId = req.headers['mcp-session-id'] as string | undefined
+    if (sessionId) {
+      const transport = sessions.get(sessionId)
+      if (!transport) {
+        res
+          .writeHead(404)
+          .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }))
+        return
+      }
+      await transport.handleRequest(req, res)
+      return
+    }
+    const transport = await createSession()
+    await transport.handleRequest(req, res)
+  }
+
+  let httpServer: HttpServer | null = null
+  let resolvedPort = port
+
+  return {
+    get port() {
+      return resolvedPort
+    },
+    async listen() {
+      if (httpServer) return
+      const server = createServer((req, res) => {
+        handleRequest(req, res).catch(err => {
+          console.error('[mcp-pgvector] Unhandled request error:', err)
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'Internal error' }, id: null }))
+          }
+        })
+      })
+      httpServer = server
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(port, host, () => {
+          const addr = server.address()
+          if (addr && typeof addr === 'object') resolvedPort = addr.port
+          server.removeListener('error', reject)
+          resolve()
+        })
+      })
+    },
+    async close() {
+      const server = httpServer
+      if (!server) return
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()))
+      })
+      httpServer = null
+      sessions.clear()
+    }
+  }
+}

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -41,6 +41,8 @@ export interface PgvectorMcpConfig {
   transport?: { port?: number; host?: string }
   /** Postgres connection string. */
   connectionString: string
+  /** Required dedicated Postgres schema the tables live in (e.g. `pgvector`). Must match how they were indexed. */
+  schema: string
   /** Embedding config (OpenAI-compatible, e.g. a LiteLLM gateway). */
   embedding: OpenAICompatibleEmbeddingConfig
   collections: PgvectorMcpCollection[]
@@ -146,6 +148,7 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
 export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpHandle {
   const adapter = createPgvectorAdapter({
     connectionString: config.connectionString,
+    schema: config.schema,
     embedding: config.embedding
   })
   // Register metadata (no DDL) so filters + vectorSearch resolve correctly.

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -110,6 +110,9 @@ function denied(): boolean {
 function registerTools(server: McpServer, adapter: PgvectorAdapter, collections: PgvectorMcpCollection[]): void {
   const names = collections.map(c => c.name)
   const nameList = names.join(', ')
+  // Allowlist: a client may only name a configured collection. Without this the
+  // SQL ident guard alone would let any table in the pgvector schema be queried.
+  const known = new Set(names)
 
   server.registerTool(
     'search_collections',
@@ -130,6 +133,9 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
     },
     async input => {
       if (denied()) return text({ hits: [], total: 0 })
+      if (input.collection && !known.has(input.collection)) {
+        return text({ error: `Unknown collection: ${input.collection}. Known: ${nameList}`, hits: [], total: 0 })
+      }
       const targets = input.collection ? [input.collection] : names
       const limit = input.limit ?? 10
       // Scope wins over client-supplied taxonomy_slugs — cannot be widened.
@@ -156,12 +162,19 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
     },
     async input => {
       if (denied()) return text({ chunks: [], total: 0 })
+      if (!known.has(input.collection)) {
+        return text({ error: `Unknown collection: ${input.collection}. Known: ${nameList}`, chunks: [], total: 0 })
+      }
+      // Order by chunk_index in SQL + a high explicit cap, so a large document
+      // returns its chunks in order and we can flag truncation instead of silently
+      // dropping the middle (the default 250 with no ORDER BY did exactly that).
+      const CAP = 5000
       const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
         input.collection,
-        applyScope({ parent_doc_id: input.parent_doc_id })
+        applyScope({ parent_doc_id: input.parent_doc_id }),
+        { orderBy: 'chunk_index', limit: CAP }
       )
-      rows.sort((a, b) => Number(a.chunk_index ?? 0) - Number(b.chunk_index ?? 0))
-      return text({ chunks: rows, total: rows.length })
+      return text({ chunks: rows, total: rows.length, truncated: rows.length >= CAP })
     }
   )
 
@@ -177,9 +190,14 @@ function registerTools(server: McpServer, adapter: PgvectorAdapter, collections:
     },
     async input => {
       if (denied()) return text({ chunks: [], total: 0 })
+      if (!known.has(input.collection)) {
+        return text({ error: `Unknown collection: ${input.collection}. Known: ${nameList}`, chunks: [], total: 0 })
+      }
+      // Cap at the number of ids requested so we never silently drop any.
       const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
         input.collection,
-        applyScope({ id: input.ids })
+        applyScope({ id: input.ids }),
+        { limit: input.ids.length }
       )
       return text({ chunks: rows, total: rows.length })
     }

--- a/packages/mcp-pgvector/src/standalone.ts
+++ b/packages/mcp-pgvector/src/standalone.ts
@@ -1,0 +1,43 @@
+/**
+ * Standalone runner — wires createPgvectorMcpServer from env vars so you can run
+ * it directly for A/B comparison:
+ *
+ *   DATABASE_URL=... LITELLM_PROXY_URL=... LITELLM_MASTER_KEY=... \
+ *   node dist/standalone.mjs
+ */
+import { createPgvectorMcpServer } from './server'
+
+const PORT = Number.parseInt(process.env.MCP_PGVECTOR_PORT || '3041', 10)
+
+const mcp = createPgvectorMcpServer({
+  server: {
+    name: 'mcp-pgvector',
+    version: '0.0.0',
+    instructions:
+      'Thin pgvector search probe. Query by concept (no author/meta words). Scores are raw vector distances ' +
+      '(lower = closer) — do not threshold. Filters map to SQL WHERE; array columns (taxonomy_slugs) use overlap.'
+  },
+  transport: { port: PORT },
+  connectionString: process.env.DATABASE_URL || '',
+  embedding: {
+    baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
+    apiKey: process.env.LITELLM_MASTER_KEY || '',
+    model: process.env.MCP_PGVECTOR_EMBED_MODEL || 'embeddings-dev',
+    dimensions: Number.parseInt(process.env.MCP_PGVECTOR_EMBED_DIMS || '1536', 10)
+  },
+  collections: [
+    {
+      name: 'posts_pgvector_chunk',
+      displayName: 'Posts (pgvector)',
+      distance: 'cosine',
+      filterColumns: {
+        parent_doc_id: 'text',
+        slug: 'text',
+        taxonomy_slugs: 'text[]'
+      }
+    }
+  ]
+})
+
+await mcp.listen()
+console.error(`[mcp-pgvector] running on http://0.0.0.0:${mcp.port}/mcp`)

--- a/packages/mcp-pgvector/src/standalone.ts
+++ b/packages/mcp-pgvector/src/standalone.ts
@@ -25,8 +25,11 @@ const mcp = createPgvectorMcpServer({
     apiKey: process.env.LITELLM_MASTER_KEY || '',
     model: process.env.MCP_PGVECTOR_EMBED_MODEL || 'embeddings-dev',
     dimensions: Number.parseInt(process.env.MCP_PGVECTOR_EMBED_DIMS || '1536', 10),
-    // text-embedding-3-* honour dimensionality reduction; must match index-time.
-    sendDimensions: process.env.MCP_PGVECTOR_SEND_DIMS === 'true'
+    // MUST match index-time: query and index embeddings have to use the same
+    // model + dimensions or similarity is garbage. Defaults ON to match the
+    // app-side indexer default (text-embedding-3-*); set MCP_PGVECTOR_SEND_DIMS=false
+    // for models that reject the param (e.g. BGE-M3) — and keep the indexer in sync.
+    sendDimensions: process.env.MCP_PGVECTOR_SEND_DIMS !== 'false'
   },
   // Off by default: unscoped requests are allowed (a token without taxonomies is
   // a deliberately broad reader). Set MCP_PGVECTOR_REQUIRE_SCOPE=true to deny

--- a/packages/mcp-pgvector/src/standalone.ts
+++ b/packages/mcp-pgvector/src/standalone.ts
@@ -19,6 +19,7 @@ const mcp = createPgvectorMcpServer({
   },
   transport: { port: PORT },
   connectionString: process.env.DATABASE_URL || '',
+  schema: process.env.MCP_PGVECTOR_SCHEMA || 'pgvector',
   embedding: {
     baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
     apiKey: process.env.LITELLM_MASTER_KEY || '',

--- a/packages/mcp-pgvector/src/standalone.ts
+++ b/packages/mcp-pgvector/src/standalone.ts
@@ -28,11 +28,10 @@ const mcp = createPgvectorMcpServer({
     // text-embedding-3-* honour dimensionality reduction; must match index-time.
     sendDimensions: process.env.MCP_PGVECTOR_SEND_DIMS === 'true'
   },
-  // Secure by default at the deployment boundary: a request reaching the MCP
-  // without a taxonomy scope reads nothing (the constructor defaults this OFF to
-  // keep the package generic; the runner is deployment-facing, so it opts IN).
-  // Set MCP_PGVECTOR_REQUIRE_SCOPE=false to allow deliberately unscoped callers.
-  requireScope: process.env.MCP_PGVECTOR_REQUIRE_SCOPE !== 'false',
+  // Off by default: unscoped requests are allowed (a token without taxonomies is
+  // a deliberately broad reader). Set MCP_PGVECTOR_REQUIRE_SCOPE=true to deny
+  // unscoped requests where every caller is expected to be tenant-scoped.
+  requireScope: process.env.MCP_PGVECTOR_REQUIRE_SCOPE === 'true',
   collections: [
     {
       name: 'posts_pgvector_chunk',

--- a/packages/mcp-pgvector/src/standalone.ts
+++ b/packages/mcp-pgvector/src/standalone.ts
@@ -24,8 +24,15 @@ const mcp = createPgvectorMcpServer({
     baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
     apiKey: process.env.LITELLM_MASTER_KEY || '',
     model: process.env.MCP_PGVECTOR_EMBED_MODEL || 'embeddings-dev',
-    dimensions: Number.parseInt(process.env.MCP_PGVECTOR_EMBED_DIMS || '1536', 10)
+    dimensions: Number.parseInt(process.env.MCP_PGVECTOR_EMBED_DIMS || '1536', 10),
+    // text-embedding-3-* honour dimensionality reduction; must match index-time.
+    sendDimensions: process.env.MCP_PGVECTOR_SEND_DIMS === 'true'
   },
+  // Secure by default at the deployment boundary: a request reaching the MCP
+  // without a taxonomy scope reads nothing (the constructor defaults this OFF to
+  // keep the package generic; the runner is deployment-facing, so it opts IN).
+  // Set MCP_PGVECTOR_REQUIRE_SCOPE=false to allow deliberately unscoped callers.
+  requireScope: process.env.MCP_PGVECTOR_REQUIRE_SCOPE !== 'false',
   collections: [
     {
       name: 'posts_pgvector_chunk',

--- a/packages/mcp-pgvector/tsconfig.json
+++ b/packages/mcp-pgvector/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "./src" },
+  "references": [{ "path": "../payload-pgvector" }],
+  "include": ["src/**/*"]
+}

--- a/packages/mcp-pgvector/tsdown.config.ts
+++ b/packages/mcp-pgvector/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/standalone.ts'],
+  format: ['esm'],
+  dts: { resolve: true },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  outDir: 'dist',
+  tsconfig: './tsconfig.json',
+  external: ['@zetesis/payload-pgvector', '@modelcontextprotocol/sdk', 'pg']
+})

--- a/packages/mcp-pgvector/tsdown.config.ts
+++ b/packages/mcp-pgvector/tsdown.config.ts
@@ -9,5 +9,9 @@ export default defineConfig({
   treeshake: true,
   outDir: 'dist',
   tsconfig: './tsconfig.json',
-  external: ['@zetesis/payload-pgvector', '@modelcontextprotocol/sdk', 'pg']
+  // Bundle the workspace @zetesis/* deps (their dev exports point at TS source,
+  // which Node can't load) so the compiled artifact actually runs. Keep real npm
+  // deps external — Node resolves them from node_modules at runtime.
+  noExternal: [/^@zetesis\//],
+  external: ['@modelcontextprotocol/sdk', 'pg', 'zod', 'payload']
 })

--- a/packages/payload-agents-core/src/client.ts
+++ b/packages/payload-agents-core/src/client.ts
@@ -4,4 +4,5 @@
  * Client entry point — admin UI components.
  */
 
+export { McpServerSelectField } from './components/mcp-server-select-field'
 export { ModelSelectField } from './components/model-select-field'

--- a/packages/payload-agents-core/src/collections/agents.ts
+++ b/packages/payload-agents-core/src/collections/agents.ts
@@ -18,6 +18,13 @@ import {
 import { createModelCatalogValidateHook } from './hooks/validate-model'
 
 export function createAgentsCollection(config: ResolvedPluginConfig): CollectionConfig {
+  // Options for the agent's MCP-server multi-select, derived from the MCP
+  // servers registered in the gateway (so the picker lists exactly what exists).
+  const mcpServerOptions = config.mcpServers.map(server => ({
+    label: server.description ?? server.alias,
+    value: server.alias
+  }))
+
   const base: CollectionConfig = {
     slug: config.collectionSlug,
     access: {
@@ -122,6 +129,16 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
                 name: 'toolCallLimit',
                 type: 'number',
                 admin: { description: 'Max tool calls per turn. Leave empty for no limit.' }
+              },
+              {
+                name: 'mcpServers',
+                type: 'select',
+                hasMany: true,
+                options: mcpServerOptions,
+                admin: {
+                  description:
+                    'Search backends (MCP servers) this agent can use, routed through the LiteLLM gateway. Empty = none.'
+                }
               },
               {
                 type: 'row',

--- a/packages/payload-agents-core/src/collections/agents.ts
+++ b/packages/payload-agents-core/src/collections/agents.ts
@@ -18,13 +18,6 @@ import {
 import { createModelCatalogValidateHook } from './hooks/validate-model'
 
 export function createAgentsCollection(config: ResolvedPluginConfig): CollectionConfig {
-  // Options for the agent's MCP-server multi-select, derived from the MCP
-  // servers registered in the gateway (so the picker lists exactly what exists).
-  const mcpServerOptions = config.mcpServers.map(server => ({
-    label: server.description ?? server.alias,
-    value: server.alias
-  }))
-
   const base: CollectionConfig = {
     slug: config.collectionSlug,
     access: {
@@ -132,12 +125,15 @@ export function createAgentsCollection(config: ResolvedPluginConfig): Collection
               },
               {
                 name: 'mcpServers',
-                type: 'select',
+                type: 'text',
                 hasMany: true,
-                options: mcpServerOptions,
                 admin: {
-                  description:
-                    'Search backends (MCP servers) this agent can use, routed through the LiteLLM gateway. Empty = none.'
+                  components: {
+                    Field: {
+                      path: '@zetesis/payload-agents-core/client#McpServerSelectField',
+                      clientProps: { listPath: `/api${config.basePath}/mcp-servers` }
+                    }
+                  }
                 }
               },
               {

--- a/packages/payload-agents-core/src/components/mcp-server-select-field.tsx
+++ b/packages/payload-agents-core/src/components/mcp-server-select-field.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+/**
+ * Admin field component for `mcpServers`.
+ *
+ * Loads every MCP server registered in the LiteLLM gateway from the plugin's
+ * {basePath}/mcp-servers endpoint and renders them as a multi-select — so the
+ * agent can pick from the Payload-managed backends AND any MCP an admin added
+ * directly in LiteLLM. Selected values that are no longer registered stay
+ * selectable so opening an agent never drops its config.
+ */
+
+import { FieldLabel, SelectInput, useField } from '@payloadcms/ui'
+import { useEffect, useMemo, useState } from 'react'
+
+interface McpServerOption {
+  alias: string
+  label?: string
+  source?: string
+}
+
+interface SelectedOption {
+  value?: string | number
+}
+
+export function McpServerSelectField(props: { path: string; listPath?: string; readOnly?: boolean }) {
+  const { path, listPath = '/api/agents/mcp-servers', readOnly } = props
+  const { value, setValue } = useField<string[]>({ path })
+  const [servers, setServers] = useState<McpServerOption[] | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(listPath, { credentials: 'include' })
+      .then(res => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+      .then((body: { servers?: McpServerOption[] }) => {
+        if (!cancelled) setServers(body.servers ?? [])
+      })
+      .catch(err => {
+        if (!cancelled) setError(err instanceof Error ? err.message : 'fetch failed')
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [listPath])
+
+  const current = useMemo(() => (Array.isArray(value) ? value : []), [value])
+
+  const options = useMemo(() => {
+    const opts = (servers ?? []).map(s => ({
+      label: s.source === 'admin' ? `${s.label ?? s.alias} (custom)` : (s.label ?? s.alias),
+      value: s.alias
+    }))
+    for (const v of current) {
+      if (!opts.some(o => o.value === v)) opts.push({ label: `${v} (unavailable)`, value: v })
+    }
+    return opts
+  }, [servers, current])
+
+  return (
+    <div className="field-type">
+      <FieldLabel label="MCP Servers" path={path} />
+      <SelectInput
+        path={path}
+        name={path}
+        hasMany
+        options={options}
+        value={current}
+        readOnly={readOnly}
+        onChange={option => {
+          const arr = (Array.isArray(option) ? option : option ? [option] : []) as SelectedOption[]
+          setValue(arr.map(o => o.value).filter((v): v is string => typeof v === 'string'))
+        }}
+      />
+      <div style={{ fontSize: '0.75rem', marginTop: '4px', opacity: 0.8 }}>
+        Search backends (MCP servers) this agent can use, routed through LiteLLM.
+      </div>
+      {error ? (
+        <div style={{ fontSize: '0.75rem', marginTop: '4px', color: 'var(--theme-error-500)' }}>
+          MCP servers unavailable: {error}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/payload-agents-core/src/endpoints/mcp-servers.ts
+++ b/packages/payload-agents-core/src/endpoints/mcp-servers.ts
@@ -1,0 +1,37 @@
+/**
+ * GET {basePath}/mcp-servers — MCP servers registered in the LiteLLM gateway.
+ *
+ * Proxies the gateway's /v1/mcp/server (server-side, master key) so the agent
+ * admin can pick from EVERY exposed MCP — both the Payload-managed backends and
+ * any MCP an admin added directly in LiteLLM. Requires an authenticated user.
+ */
+
+import type { PayloadHandler } from 'payload'
+import { LiteLlmAdminClient, type LiteLlmMcpServer } from '../lib/litellm-admin'
+import type { ResolvedPluginConfig } from '../types'
+
+type McpServerRow = LiteLlmMcpServer & { server_name?: string; description?: string }
+
+export function createMcpServersListHandler(config: ResolvedPluginConfig): PayloadHandler {
+  return async req => {
+    if (!req.user) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const { gatewayUrl, masterKey } = config.modelCatalog
+    const client = new LiteLlmAdminClient({ gatewayUrl, masterKey })
+    try {
+      const servers = (await client.listMcpServers()) as McpServerRow[]
+      const list = servers
+        .filter(s => typeof s.alias === 'string' && s.alias)
+        .map(s => ({
+          alias: s.alias as string,
+          label: s.description || s.server_name || (s.alias as string),
+          source: s.mcp_info?.source === 'payload' ? 'payload' : 'admin'
+        }))
+      return Response.json({ servers: list })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'mcp servers unavailable'
+      return Response.json({ error: message }, { status: 503 })
+    }
+  }
+}

--- a/packages/payload-agents-core/src/index.ts
+++ b/packages/payload-agents-core/src/index.ts
@@ -26,6 +26,8 @@ export type { RunMetrics } from './lib/cost-calculator'
 // Utilities (for advanced consumers)
 export { costBreakdown, effectiveTokens, estimateRunCost } from './lib/cost-calculator'
 export { decrypt, encrypt, isEncrypted } from './lib/encryption'
+export type { LiteLlmMcpServerPayload, LiteLlmVirtualKeyPayload } from './lib/litellm-admin'
+export { LiteLlmAdminClient, LiteLlmRequestError } from './lib/litellm-admin'
 export type { MultiTenantSessionStrategy, MultiTenantSessionStrategyOptions } from './lib/multi-tenant'
 export { multiTenantSessionStrategy } from './lib/multi-tenant'
 export { runtimeFetch } from './lib/runtime-client'

--- a/packages/payload-agents-core/src/lib/litellm-admin.spec.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.spec.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { LiteLlmAdminClient, type LiteLlmVirtualKeyPayload } from './litellm-admin'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { LiteLlmAdminClient, type LiteLlmMcpServer, type LiteLlmVirtualKeyPayload } from './litellm-admin'
 
 const PAYLOAD: LiteLlmVirtualKeyPayload = {
   keyAlias: 'agent/bastos',
@@ -227,5 +227,92 @@ describe('LiteLlmAdminClient', () => {
     expect(JSON.parse(fetchMock.mock.calls[1]?.[1]?.body as string)).toMatchObject({
       model_name: 'economico'
     })
+  })
+})
+
+describe('LiteLlmAdminClient.syncMcpServers', () => {
+  let calls: { method: string; url: string; body?: Record<string, unknown> }[]
+  let existing: LiteLlmMcpServer[]
+
+  beforeEach(() => {
+    calls = []
+    existing = [
+      { server_id: 's1', alias: 'typesense_search', mcp_info: { source: 'payload' } },
+      { server_id: 's3', alias: 'old_payload', mcp_info: { source: 'payload' } },
+      { server_id: 's9', alias: 'context7', mcp_info: { source: 'admin' } }
+    ]
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string, init?: { method?: string; body?: string }) => {
+        const method = init?.method ?? 'GET'
+        calls.push({ method, url, body: init?.body ? JSON.parse(init.body) : undefined })
+        const json = method === 'GET' && url.endsWith('/v1/mcp/server') ? existing : {}
+        return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(json) } as unknown as Response)
+      })
+    )
+  })
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('creates missing, updates by alias, prunes payload orphans, leaves admin servers untouched', async () => {
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://gw', masterKey: 'k' })
+
+    const result = await client.syncMcpServers(
+      [
+        { alias: 'typesense_search', serverName: 'typesense_search', transport: 'http', url: 'u1' },
+        { alias: 'pgvector_search', serverName: 'pgvector_search', transport: 'http', url: 'u2' }
+      ],
+      { prune: true }
+    )
+
+    expect(result).toEqual({ created: 1, updated: 1, deleted: 1 })
+
+    // existing payload server updated in place by its server_id
+    const put = calls.find(c => c.method === 'PUT')
+    expect(put?.body).toMatchObject({ server_id: 's1', alias: 'typesense_search' })
+
+    // new server created, tagged source=payload so future syncs recognise it
+    const post = calls.find(c => c.method === 'POST')
+    expect(post?.body).toMatchObject({ alias: 'pgvector_search', mcp_info: { source: 'payload' } })
+
+    // the payload-managed orphan (not in the desired set) is pruned
+    expect(calls.some(c => c.method === 'DELETE' && c.url.endsWith('/v1/mcp/server/s3'))).toBe(true)
+
+    // the admin-added server is never touched
+    expect(calls.some(c => c.url.includes('s9'))).toBe(false)
+  })
+
+  it('never prunes when prune is not requested', async () => {
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://gw', masterKey: 'k' })
+
+    const result = await client.syncMcpServers(
+      [{ alias: 'typesense_search', serverName: 'x', transport: 'http', url: 'u' }],
+      {}
+    )
+
+    expect(result.deleted).toBe(0)
+    expect(calls.some(c => c.method === 'DELETE')).toBe(false)
+  })
+
+  it('scopes prune to its environment and leaves other environments alone', async () => {
+    existing = [
+      { server_id: 's1', alias: 'typesense_search', mcp_info: { source: 'payload', env: 'prod' } },
+      { server_id: 's2', alias: 'staging_only', mcp_info: { source: 'payload', env: 'staging' } },
+      { server_id: 's3', alias: 'legacy_untagged', mcp_info: { source: 'payload' } }
+    ]
+    const client = new LiteLlmAdminClient({ gatewayUrl: 'http://gw', masterKey: 'k' })
+
+    const result = await client.syncMcpServers(
+      [{ alias: 'typesense_search', serverName: 'typesense_search', transport: 'http', url: 'u1' }],
+      { prune: true, environment: 'prod' }
+    )
+
+    // typesense_search (prod) updated and re-tagged with env; legacy_untagged adopted+pruned;
+    // staging_only (other env) is neither updated nor deleted.
+    expect(result).toEqual({ created: 0, updated: 1, deleted: 1 })
+    const put = calls.find(c => c.method === 'PUT')
+    expect(put?.body).toMatchObject({ server_id: 's1', mcp_info: { source: 'payload', env: 'prod' } })
+    expect(calls.some(c => c.method === 'DELETE' && c.url.endsWith('/v1/mcp/server/s3'))).toBe(true)
+    expect(calls.some(c => c.url.includes('s2'))).toBe(false)
   })
 })

--- a/packages/payload-agents-core/src/lib/litellm-admin.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.ts
@@ -23,6 +23,27 @@ export interface LiteLlmModelPayload {
   modelInfo?: Record<string, unknown>
 }
 
+export interface LiteLlmMcpServerPayload {
+  /** Stable id; also the `/{alias}/mcp` gateway path segment. */
+  alias: string
+  serverName: string
+  description?: string
+  transport: string
+  url: string
+  /** Client headers LiteLLM forwards to the MCP (`extra_headers`). */
+  extraHeaders?: string[]
+  /** When true, any virtual key can use this server (no per-key grant needed). */
+  allowAllKeys?: boolean
+  mcpInfo?: Record<string, unknown>
+}
+
+/** Shape of an MCP server as returned by GET /v1/mcp/server (loosely typed). */
+export interface LiteLlmMcpServer {
+  server_id: string
+  alias?: string
+  mcp_info?: { source?: string } | null
+}
+
 /** Error carrying the HTTP status + raw body so callers can react to specific failures. */
 export class LiteLlmRequestError extends Error {
   constructor(
@@ -76,6 +97,21 @@ function toModelApiPayload(payload: LiteLlmModelPayload): Record<string, unknown
     model_name: payload.modelName,
     litellm_params: { model: payload.model },
     ...(payload.modelInfo ? { model_info: payload.modelInfo } : {})
+  }
+}
+
+function toMcpApiPayload(payload: LiteLlmMcpServerPayload): Record<string, unknown> {
+  return {
+    alias: payload.alias,
+    server_name: payload.serverName,
+    ...(payload.description ? { description: payload.description } : {}),
+    transport: payload.transport,
+    url: payload.url,
+    extra_headers: payload.extraHeaders ?? [],
+    allow_all_keys: payload.allowAllKeys ?? false,
+    // Marks this server as Payload-managed so reconciliation never touches
+    // servers an admin added directly in LiteLLM.
+    mcp_info: { source: 'payload', ...(payload.mcpInfo ?? {}) }
   }
 }
 
@@ -171,5 +207,71 @@ export class LiteLlmAdminClient {
       created += 1
     }
     return { created, existing: existingModels.size - created }
+  }
+
+  // === MCP servers ===
+
+  async listMcpServers(): Promise<LiteLlmMcpServer[]> {
+    const body = await this.request<LiteLlmMcpServer[] | { data?: LiteLlmMcpServer[] }>(
+      '/v1/mcp/server',
+      undefined,
+      'GET'
+    )
+    return Array.isArray(body) ? body : (body.data ?? [])
+  }
+
+  async createMcpServer(payload: LiteLlmMcpServerPayload): Promise<void> {
+    await this.request('/v1/mcp/server', toMcpApiPayload(payload), 'POST')
+  }
+
+  async updateMcpServer(serverId: string, payload: LiteLlmMcpServerPayload): Promise<void> {
+    await this.request('/v1/mcp/server', { server_id: serverId, ...toMcpApiPayload(payload) }, 'PUT')
+  }
+
+  async deleteMcpServer(serverId: string): Promise<void> {
+    await this.request(`/v1/mcp/server/${serverId}`, undefined, 'DELETE')
+  }
+
+  /**
+   * Reconcile the Payload-managed MCP servers in LiteLLM to match `servers`
+   * (matched by alias). Creates missing ones, updates existing ones, and—when
+   * `prune`—removes Payload-managed servers no longer present. Servers an admin
+   * added directly (no `mcp_info.source === 'payload'`) are never touched.
+   */
+  async syncMcpServers(
+    servers: LiteLlmMcpServerPayload[],
+    opts: { prune?: boolean } = {}
+  ): Promise<{ created: number; updated: number; deleted: number }> {
+    const existing = await this.listMcpServers()
+    const managed = new Map<string, LiteLlmMcpServer>()
+    for (const server of existing) {
+      if (server.mcp_info?.source === 'payload' && server.alias) {
+        managed.set(server.alias, server)
+      }
+    }
+
+    let created = 0
+    let updated = 0
+    for (const server of servers) {
+      const found = managed.get(server.alias)
+      if (found) {
+        await this.updateMcpServer(found.server_id, server)
+        updated += 1
+      } else {
+        await this.createMcpServer(server)
+        created += 1
+      }
+      managed.delete(server.alias)
+    }
+
+    let deleted = 0
+    if (opts.prune) {
+      for (const orphan of managed.values()) {
+        await this.deleteMcpServer(orphan.server_id)
+        deleted += 1
+      }
+    }
+
+    return { created, updated, deleted }
   }
 }

--- a/packages/payload-agents-core/src/lib/litellm-admin.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.ts
@@ -11,6 +11,8 @@ export interface LiteLlmVirtualKeyPayload {
   budgetDuration?: string
   rpmLimit?: number
   tpmLimit?: number
+  /** Restricts which MCP servers / access-groups this key may reach (LiteLLM object_permission). */
+  objectPermission?: { mcpServers?: string[]; mcpAccessGroups?: string[] }
 }
 
 export interface LiteLlmGeneratedKey {
@@ -74,6 +76,14 @@ function toApiPayload(payload: LiteLlmVirtualKeyPayload, key?: string): Record<s
     key_alias: payload.keyAlias,
     models: payload.models,
     metadata: payload.metadata
+  }
+  if (payload.objectPermission) {
+    result.object_permission = {
+      ...(payload.objectPermission.mcpServers ? { mcp_servers: payload.objectPermission.mcpServers } : {}),
+      ...(payload.objectPermission.mcpAccessGroups
+        ? { mcp_access_groups: payload.objectPermission.mcpAccessGroups }
+        : {})
+    }
   }
   // On update, an unset limit becomes explicit null so LiteLLM clears a
   // previously-set value — /key/update is a partial PATCH, so an omitted field

--- a/packages/payload-agents-core/src/lib/litellm-admin.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.ts
@@ -11,8 +11,6 @@ export interface LiteLlmVirtualKeyPayload {
   budgetDuration?: string
   rpmLimit?: number
   tpmLimit?: number
-  /** Restricts which MCP servers / access-groups this key may reach (LiteLLM object_permission). */
-  objectPermission?: { mcpServers?: string[]; mcpAccessGroups?: string[] }
 }
 
 export interface LiteLlmGeneratedKey {
@@ -43,7 +41,7 @@ export interface LiteLlmMcpServerPayload {
 export interface LiteLlmMcpServer {
   server_id: string
   alias?: string
-  mcp_info?: { source?: string } | null
+  mcp_info?: { source?: string; env?: string } | null
 }
 
 /** Error carrying the HTTP status + raw body so callers can react to specific failures. */
@@ -76,14 +74,6 @@ function toApiPayload(payload: LiteLlmVirtualKeyPayload, key?: string): Record<s
     key_alias: payload.keyAlias,
     models: payload.models,
     metadata: payload.metadata
-  }
-  if (payload.objectPermission) {
-    result.object_permission = {
-      ...(payload.objectPermission.mcpServers ? { mcp_servers: payload.objectPermission.mcpServers } : {}),
-      ...(payload.objectPermission.mcpAccessGroups
-        ? { mcp_access_groups: payload.objectPermission.mcpAccessGroups }
-        : {})
-    }
   }
   // On update, an unset limit becomes explicit null so LiteLLM clears a
   // previously-set value — /key/update is a partial PATCH, so an omitted field
@@ -144,12 +134,11 @@ export class LiteLlmAdminClient {
       ...(body ? { body: JSON.stringify(body) } : {})
     })
     if (!res.ok) {
-      const message = await res.text().catch(() => '')
-      throw new LiteLlmRequestError(
-        res.status,
-        message,
-        `LiteLLM ${path} failed: HTTP ${res.status}${message ? ` ${message}` : ''}`
-      )
+      // Keep the raw upstream body on `.body` (used for self-heal + server-side
+      // logging) but NOT in the user-facing message — it surfaces to token
+      // owners via the synced error field and the /mcp-servers endpoint.
+      const body = await res.text().catch(() => '')
+      throw new LiteLlmRequestError(res.status, body, `LiteLLM ${path} failed: HTTP ${res.status}`)
     }
     return (await res.json()) as T
   }
@@ -230,6 +219,16 @@ export class LiteLlmAdminClient {
     return Array.isArray(body) ? body : (body.data ?? [])
   }
 
+  /**
+   * Create an MCP server. Unlike `generateKey`, this deliberately does NOT
+   * self-heal an alias conflict: a key alias (`agent/<slug>`) is unambiguously
+   * Payload-owned, but an MCP alias may belong to an admin-added server or to
+   * another environment's managed server — reclaiming it would delete something
+   * we promised not to touch. Known limitation: the alias is the global
+   * `/{alias}/mcp` gateway path, so two deployments sharing one LiteLLM cannot
+   * both register the same alias; that needs per-environment alias prefixing,
+   * not a reclaim. Single-deployment setups never hit this.
+   */
   async createMcpServer(payload: LiteLlmMcpServerPayload): Promise<void> {
     await this.request('/v1/mcp/server', toMcpApiPayload(payload), 'POST')
   }
@@ -247,35 +246,48 @@ export class LiteLlmAdminClient {
    * (matched by alias). Creates missing ones, updates existing ones, and—when
    * `prune`—removes Payload-managed servers no longer present. Servers an admin
    * added directly (no `mcp_info.source === 'payload'`) are never touched.
+   *
+   * `environment` makes prune safe when several deployments share one LiteLLM:
+   * managed servers are tagged with it, and reconciliation only adopts/prunes
+   * servers of THIS environment (untagged legacy servers are adopted on first
+   * sync, so they migrate forward). Without it, all Payload-managed servers are
+   * in scope — fine for a single deployment, unsafe for a shared gateway.
    */
   async syncMcpServers(
     servers: LiteLlmMcpServerPayload[],
-    opts: { prune?: boolean } = {}
+    opts: { prune?: boolean; environment?: string } = {}
   ): Promise<{ created: number; updated: number; deleted: number }> {
+    const { prune = false, environment } = opts
     const existing = await this.listMcpServers()
     const managed = new Map<string, LiteLlmMcpServer>()
     for (const server of existing) {
-      if (server.mcp_info?.source === 'payload' && server.alias) {
-        managed.set(server.alias, server)
-      }
+      if (server.mcp_info?.source !== 'payload' || !server.alias) continue
+      // Scope to this environment: skip servers explicitly tagged for another.
+      // Untagged (env == null) servers are adopted and re-tagged on update.
+      const env = server.mcp_info?.env
+      if (environment != null && env != null && env !== environment) continue
+      managed.set(server.alias, server)
     }
+
+    const tag = (server: LiteLlmMcpServerPayload): LiteLlmMcpServerPayload =>
+      environment ? { ...server, mcpInfo: { ...(server.mcpInfo ?? {}), env: environment } } : server
 
     let created = 0
     let updated = 0
     for (const server of servers) {
       const found = managed.get(server.alias)
       if (found) {
-        await this.updateMcpServer(found.server_id, server)
+        await this.updateMcpServer(found.server_id, tag(server))
         updated += 1
       } else {
-        await this.createMcpServer(server)
+        await this.createMcpServer(tag(server))
         created += 1
       }
       managed.delete(server.alias)
     }
 
     let deleted = 0
-    if (opts.prune) {
+    if (prune) {
       for (const orphan of managed.values()) {
         await this.deleteMcpServer(orphan.server_id)
         deleted += 1

--- a/packages/payload-agents-core/src/lib/litellm-admin.ts
+++ b/packages/payload-agents-core/src/lib/litellm-admin.ts
@@ -131,7 +131,9 @@ export class LiteLlmAdminClient {
         Authorization: `Bearer ${this.masterKey}`,
         'Content-Type': 'application/json'
       },
-      ...(body ? { body: JSON.stringify(body) } : {})
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      // Bound the request: a hung gateway must not block boot or token/key syncs.
+      signal: AbortSignal.timeout(15_000)
     })
     if (!res.ok) {
       // Keep the raw upstream body on `.body` (used for self-heal + server-side

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -93,17 +93,18 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
  */
 async function syncMcpServersOnInit(config: ResolvedPluginConfig): Promise<void> {
   const { environment } = config.mcpServerSync
+  // Nothing to register → do nothing. We NEVER prune to an empty desired set: an
+  // empty list means "not managing MCP servers" (or a misconfig), not "delete
+  // everything", so reconciliation (incl. prune) only runs with ≥1 desired server.
+  if (config.mcpServers.length === 0) return
   // Pruning is destructive and only safe when scoped to an environment, so it
-  // requires BOTH prune:true and a non-empty environment. Without the env we
-  // refuse to delete (a default/empty config must never wipe a shared gateway).
+  // requires BOTH prune:true and a non-empty environment.
   const prune = config.mcpServerSync.prune && Boolean(environment)
   if (config.mcpServerSync.prune && !environment) {
     console.warn(
       '[agent-plugin] MCP prune requested without mcpServerSync.environment — skipping prune; deleting unscoped would be unsafe on a shared gateway.'
     )
   }
-  // Nothing to register and nothing to (safely) prune.
-  if (config.mcpServers.length === 0 && !prune) return
   const client = new LiteLlmAdminClient({
     gatewayUrl: config.modelCatalog.gatewayUrl,
     masterKey: config.modelCatalog.masterKey

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -80,7 +80,7 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
     },
     mcpServers: userConfig.mcpServers ?? [],
     mcpServerSync: {
-      prune: userConfig.mcpServerSync?.prune ?? true,
+      prune: userConfig.mcpServerSync?.prune ?? false,
       environment: userConfig.mcpServerSync?.environment
     }
   }
@@ -92,19 +92,22 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
  * virtual-key sync is the hard path; MCP registration is additive).
  */
 async function syncMcpServersOnInit(config: ResolvedPluginConfig): Promise<void> {
-  const { prune, environment } = config.mcpServerSync
-  // Skip only when there is nothing to register AND nothing to prune. With prune
-  // on, an empty desired list still runs so orphaned managed servers get removed.
+  const { environment } = config.mcpServerSync
+  // Pruning is destructive and only safe when scoped to an environment, so it
+  // requires BOTH prune:true and a non-empty environment. Without the env we
+  // refuse to delete (a default/empty config must never wipe a shared gateway).
+  const prune = config.mcpServerSync.prune && Boolean(environment)
+  if (config.mcpServerSync.prune && !environment) {
+    console.warn(
+      '[agent-plugin] MCP prune requested without mcpServerSync.environment — skipping prune; deleting unscoped would be unsafe on a shared gateway.'
+    )
+  }
+  // Nothing to register and nothing to (safely) prune.
   if (config.mcpServers.length === 0 && !prune) return
   const client = new LiteLlmAdminClient({
     gatewayUrl: config.modelCatalog.gatewayUrl,
     masterKey: config.modelCatalog.masterKey
   })
-  if (prune && !environment) {
-    console.warn(
-      "[agent-plugin] MCP prune is on without mcpServerSync.environment — on a LiteLLM shared across deployments this can delete another deployment's managed servers. Set an environment to scope it."
-    )
-  }
   try {
     const { created, updated, deleted } = await client.syncMcpServers(config.mcpServers, { prune, environment })
     console.info(`[agent-plugin] MCP servers synced to LiteLLM: +${created} ~${updated} -${deleted}`)

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -11,6 +11,7 @@ import { createSyncLiteLlmVirtualKeyTask } from './collections/jobs/sync-litellm
 import { createAgentsInternalListHandler } from './endpoints/agents-internal-list'
 import { createAgentsListHandler } from './endpoints/agents-list'
 import { createChatHandler } from './endpoints/chat'
+import { createMcpServersListHandler } from './endpoints/mcp-servers'
 import { createModelsListHandler } from './endpoints/models'
 import { createSessionDeleteHandler, createSessionGetHandler, createSessionPatchHandler } from './endpoints/session'
 import { createSessionsListHandler } from './endpoints/sessions'
@@ -177,6 +178,12 @@ export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
       path: `${basePath}/models`,
       method: 'get' as const,
       handler: createModelsListHandler(config)
+    })
+
+    endpoints.push({
+      path: `${basePath}/mcp-servers`,
+      method: 'get' as const,
+      handler: createMcpServersListHandler(config)
     })
 
     return {

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -78,7 +78,11 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
       masterKey,
       cacheTtlMs: userConfig.modelCatalog.cacheTtlMs ?? 60_000
     },
-    mcpServers: userConfig.mcpServers ?? []
+    mcpServers: userConfig.mcpServers ?? [],
+    mcpServerSync: {
+      prune: userConfig.mcpServerSync?.prune ?? true,
+      environment: userConfig.mcpServerSync?.environment
+    }
   }
 }
 
@@ -88,13 +92,21 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
  * virtual-key sync is the hard path; MCP registration is additive).
  */
 async function syncMcpServersOnInit(config: ResolvedPluginConfig): Promise<void> {
-  if (config.mcpServers.length === 0) return
+  const { prune, environment } = config.mcpServerSync
+  // Skip only when there is nothing to register AND nothing to prune. With prune
+  // on, an empty desired list still runs so orphaned managed servers get removed.
+  if (config.mcpServers.length === 0 && !prune) return
   const client = new LiteLlmAdminClient({
     gatewayUrl: config.modelCatalog.gatewayUrl,
     masterKey: config.modelCatalog.masterKey
   })
+  if (prune && !environment) {
+    console.warn(
+      "[agent-plugin] MCP prune is on without mcpServerSync.environment — on a LiteLLM shared across deployments this can delete another deployment's managed servers. Set an environment to scope it."
+    )
+  }
   try {
-    const { created, updated, deleted } = await client.syncMcpServers(config.mcpServers, { prune: true })
+    const { created, updated, deleted } = await client.syncMcpServers(config.mcpServers, { prune, environment })
     console.info(`[agent-plugin] MCP servers synced to LiteLLM: +${created} ~${updated} -${deleted}`)
   } catch (error) {
     console.warn('[agent-plugin] MCP server sync failed:', error instanceof Error ? error.message : error)

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -15,6 +15,7 @@ import { createModelsListHandler } from './endpoints/models'
 import { createSessionDeleteHandler, createSessionGetHandler, createSessionPatchHandler } from './endpoints/session'
 import { createSessionsListHandler } from './endpoints/sessions'
 import { createUsageHandler } from './endpoints/usage'
+import { LiteLlmAdminClient } from './lib/litellm-admin'
 import { defaultBuildSessionId, defaultValidateSessionOwnership } from './lib/session-id'
 import type { AgentPluginConfig, ResolvedPluginConfig } from './types'
 
@@ -75,7 +76,27 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
       gatewayUrl,
       masterKey,
       cacheTtlMs: userConfig.modelCatalog.cacheTtlMs ?? 60_000
-    }
+    },
+    mcpServers: userConfig.mcpServers ?? []
+  }
+}
+
+/**
+ * Reconcile the configured MCP servers into the LiteLLM gateway on startup.
+ * Best-effort: a gateway hiccup logs a warning but never blocks boot (the
+ * virtual-key sync is the hard path; MCP registration is additive).
+ */
+async function syncMcpServersOnInit(config: ResolvedPluginConfig): Promise<void> {
+  if (config.mcpServers.length === 0) return
+  const client = new LiteLlmAdminClient({
+    gatewayUrl: config.modelCatalog.gatewayUrl,
+    masterKey: config.modelCatalog.masterKey
+  })
+  try {
+    const { created, updated, deleted } = await client.syncMcpServers(config.mcpServers, { prune: true })
+    console.info(`[agent-plugin] MCP servers synced to LiteLLM: +${created} ~${updated} -${deleted}`)
+  } catch (error) {
+    console.warn('[agent-plugin] MCP server sync failed:', error instanceof Error ? error.message : error)
   }
 }
 
@@ -165,6 +186,7 @@ export function agentPlugin(userConfig: AgentPluginConfig): Plugin {
       jobs: buildLiteLlmJobs(incomingConfig.jobs, config),
       onInit: async payload => {
         await incomingOnInit?.(payload)
+        await syncMcpServersOnInit(config)
         await enqueueExistingLiteLlmVirtualKeySyncs(payload, config)
       }
     }

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -193,9 +193,11 @@ export interface AgentPluginConfig {
 
   /**
    * How `mcpServers` are reconciled into LiteLLM on startup. `environment` tags
-   * the managed servers so several deployments sharing one gateway don't prune
-   * each other's; `prune` (default true) deletes only THIS environment's managed
-   * orphans. Set `prune: false` to never delete. Reconciliation runs every boot.
+   * the managed servers so several deployments sharing one gateway don't touch
+   * each other's. Pruning is DESTRUCTIVE (it deletes Payload-managed servers from
+   * a possibly shared gateway), so it is OFF by default and only ever runs when
+   * `prune: true` AND an `environment` is set — an empty/default config can never
+   * wipe servers on boot. Reconciliation (create/update) runs every boot.
    */
   mcpServerSync?: { prune?: boolean; environment?: string }
 }

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -1,4 +1,5 @@
 import type { CollectionConfig, Payload, PayloadRequest, TypedUser } from 'payload'
+import type { LiteLlmMcpServerPayload } from './lib/litellm-admin'
 
 /**
  * Context passed to `buildSessionId` when a new chat starts.
@@ -181,6 +182,14 @@ export interface AgentPluginConfig {
     /** Catalog cache TTL in ms. Default: 60_000. */
     cacheTtlMs?: number
   }
+
+  /**
+   * MCP servers to register in the LiteLLM gateway on startup. Typically derived
+   * from the configured search backends' MCP descriptors. They're reconciled
+   * (created/updated, and Payload-managed orphans pruned) so agents can be
+   * granted access to them; admin-added servers in LiteLLM are left untouched.
+   */
+  mcpServers?: LiteLlmMcpServerPayload[]
 }
 
 // ── Run completed callback ────────────────────────────────────────────────
@@ -267,4 +276,5 @@ export interface ResolvedPluginConfig {
   collectionOverrides: CollectionOverrides | undefined
   onRunCompleted: OnRunCompleted | undefined
   modelCatalog: { gatewayUrl: string; masterKey: string; cacheTtlMs: number }
+  mcpServers: LiteLlmMcpServerPayload[]
 }

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -190,6 +190,14 @@ export interface AgentPluginConfig {
    * granted access to them; admin-added servers in LiteLLM are left untouched.
    */
   mcpServers?: LiteLlmMcpServerPayload[]
+
+  /**
+   * How `mcpServers` are reconciled into LiteLLM on startup. `environment` tags
+   * the managed servers so several deployments sharing one gateway don't prune
+   * each other's; `prune` (default true) deletes only THIS environment's managed
+   * orphans. Set `prune: false` to never delete. Reconciliation runs every boot.
+   */
+  mcpServerSync?: { prune?: boolean; environment?: string }
 }
 
 // ── Run completed callback ────────────────────────────────────────────────
@@ -277,4 +285,5 @@ export interface ResolvedPluginConfig {
   onRunCompleted: OnRunCompleted | undefined
   modelCatalog: { gatewayUrl: string; masterKey: string; cacheTtlMs: number }
   mcpServers: LiteLlmMcpServerPayload[]
+  mcpServerSync: { prune: boolean; environment: string | undefined }
 }

--- a/packages/payload-indexer/README.md
+++ b/packages/payload-indexer/README.md
@@ -99,11 +99,11 @@ createSummarizeLexicalTransform
 
 When `features.sync.enabled` is `true`, the plugin automatically:
 
-1. **Injects a `_syncStatus` virtual field** into every indexed collection. This field appears in the admin sidebar and list view.
-2. **Registers REST endpoints** for sync status checks:
-   - `GET /api/sync-status/:collection` -- Batch check all documents in a collection (supports `page`, `limit`, `ids`, `where` params)
-   - `GET /api/sync-status/:collection/:id` -- Check a single document
-   - `POST /api/sync-status/:collection/:id/sync` -- Trigger re-indexing of a single document
+1. **Injects a `_syncStatus_<adapter>` virtual field** into every indexed collection (namespaced by `adapter.name`, e.g. `_syncStatus_typesense`, so multiple adapters can index the same collection in parallel). This field appears in the admin sidebar and list view.
+2. **Registers REST endpoints** for sync status checks (also namespaced by adapter, e.g. `/api/sync-status-typesense`):
+   - `GET /api/sync-status-<adapter>/:collection` -- Batch check all documents in a collection (supports `page`, `limit`, `ids`, `where` params)
+   - `GET /api/sync-status-<adapter>/:collection/:id` -- Check a single document
+   - `POST /api/sync-status-<adapter>/:collection/:id/sync` -- Trigger re-indexing of a single document
 
 The sync status is computed by comparing content hashes (SHA-256) between the Payload document and its indexed counterpart. Possible values: `synced`, `outdated`, `not-indexed`, `error`.
 

--- a/packages/payload-indexer/src/adapter/types.ts
+++ b/packages/payload-indexer/src/adapter/types.ts
@@ -131,6 +131,20 @@ export interface IndexerAdapter<TSchema extends BaseCollectionSchema = BaseColle
    */
   deleteDocumentsByFilter(collectionName: string, filter: Record<string, unknown>): Promise<number>
 
+  /**
+   * Atomically replace the documents matching `filter` with `documents`.
+   * Optional: adapters that embed app-side (e.g. pgvector) implement this so a
+   * reindex computes embeddings BEFORE deleting and runs delete+insert in one
+   * transaction — a mid-reindex failure then leaves the old index intact instead
+   * of wiping it. Adapters whose backend auto-embeds (e.g. Typesense) can omit it;
+   * the syncer falls back to delete-then-upsert.
+   */
+  replaceDocumentsByFilter?(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    documents: IndexDocument[]
+  ): Promise<void>
+
   // === Optional: Vector Search ===
 
   /**
@@ -152,7 +166,7 @@ export interface IndexerAdapter<TSchema extends BaseCollectionSchema = BaseColle
   searchDocumentsByFilter?<TDoc = Record<string, unknown>>(
     collectionName: string,
     filter: Record<string, unknown>,
-    options?: { includeFields?: string[]; limit?: number }
+    options?: { includeFields?: string[]; limit?: number; orderBy?: string }
   ): Promise<TDoc[]>
 
   /**

--- a/packages/payload-indexer/src/client/components/SyncStatusField.tsx
+++ b/packages/payload-indexer/src/client/components/SyncStatusField.tsx
@@ -45,7 +45,17 @@ const descStyle: React.CSSProperties = {
   opacity: 0.7
 }
 
-export const SyncStatusField: SelectFieldClientComponent = ({ path }) => {
+/**
+ * Custom client props injected by the plugin, namespaced per adapter
+ * (e.g. basePath `/api/sync-status-pgvector`, instanceLabel `Pgvector Sync`).
+ */
+type SyncStatusFieldProps = Parameters<SelectFieldClientComponent>[0] & {
+  basePath?: string
+  instanceLabel?: string
+}
+
+export const SyncStatusField = (props: SyncStatusFieldProps) => {
+  const { path, basePath, instanceLabel = 'Sync' } = props
   const { value, setValue } = useField<string>({ path })
   const { id, collectionSlug } = useDocumentInfo()
   const [syncing, setSyncing] = useState(false)
@@ -56,7 +66,7 @@ export const SyncStatusField: SelectFieldClientComponent = ({ path }) => {
 
     setSyncing(true)
     try {
-      const res = await fetch(`/api/sync-status/${collectionSlug}/${id}/sync`, { method: 'POST' })
+      const res = await fetch(`${basePath}/${collectionSlug}/${id}/sync`, { method: 'POST' })
       const data = (await res.json()) as { success?: boolean; status?: string; error?: string }
 
       if (data.success) {
@@ -72,12 +82,12 @@ export const SyncStatusField: SelectFieldClientComponent = ({ path }) => {
     } finally {
       setSyncing(false)
     }
-  }, [id, collectionSlug, syncing, setValue])
+  }, [id, collectionSlug, syncing, setValue, basePath])
 
   return (
     <div style={containerStyle}>
       <div style={headerStyle}>
-        <strong>Typesense Sync</strong>
+        <strong>{instanceLabel}</strong>
         <Pill pillStyle={pillStyle[status]} size="small">
           {labels[status]}
         </Pill>

--- a/packages/payload-indexer/src/index.ts
+++ b/packages/payload-indexer/src/index.ts
@@ -39,6 +39,12 @@ export type { ChunkOptions, TextChunk } from './embedding/chunking/types'
 export type { IndexableCollectionConfig } from './plugin/types'
 
 // ============================================================================
+// MCP DESCRIPTOR EXPORTS
+// ============================================================================
+
+export type { McpDescriptor, McpRetrievalOption } from './mcp/descriptor'
+
+// ============================================================================
 // DOCUMENT EXPORTS
 // ============================================================================
 

--- a/packages/payload-indexer/src/mcp/descriptor.ts
+++ b/packages/payload-indexer/src/mcp/descriptor.ts
@@ -1,0 +1,40 @@
+/**
+ * MCP descriptor — the read-side analog of IndexerAdapter.
+ *
+ * It declares how a search backend exposes itself as an MCP server, so the app
+ * can (a) auto-register that MCP in a gateway (e.g. LiteLLM) and (b) render the
+ * backend's tunable retrieval options per agent. Backends (payload-typesense,
+ * payload-pgvector, ...) each export a descriptor; the app supplies the
+ * deployment-specific URL.
+ */
+
+/** A tunable retrieval option: agent-configurable and sent to the MCP as a header. */
+export interface McpRetrievalOption {
+  /** Stable key — also used as the agent-config field name. */
+  key: string
+  /** HTTP header this option is sent as to the MCP (e.g. `x-hybrid-alpha`). */
+  header: string
+  /** Value/UI type. */
+  type: 'text' | 'number' | 'boolean' | 'stringList'
+  label: string
+  description?: string
+  defaultValue?: string | number | boolean | string[]
+}
+
+export interface McpDescriptor {
+  /** Stable id used to register the server in an MCP gateway (e.g. `typesense-search`). */
+  id: string
+  displayName: string
+  /** Reachable MCP endpoint (streamable HTTP), supplied by the app/deployment. */
+  url: string
+  /** Transport the MCP speaks. */
+  transport: 'http' | 'sse'
+  /**
+   * Headers the gateway must forward from the agent request to this MCP
+   * (LiteLLM `extra_headers`). Superset of the option headers plus any context
+   * headers (tenant, retrieval-profile catalog, ...) the MCP consumes.
+   */
+  forwardHeaders: string[]
+  /** Tunable options exposed to agents; each maps to one forwarded header. */
+  retrievalOptions: McpRetrievalOption[]
+}

--- a/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
+++ b/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
@@ -145,7 +145,8 @@ function createSyncStatusAfterRead(adapter: IndexerAdapter, collectionSlug: stri
 }
 
 /**
- * Injects the _syncStatus virtual field into collections that have indexer tables configured
+ * Injects the adapter-namespaced sync-status virtual field (`_syncStatus_<adapter>`)
+ * into collections that have indexer tables configured.
  */
 function injectSyncStatusField(
   payloadCollections: CollectionConfig[],

--- a/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
+++ b/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
@@ -65,6 +65,15 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
   const { adapter, features, collections } = config
   const logger = new Logger({ enabled: true, prefix: '[payload-indexer]' })
 
+  // The sync-status field and endpoints are namespaced by the adapter, so
+  // multiple indexer plugins (Typesense, pgvector, ...) can index the same
+  // collections in parallel without colliding.
+  const namespacing: SyncStatusNamespacing = {
+    fieldName: `_syncStatus_${adapter.name}`,
+    label: `${capitalize(adapter.name)} Sync`,
+    endpointBasePath: `/sync-status-${adapter.name}`
+  }
+
   const plugin = (payloadConfig: Config): Config => {
     if (payloadConfig.collections && features.sync?.enabled) {
       payloadConfig.collections = applySyncHooks(payloadConfig.collections, config, adapter)
@@ -75,7 +84,11 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
     }
 
     if (features.sync?.enabled) {
-      const syncStatusEndpoints = createSyncStatusEndpoints({ adapter, collections })
+      const syncStatusEndpoints = createSyncStatusEndpoints({
+        adapter,
+        collections,
+        basePath: namespacing.endpointBasePath
+      })
       payloadConfig.endpoints = [...(payloadConfig.endpoints || []), ...syncStatusEndpoints]
 
       if (payloadConfig.collections) {
@@ -83,7 +96,8 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
           payloadConfig.collections,
           collections,
           adapter,
-          features.sync
+          features.sync,
+          namespacing
         )
       }
 
@@ -95,6 +109,16 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
 
   return { plugin, adapter }
 }
+
+/** Per-instance naming for the sync-status field and endpoints. */
+interface SyncStatusNamespacing {
+  fieldName: string
+  label: string
+  endpointBasePath: string
+}
+
+const capitalize = (value: string): string =>
+  value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`
 
 /**
  * Creates an afterRead hook that computes sync status by comparing content hashes with the index
@@ -127,7 +151,8 @@ function injectSyncStatusField(
   payloadCollections: CollectionConfig[],
   indexedCollections: Record<string, TableConfig[]>,
   adapter: IndexerAdapter,
-  syncConfig?: SyncFeatureConfig
+  syncConfig: SyncFeatureConfig | undefined,
+  namespacing: SyncStatusNamespacing
 ): CollectionConfig[] {
   return payloadCollections.map(collection => {
     const tableConfigs = indexedCollections[collection.slug]
@@ -148,8 +173,8 @@ function injectSyncStatusField(
       fields: [
         ...(collection.fields || []),
         {
-          name: '_syncStatus',
-          label: 'Typesense Sync',
+          name: namespacing.fieldName,
+          label: namespacing.label,
           type: 'select' as const,
           virtual: true,
           options: [
@@ -164,7 +189,13 @@ function injectSyncStatusField(
           admin: {
             position: 'sidebar',
             components: {
-              Field: '@zetesis/payload-indexer/client#SyncStatusField',
+              Field: {
+                path: '@zetesis/payload-indexer/client#SyncStatusField',
+                clientProps: {
+                  basePath: `/api${namespacing.endpointBasePath}`,
+                  instanceLabel: namespacing.label
+                }
+              },
               Cell: '@zetesis/payload-indexer/client#SyncStatusCell'
             }
           }

--- a/packages/payload-indexer/src/plugin/sync/document-syncer.spec.ts
+++ b/packages/payload-indexer/src/plugin/sync/document-syncer.spec.ts
@@ -144,6 +144,21 @@ describe('DocumentSyncer (autoEmbed-only)', () => {
       expect(adapter.updateDocumentsByFilter).not.toHaveBeenCalled()
     })
 
+    it('uses the adapter atomic replace path on update when implemented', async () => {
+      const replaceDocumentsByFilter = vi.fn().mockResolvedValue(undefined)
+      const atomic = createMockAdapter({ replaceDocumentsByFilter })
+      vi.mocked(
+        atomic.searchDocumentsByFilter as NonNullable<typeof atomic.searchDocumentsByFilter>
+      ).mockResolvedValue([{ content_hash: 'different-hash' }])
+
+      await syncDocumentToIndex(atomic, 'posts', createMockDocument(), 'update', createMockChunkedTableConfig())
+
+      // Atomic path: one replace call, NOT the legacy delete-then-upsert.
+      expect(replaceDocumentsByFilter).toHaveBeenCalledOnce()
+      expect(atomic.deleteDocumentsByFilter).not.toHaveBeenCalled()
+      expect(atomic.upsertDocuments).not.toHaveBeenCalled()
+    })
+
     it('forces full re-sync via forceReindex even when content unchanged', async () => {
       const doc = createMockDocument()
       const config = createMockChunkedTableConfig()

--- a/packages/payload-indexer/src/plugin/sync/document-syncer.ts
+++ b/packages/payload-indexer/src/plugin/sync/document-syncer.ts
@@ -207,11 +207,16 @@ export class DocumentSyncer {
       return
     }
 
-    if (operation === 'update') {
-      await this.adapter.deleteDocumentsByFilter(this.tableName, { parent_doc_id: String(doc.id) })
+    if (operation === 'update' && this.adapter.replaceDocumentsByFilter) {
+      // Atomic path (app-side embedding adapters): embed → tx{delete+insert}, so a
+      // failed reindex never wipes the existing chunks.
+      await this.adapter.replaceDocumentsByFilter(this.tableName, { parent_doc_id: String(doc.id) }, chunkDocs)
+    } else {
+      if (operation === 'update') {
+        await this.adapter.deleteDocumentsByFilter(this.tableName, { parent_doc_id: String(doc.id) })
+      }
+      await this.adapter.upsertDocuments(this.tableName, chunkDocs)
     }
-
-    await this.adapter.upsertDocuments(this.tableName, chunkDocs)
 
     recordSyncSuccess(this.collectionSlug, String(doc.id), chunkDocs.length)
     logger.info(`Synced ${chunkDocs.length} chunks for document ${doc.id} to ${this.tableName}`)

--- a/packages/payload-indexer/src/sync-status/create-sync-status-endpoint.ts
+++ b/packages/payload-indexer/src/sync-status/create-sync-status-endpoint.ts
@@ -12,6 +12,8 @@ import { checkBatchSyncStatus, checkSyncStatus } from './sync-status-service'
 interface SyncStatusEndpointConfig {
   adapter: IndexerAdapter
   collections: Record<string, TableConfig[]>
+  /** Route prefix for the endpoints, namespaced per adapter (e.g. `/sync-status-pgvector`). */
+  basePath: string
 }
 
 /**
@@ -58,12 +60,12 @@ const findDocumentWithAccessCheck = async (
  * - ids (comma-separated doc IDs)
  */
 export const createSyncStatusEndpoints = (config: SyncStatusEndpointConfig): Endpoint[] => {
-  const { adapter, collections } = config
+  const { adapter, collections, basePath } = config
 
   return [
     // Single document sync status
     {
-      path: '/sync-status/:collection/:id',
+      path: `${basePath}/:collection/:id`,
       method: 'get',
       handler: async (req: PayloadRequest) => {
         if (!req.user) {
@@ -100,7 +102,7 @@ export const createSyncStatusEndpoints = (config: SyncStatusEndpointConfig): End
     },
     // Batch sync status for collection
     {
-      path: '/sync-status/:collection',
+      path: `${basePath}/:collection`,
       method: 'get',
       handler: async (req: PayloadRequest) => {
         if (!req.user) {
@@ -172,7 +174,7 @@ export const createSyncStatusEndpoints = (config: SyncStatusEndpointConfig): End
     },
     // Trigger sync for a single document
     {
-      path: '/sync-status/:collection/:id/sync',
+      path: `${basePath}/:collection/:id/sync`,
       method: 'post',
       handler: async (req: PayloadRequest) => {
         if (!req.user) {

--- a/packages/payload-pgvector/package.json
+++ b/packages/payload-pgvector/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@zetesis/payload-pgvector",
+  "version": "0.0.0",
+  "description": "A Payload CMS search adapter backed by Postgres + pgvector. Sibling of @zetesis/payload-typesense: implements the payload-indexer IndexerAdapter contract over pgvector, with app-side embeddings via any OpenAI-compatible endpoint (e.g. a LiteLLM gateway).",
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./dist/index.d.mts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.4",
+    "@types/pg": "^8.11.10",
+    "rimraf": "3.0.2",
+    "tsdown": "^0.16.5",
+    "typescript": "5.7.3"
+  },
+  "peerDependencies": {
+    "payload": "^3.81.0"
+  },
+  "engines": {
+    "pnpm": "^9 || ^10"
+  },
+  "dependencies": {
+    "@zetesis/payload-indexer": "workspace:*",
+    "pg": "^8.13.1",
+    "zod": "^4.1.11"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    },
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
+}

--- a/packages/payload-pgvector/src/adapter/create-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/create-adapter.ts
@@ -1,0 +1,48 @@
+import type { Pool, PoolConfig } from 'pg'
+import pg from 'pg'
+import {
+  type EmbeddingProvider,
+  type OpenAICompatibleEmbeddingConfig,
+  OpenAICompatibleEmbeddingProvider
+} from '../embedding/provider'
+import { PgvectorAdapter } from './pgvector-adapter'
+
+const { Pool: PoolCtor } = pg
+
+export interface CreatePgvectorAdapterOptions {
+  /** Postgres connection. Either a connection string or a node-pg Pool config. */
+  connectionString?: string
+  poolConfig?: PoolConfig
+  /**
+   * Embedding provider, or a shorthand OpenAI-compatible config (e.g. pointing at
+   * a LiteLLM gateway). Optional: omit when documents arrive pre-vectorized.
+   */
+  embeddingProvider?: EmbeddingProvider
+  embedding?: OpenAICompatibleEmbeddingConfig
+}
+
+/**
+ * Build a PgvectorAdapter from a connection string/pool config. Mirrors
+ * createTypesenseAdapter. The returned adapter plugs straight into
+ * createIndexerPlugin from @zetesis/payload-indexer.
+ */
+export const createPgvectorAdapter = (options: CreatePgvectorAdapterOptions): PgvectorAdapter => {
+  if (!options.connectionString && !options.poolConfig) {
+    throw new Error('createPgvectorAdapter requires connectionString or poolConfig')
+  }
+
+  const pool = new PoolCtor(options.poolConfig ?? { connectionString: options.connectionString })
+
+  const embeddingProvider =
+    options.embeddingProvider ??
+    (options.embedding ? new OpenAICompatibleEmbeddingProvider(options.embedding) : undefined)
+
+  return new PgvectorAdapter(pool, { embeddingProvider })
+}
+
+/**
+ * Build a PgvectorAdapter from an existing node-pg Pool. Use when the app already
+ * owns the connection (e.g. sharing Payload's pool).
+ */
+export const createPgvectorAdapterFromPool = (pool: Pool, embeddingProvider?: EmbeddingProvider): PgvectorAdapter =>
+  new PgvectorAdapter(pool, { embeddingProvider })

--- a/packages/payload-pgvector/src/adapter/create-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/create-adapter.ts
@@ -19,6 +19,8 @@ export interface CreatePgvectorAdapterOptions {
    */
   embeddingProvider?: EmbeddingProvider
   embedding?: OpenAICompatibleEmbeddingConfig
+  /** Required dedicated Postgres schema (e.g. `pgvector`). Never `public` — keeps these raw tables out of the ORM-managed schema. */
+  schema: string
 }
 
 /**
@@ -37,12 +39,14 @@ export const createPgvectorAdapter = (options: CreatePgvectorAdapterOptions): Pg
     options.embeddingProvider ??
     (options.embedding ? new OpenAICompatibleEmbeddingProvider(options.embedding) : undefined)
 
-  return new PgvectorAdapter(pool, { embeddingProvider })
+  return new PgvectorAdapter(pool, { embeddingProvider, schema: options.schema })
 }
 
 /**
  * Build a PgvectorAdapter from an existing node-pg Pool. Use when the app already
  * owns the connection (e.g. sharing Payload's pool).
  */
-export const createPgvectorAdapterFromPool = (pool: Pool, embeddingProvider?: EmbeddingProvider): PgvectorAdapter =>
-  new PgvectorAdapter(pool, { embeddingProvider })
+export const createPgvectorAdapterFromPool = (
+  pool: Pool,
+  options: { embeddingProvider?: EmbeddingProvider; schema: string }
+): PgvectorAdapter => new PgvectorAdapter(pool, options)

--- a/packages/payload-pgvector/src/adapter/create-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/create-adapter.ts
@@ -39,7 +39,8 @@ export const createPgvectorAdapter = (options: CreatePgvectorAdapterOptions): Pg
     options.embeddingProvider ??
     (options.embedding ? new OpenAICompatibleEmbeddingProvider(options.embedding) : undefined)
 
-  return new PgvectorAdapter(pool, { embeddingProvider, schema: options.schema })
+  // This adapter created the pool, so it owns it and may end it on close().
+  return new PgvectorAdapter(pool, { embeddingProvider, schema: options.schema, ownsPool: true })
 }
 
 /**

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
@@ -97,15 +97,36 @@ describe('PgvectorAdapter', () => {
       expect(params).toEqual(['[0.1,0.2,0.3]', 'd1', 7])
     })
 
-    it('omits WHERE and keeps vector+limit when no filter', async () => {
+    it('always excludes null embeddings even with no filter', async () => {
       await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { limit: 4 })
-      expect(pool.last().text).not.toContain('WHERE')
+      // Without this, NULL distance → Number(null)=0 would rank unembedded rows first.
+      expect(pool.last().text).toContain('WHERE "embedding" IS NOT NULL')
       expect(pool.last().params).toEqual(['[0.1,0.2,0.3]', 4])
     })
 
     it('uses the cosine operator <=> by default', async () => {
       await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3])
       expect(pool.last().text).toContain('<=>')
+    })
+  })
+
+  describe('replaceDocumentsByFilter (atomic reindex)', () => {
+    it('runs delete + insert in one transaction (BEGIN → DELETE → INSERT → COMMIT)', async () => {
+      await adapter.replaceDocumentsByFilter('chunks', { parent_doc_id: 'd1' }, [
+        // precomputed embedding so no EmbeddingProvider is needed for the test
+        { id: '1', parent_doc_id: 'd1', chunk_text: 'a', embedding: [0.1, 0.2, 0.3] }
+      ])
+      const texts = pool.queries.map(q => q.text)
+      const begin = texts.findIndex(t => t.includes('BEGIN'))
+      const del = texts.findIndex(t => t.startsWith('DELETE'))
+      const ins = texts.findIndex(t => t.includes('INSERT INTO'))
+      const commit = texts.findIndex(t => t.includes('COMMIT'))
+      expect(begin).toBeGreaterThanOrEqual(0)
+      expect(begin).toBeLessThan(del)
+      expect(del).toBeLessThan(ins)
+      expect(ins).toBeLessThan(commit)
+      expect(texts[del]).toContain('DELETE FROM "pgvector"."chunks"')
+      expect(texts[del]).toContain('"parent_doc_id" =')
     })
   })
 

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
@@ -4,6 +4,7 @@ vi.mock('../core/logging/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
 }))
 
+import { logger } from '../core/logging/logger'
 import { PgvectorAdapter } from './pgvector-adapter'
 import type { PgvectorCollectionSchema } from './types'
 
@@ -107,6 +108,24 @@ describe('PgvectorAdapter', () => {
     it('uses the cosine operator <=> by default', async () => {
       await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3])
       expect(pool.last().text).toContain('<=>')
+    })
+  })
+
+  describe('ensureCollection incompatible-schema warnings', () => {
+    it('warns when the existing embedding column dimension differs from config', async () => {
+      vi.mocked(logger.warn).mockClear()
+      pool.rows = [{ dim: 1024 }] // pg_attribute reports the existing column as vector(1024)
+      await adapter.ensureCollection(schema) // schema declares vector(3)
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('vector(1024) but config wants vector(3)')
+      )
+    })
+
+    it('does not warn when the dimension matches (no existing column)', async () => {
+      vi.mocked(logger.warn).mockClear()
+      pool.rows = [] // column doesn't exist yet
+      await adapter.ensureCollection(schema)
+      expect(logger.warn).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
@@ -147,6 +147,27 @@ describe('PgvectorAdapter', () => {
       expect(texts[del]).toContain('DELETE FROM "pgvector"."chunks"')
       expect(texts[del]).toContain('"parent_doc_id" =')
     })
+
+    it('rolls back when an insert fails (old chunks are not lost)', async () => {
+      const failPool = new FakePool()
+      failPool.query = async (text: string, params?: unknown[]) => {
+        failPool.queries.push({ text, params })
+        if (text.includes('INSERT INTO')) throw new Error('insert boom')
+        return { rows: failPool.rows, rowCount: failPool.rows.length }
+      }
+      const a = new PgvectorAdapter(failPool as never, { schema: 'pgvector' })
+      a.registerCollection(schema)
+
+      await expect(
+        a.replaceDocumentsByFilter('chunks', { parent_doc_id: 'd1' }, [
+          { id: '1', parent_doc_id: 'd1', chunk_text: 'a', embedding: [0.1, 0.2, 0.3] }
+        ])
+      ).rejects.toThrow('insert boom')
+
+      const texts = failPool.queries.map(q => q.text)
+      expect(texts.some(t => t.includes('ROLLBACK'))).toBe(true)
+      expect(texts.some(t => t.includes('COMMIT'))).toBe(false)
+    })
   })
 
   describe('upsert', () => {

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../core/logging/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+import { PgvectorAdapter } from './pgvector-adapter'
+import type { PgvectorCollectionSchema } from './types'
+
+/** Fake node-pg Pool/Client that records every query for assertions. */
+class FakePool {
+  queries: { text: string; params?: unknown[] }[] = []
+  rows: Record<string, unknown>[] = []
+
+  async query(text: string, params?: unknown[]) {
+    this.queries.push({ text, params })
+    return { rows: this.rows, rowCount: this.rows.length }
+  }
+
+  async connect() {
+    return { query: (t: string, p?: unknown[]) => this.query(t, p), release: () => {} }
+  }
+
+  find(substr: string) {
+    return this.queries.find(q => q.text.includes(substr))
+  }
+
+  last() {
+    return this.queries[this.queries.length - 1]
+  }
+}
+
+const schema: PgvectorCollectionSchema = {
+  name: 'chunks',
+  idField: 'id',
+  embeddingField: 'embedding',
+  embedFrom: ['chunk_text'],
+  fields: [
+    { name: 'id', type: 'text' },
+    { name: 'parent_doc_id', type: 'text', index: true },
+    { name: 'chunk_text', type: 'text' },
+    { name: 'taxonomy_slugs', type: 'text[]', index: true, optional: true },
+    { name: 'embedding', type: 'vector', dimensions: 3 }
+  ]
+}
+
+describe('PgvectorAdapter', () => {
+  let pool: FakePool
+  let adapter: PgvectorAdapter
+
+  beforeEach(() => {
+    pool = new FakePool()
+    adapter = new PgvectorAdapter(pool as never, { schema: 'pgvector' })
+    adapter.registerCollection(schema)
+  })
+
+  describe('schema isolation', () => {
+    it('requires a dedicated schema and rejects "public"', () => {
+      expect(() => new PgvectorAdapter(pool as never, { schema: 'public' })).toThrow()
+      expect(() => new PgvectorAdapter(pool as never, { schema: '' })).toThrow()
+    })
+
+    it('schema-qualifies every table reference', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3])
+      expect(pool.last().text).toContain('FROM "pgvector"."chunks"')
+    })
+  })
+
+  describe('buildWhere operator matrix (chosen by column type)', () => {
+    it('text[] column + array value → overlap &&', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { taxonomy_slugs: ['bastos', 'mises'] } })
+      expect(pool.last().text).toContain('"taxonomy_slugs" && $2::text[]')
+    })
+
+    it('text[] column + scalar value → membership = ANY(col)', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { taxonomy_slugs: 'bastos' } })
+      expect(pool.last().text).toContain('$2 = ANY("taxonomy_slugs")')
+    })
+
+    it('scalar column + scalar value → equality', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { parent_doc_id: 'd1' } })
+      expect(pool.last().text).toContain('"parent_doc_id" = $2')
+    })
+
+    it('scalar column + array value → IN list', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { parent_doc_id: ['d1', 'd2'] } })
+      expect(pool.last().text).toContain('"parent_doc_id" = ANY($2::text[])')
+    })
+  })
+
+  describe('vectorSearch param threading', () => {
+    it('orders params: $1 vector, then WHERE, then LIMIT', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { parent_doc_id: 'd1' }, limit: 7 })
+      const { text, params } = pool.last()
+      expect(text).toContain('$1::vector')
+      expect(text).toMatch(/LIMIT \$3$/)
+      expect(params).toEqual(['[0.1,0.2,0.3]', 'd1', 7])
+    })
+
+    it('omits WHERE and keeps vector+limit when no filter', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { limit: 4 })
+      expect(pool.last().text).not.toContain('WHERE')
+      expect(pool.last().params).toEqual(['[0.1,0.2,0.3]', 4])
+    })
+
+    it('uses the cosine operator <=> by default', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3])
+      expect(pool.last().text).toContain('<=>')
+    })
+  })
+
+  describe('upsert', () => {
+    it('builds INSERT ... ON CONFLICT DO UPDATE excluding the id column', async () => {
+      await adapter.upsertDocument('chunks', {
+        id: '1',
+        parent_doc_id: 'd1',
+        taxonomy_slugs: ['x'],
+        embedding: [0.1, 0.2, 0.3]
+      })
+      const insert = pool.find('INSERT INTO')
+      expect(insert?.text).toContain('INSERT INTO "pgvector"."chunks"')
+      expect(insert?.text).toContain('ON CONFLICT ("id") DO UPDATE SET')
+      expect(insert?.text).toContain('"parent_doc_id" = EXCLUDED."parent_doc_id"')
+      // the id column must NOT be in the SET list
+      expect(insert?.text).not.toContain('"id" = EXCLUDED."id"')
+      // a precomputed embedding is cast to ::vector
+      expect(insert?.text).toContain('::vector')
+    })
+  })
+
+  describe('SQL-injection guard', () => {
+    it('rejects a malicious table name via the identifier validator', async () => {
+      await expect(adapter.ensureCollection({ ...schema, name: 'x"; DROP TABLE y; --' })).rejects.toThrow(
+        /Invalid SQL identifier/
+      )
+    })
+  })
+})

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
@@ -15,6 +15,12 @@ export interface PgvectorAdapterOptions {
    * unmanaged and DROPs them.
    */
   schema: string
+  /**
+   * Whether this adapter owns the pool and may end it on close(). True when the
+   * adapter created the pool itself; false (default) when an external pool was
+   * passed in (e.g. Payload's), so close() leaves it alone.
+   */
+  ownsPool?: boolean
 }
 
 /** Map our PgFieldType to a concrete SQL column type. */
@@ -77,6 +83,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
   private readonly pool: Pool
   private readonly embeddingProvider?: EmbeddingProvider
   private readonly schema: string
+  private readonly ownsPool: boolean
   /** Per-collection embedding metadata, captured during ensureCollection. */
   private readonly embedInfo = new Map<string, CollectionEmbedInfo>()
 
@@ -87,6 +94,12 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     this.pool = pool
     this.embeddingProvider = options.embeddingProvider
     this.schema = options.schema
+    this.ownsPool = options.ownsPool ?? false
+  }
+
+  /** Release the connection pool when this adapter owns it (no-op for an external pool). */
+  async close(): Promise<void> {
+    if (this.ownsPool) await this.pool.end()
   }
 
   /** Schema-qualified, quoted table reference: `"schema"."table"`. */

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
@@ -244,6 +244,39 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     }
   }
 
+  /**
+   * Atomically replace the rows matching `filter` with `documents`. Embeddings
+   * are resolved FIRST (before any delete), then delete + insert run in a single
+   * transaction. If embedding fails, nothing is deleted; if any insert fails, the
+   * delete rolls back — a reindex can never leave a document with no chunks.
+   */
+  async replaceDocumentsByFilter(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    documents: IndexDocument[]
+  ): Promise<void> {
+    const info = this.embedInfo.get(collectionName)
+    // Embed before touching the table — a gateway failure must not lose the index.
+    const vectors = await this.resolveVectors(documents, info)
+    const { clause, params } = this.buildWhere(filter, info?.columnTypes)
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(`DELETE FROM ${this.relName(collectionName)}${clause}`, params)
+      for (let i = 0; i < documents.length; i++) {
+        await this.insertRow(client, collectionName, documents[i], vectors[i], info)
+      }
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      logger.error(`Failed to replace documents in ${collectionName}`, error)
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
   async deleteDocument(collectionName: string, documentId: string): Promise<void> {
     const idField = this.embedInfo.get(collectionName)?.idField ?? 'id'
     await this.pool.query(`DELETE FROM ${this.relName(collectionName)} WHERE ${ident(idField)} = $1`, [documentId])
@@ -274,22 +307,30 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     params.push(...whereParams)
     params.push(limit)
 
+    // Exclude rows with no embedding: `NULL <=> v` is NULL → Number(null) === 0
+    // would rank an unembedded row as a perfect match. They can't take part in a
+    // vector search anyway.
+    const notNull = `${ident(embeddingField)} IS NOT NULL`
+    const where = clause ? `${clause} AND ${notNull}` : ` WHERE ${notNull}`
+
     const sql =
       `SELECT *, ${ident(embeddingField)} ${op} $1::vector AS _distance ` +
-      `FROM ${this.relName(collectionName)}${clause} ` +
+      `FROM ${this.relName(collectionName)}${where} ` +
       `ORDER BY ${ident(embeddingField)} ${op} $1::vector ` +
       `LIMIT $${params.length}`
 
     const result = await this.pool.query(sql, params)
-    return result.rows.map(row => {
-      const distance = Number(row._distance)
-      const document = this.projectRow(row, embeddingField, includeFields, excludeFields)
-      return {
-        id: String((document as Record<string, unknown>)[info?.idField ?? 'id'] ?? ''),
-        score: distance,
-        document: document as TDoc
-      }
-    })
+    return result.rows
+      .map(row => {
+        const distance = Number(row._distance)
+        const document = this.projectRow(row, embeddingField, includeFields, excludeFields)
+        return {
+          id: String((document as Record<string, unknown>)[info?.idField ?? 'id'] ?? ''),
+          score: distance,
+          document: document as TDoc
+        }
+      })
+      .filter(r => Number.isFinite(r.score))
   }
 
   /**
@@ -314,14 +355,17 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
   async searchDocumentsByFilter<TDoc = Record<string, unknown>>(
     collectionName: string,
     filter: Record<string, unknown>,
-    options?: { includeFields?: string[]; limit?: number }
+    options?: { includeFields?: string[]; limit?: number; orderBy?: string }
   ): Promise<TDoc[]> {
     const info = this.embedInfo.get(collectionName)
     const embeddingField = info?.embeddingField ?? 'embedding'
     const { clause, params } = this.buildWhere(filter, info?.columnTypes)
+    // Deterministic order when requested — without it Postgres returns an
+    // arbitrary subset under LIMIT, silently dropping rows for large documents.
+    const orderClause = options?.orderBy ? ` ORDER BY ${ident(options.orderBy)}` : ''
     const limit = options?.limit ?? 250
     params.push(limit)
-    const sql = `SELECT * FROM ${this.relName(collectionName)}${clause} LIMIT $${params.length}`
+    const sql = `SELECT * FROM ${this.relName(collectionName)}${clause}${orderClause} LIMIT $${params.length}`
     const result = await this.pool.query(sql, params)
     return result.rows.map(row => this.projectRow(row, embeddingField, options?.includeFields) as TDoc)
   }

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
@@ -117,6 +117,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
       await client.query('CREATE EXTENSION IF NOT EXISTS vector')
       await client.query(`CREATE SCHEMA IF NOT EXISTS ${ident(this.schema)}`)
       await this.createTable(client, schema, idField)
+      await this.warnOnIncompatibleSchema(client, schema, embeddingField, distance)
       await this.ensureIndexes(client, schema, embeddingField, Boolean(embeddingFieldSchema), distance)
     } finally {
       client.release()
@@ -170,6 +171,55 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     for (const field of schema.fields) {
       await client.query(
         `ALTER TABLE ${this.relName(schema.name)} ADD COLUMN IF NOT EXISTS ${ident(field.name)} ${sqlColumnType(field)}`
+      )
+    }
+  }
+
+  /**
+   * The schema sync is additive (CREATE/ADD ... IF NOT EXISTS), so it can't change
+   * an embedding column's dimension or an HNSW index's distance once they exist.
+   * Detect those incompatible drifts and warn loudly — the operator must drop &
+   * recreate (and reindex) to apply them; silently they'd break inserts/searches
+   * or degrade relevance.
+   */
+  private async warnOnIncompatibleSchema(
+    client: PoolClient,
+    schema: PgvectorCollectionSchema,
+    embeddingField: string,
+    distance: CollectionEmbedInfo['distance']
+  ): Promise<void> {
+    const expectedDim = schema.fields.find(f => f.name === embeddingField)?.dimensions
+    if (expectedDim) {
+      // For a pgvector column, atttypmod holds the declared dimension (-1 if none).
+      const { rows } = await client.query<{ dim: number }>(
+        `SELECT a.atttypmod AS dim FROM pg_attribute a
+         JOIN pg_class c ON a.attrelid = c.oid
+         JOIN pg_namespace n ON c.relnamespace = n.oid
+         WHERE n.nspname = $1 AND c.relname = $2 AND a.attname = $3 AND NOT a.attisdropped`,
+        [this.schema, schema.name, embeddingField]
+      )
+      const actualDim = rows[0]?.dim
+      if (typeof actualDim === 'number' && actualDim > 0 && actualDim !== expectedDim) {
+        logger.warn(
+          `[${schema.name}] embedding column "${embeddingField}" is vector(${actualDim}) but config wants vector(${expectedDim}). ` +
+            'The additive schema sync will NOT change it — drop & recreate the table and reindex to switch dimensions.'
+        )
+      }
+    }
+
+    const indexName = `${schema.name}_${embeddingField}_hnsw`
+    const expectedOpclass = DISTANCE_OPS[distance].opclass
+    const { rows } = await client.query<{ def: string }>(
+      `SELECT pg_get_indexdef(ic.oid) AS def FROM pg_class ic
+       JOIN pg_namespace n ON ic.relnamespace = n.oid
+       WHERE n.nspname = $1 AND ic.relname = $2`,
+      [this.schema, indexName]
+    )
+    const def = rows[0]?.def
+    if (def && !def.includes(expectedOpclass)) {
+      logger.warn(
+        `[${schema.name}] HNSW index "${indexName}" exists with a different distance metric (config: ${distance}/${expectedOpclass}). ` +
+          "CREATE INDEX IF NOT EXISTS won't rebuild it — drop the index to switch distance."
       )
     }
   }

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
@@ -1,0 +1,487 @@
+import type { AdapterSearchResult, IndexDocument, IndexerAdapter, VectorSearchOptions } from '@zetesis/payload-indexer'
+import type { Pool, PoolClient } from 'pg'
+import { logger } from '../core/logging/logger'
+import type { EmbeddingProvider } from '../embedding/provider'
+import type { CollectionEmbedInfo, PgFieldSchema, PgFieldType, PgvectorCollectionSchema } from './types'
+
+export interface PgvectorAdapterOptions {
+  /** Embedding provider used to vectorize text at upsert time. Optional: if a */
+  /** document already carries a precomputed vector, no provider is needed. */
+  embeddingProvider?: EmbeddingProvider
+}
+
+/** Map our PgFieldType to a concrete SQL column type. */
+const sqlColumnType = (field: PgFieldSchema): string => {
+  switch (field.type) {
+    case 'text':
+      return 'text'
+    case 'text[]':
+      return 'text[]'
+    case 'int':
+      return 'integer'
+    case 'bigint':
+      return 'bigint'
+    case 'bool':
+      return 'boolean'
+    case 'timestamptz':
+      return 'timestamptz'
+    case 'jsonb':
+      return 'jsonb'
+    case 'vector':
+      if (!field.dimensions) {
+        throw new Error(`vector column "${field.name}" requires "dimensions"`)
+      }
+      return `vector(${field.dimensions})`
+    default: {
+      const exhaustive: never = field.type
+      throw new Error(`Unsupported field type: ${String(exhaustive)}`)
+    }
+  }
+}
+
+const DISTANCE_OPS: Record<CollectionEmbedInfo['distance'], { op: string; opclass: string }> = {
+  cosine: { op: '<=>', opclass: 'vector_cosine_ops' },
+  l2: { op: '<->', opclass: 'vector_l2_ops' },
+  ip: { op: '<#>', opclass: 'vector_ip_ops' }
+}
+
+/** Quote a SQL identifier (table/column). Validates to avoid injection via schema. */
+const ident = (name: string): string => {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid SQL identifier: ${name}`)
+  }
+  return `"${name}"`
+}
+
+/** Format a number[] as a pgvector literal: [1,2,3]. */
+const toVectorLiteral = (vector: number[]): string => `[${vector.join(',')}]`
+
+/**
+ * Postgres + pgvector implementation of the IndexerAdapter contract.
+ *
+ * Sibling of TypesenseAdapter. The crucial difference: pgvector does not embed,
+ * so this adapter produces vectors app-side via an EmbeddingProvider at upsert
+ * time (unless the document already carries one). Query-side embedding is done
+ * by the caller; vectorSearch() receives a precomputed vector, matching the
+ * IndexerAdapter signature.
+ */
+export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema> {
+  readonly name = 'pgvector'
+  private readonly pool: Pool
+  private readonly embeddingProvider?: EmbeddingProvider
+  /** Per-collection embedding metadata, captured during ensureCollection. */
+  private readonly embedInfo = new Map<string, CollectionEmbedInfo>()
+
+  constructor(pool: Pool, options: PgvectorAdapterOptions = {}) {
+    this.pool = pool
+    this.embeddingProvider = options.embeddingProvider
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.pool.query('SELECT 1')
+      return true
+    } catch (error) {
+      logger.error('pgvector connection test failed', error)
+      return false
+    }
+  }
+
+  // === Schema Management ===
+
+  async ensureCollection(schema: PgvectorCollectionSchema): Promise<void> {
+    const idField = schema.idField ?? 'id'
+    const embeddingField = schema.embeddingField ?? 'embedding'
+    const distance = schema.hnsw?.distance ?? 'cosine'
+    const embeddingFieldSchema = schema.fields.find(f => f.name === embeddingField)
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('CREATE EXTENSION IF NOT EXISTS vector')
+      await this.createTable(client, schema, idField)
+      await this.ensureIndexes(client, schema, embeddingField, Boolean(embeddingFieldSchema), distance)
+    } finally {
+      client.release()
+    }
+
+    this.registerCollection(schema)
+    logger.info(`Ensured collection (table): ${schema.name}`)
+  }
+
+  /**
+   * Register a collection's metadata (id/embedding field, distance, column
+   * types) WITHOUT running any DDL. ensureCollection calls this after creating
+   * the table; consumers that only read (e.g. a search server) can call it on
+   * an existing table so filters and vectorSearch resolve correctly.
+   */
+  registerCollection(schema: PgvectorCollectionSchema): void {
+    const idField = schema.idField ?? 'id'
+    const embeddingField = schema.embeddingField ?? 'embedding'
+    const distance = schema.hnsw?.distance ?? 'cosine'
+    const embeddingFieldSchema = schema.fields.find(f => f.name === embeddingField)
+
+    const columnTypes: Record<string, PgFieldType> = {}
+    for (const field of schema.fields) {
+      columnTypes[field.name] = field.type
+    }
+
+    this.embedInfo.set(schema.name, {
+      idField,
+      embeddingField,
+      embedFrom: schema.embedFrom ?? [],
+      dimensions: embeddingFieldSchema?.dimensions ?? this.embeddingProvider?.dimensions ?? 0,
+      distance,
+      columnTypes
+    })
+  }
+
+  /** CREATE TABLE (id guaranteed as PK) + additive ADD COLUMN for pre-existing tables. */
+  private async createTable(client: PoolClient, schema: PgvectorCollectionSchema, idField: string): Promise<void> {
+    const hasIdField = schema.fields.some(f => f.name === idField)
+    const columnDefs: string[] = []
+    if (!hasIdField) {
+      columnDefs.push(`${ident(idField)} text PRIMARY KEY`)
+    }
+    for (const field of schema.fields) {
+      const nullable = field.optional === false ? ' NOT NULL' : ''
+      const pk = field.name === idField ? ' PRIMARY KEY' : ''
+      columnDefs.push(`${ident(field.name)} ${sqlColumnType(field)}${pk}${nullable}`)
+    }
+    await client.query(`CREATE TABLE IF NOT EXISTS ${ident(schema.name)} (\n  ${columnDefs.join(',\n  ')}\n)`)
+
+    for (const field of schema.fields) {
+      await client.query(
+        `ALTER TABLE ${ident(schema.name)} ADD COLUMN IF NOT EXISTS ${ident(field.name)} ${sqlColumnType(field)}`
+      )
+    }
+  }
+
+  /** HNSW index on the embedding column + btree/GIN indexes on flagged columns. */
+  private async ensureIndexes(
+    client: PoolClient,
+    schema: PgvectorCollectionSchema,
+    embeddingField: string,
+    hasEmbedding: boolean,
+    distance: CollectionEmbedInfo['distance']
+  ): Promise<void> {
+    if (hasEmbedding) {
+      const { opclass } = DISTANCE_OPS[distance]
+      const m = schema.hnsw?.m ?? 16
+      const efc = schema.hnsw?.efConstruction ?? 64
+      const indexName = `${schema.name}_${embeddingField}_hnsw`
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${ident(schema.name)} ` +
+          `USING hnsw (${ident(embeddingField)} ${opclass}) WITH (m = ${m}, ef_construction = ${efc})`
+      )
+    }
+
+    for (const field of schema.fields) {
+      if (!field.index || field.name === embeddingField) continue
+      const indexName = `${schema.name}_${field.name}_idx`
+      const method = field.type === 'text[]' ? 'gin' : 'btree'
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${ident(schema.name)} USING ${method} (${ident(field.name)})`
+      )
+    }
+  }
+
+  async collectionExists(collectionName: string): Promise<boolean> {
+    const result = await this.pool.query<{ exists: boolean }>('SELECT to_regclass($1) IS NOT NULL AS exists', [
+      collectionName
+    ])
+    return result.rows[0]?.exists ?? false
+  }
+
+  async deleteCollection(collectionName: string): Promise<void> {
+    await this.pool.query(`DROP TABLE IF EXISTS ${ident(collectionName)} CASCADE`)
+    this.embedInfo.delete(collectionName)
+    logger.info(`Deleted collection (table): ${collectionName}`)
+  }
+
+  // === Document Operations ===
+
+  async upsertDocument(collectionName: string, document: IndexDocument): Promise<void> {
+    await this.upsertDocuments(collectionName, [document])
+  }
+
+  async upsertDocuments(collectionName: string, documents: IndexDocument[]): Promise<void> {
+    if (documents.length === 0) return
+
+    const info = this.embedInfo.get(collectionName)
+    const vectors = await this.resolveVectors(documents, info)
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      for (let i = 0; i < documents.length; i++) {
+        await this.insertRow(client, collectionName, documents[i], vectors[i], info)
+      }
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      logger.error(`Failed to upsert ${documents.length} document(s) to ${collectionName}`, error)
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async deleteDocument(collectionName: string, documentId: string): Promise<void> {
+    const idField = this.embedInfo.get(collectionName)?.idField ?? 'id'
+    await this.pool.query(`DELETE FROM ${ident(collectionName)} WHERE ${ident(idField)} = $1`, [documentId])
+  }
+
+  async deleteDocumentsByFilter(collectionName: string, filter: Record<string, unknown>): Promise<number> {
+    const columnTypes = this.embedInfo.get(collectionName)?.columnTypes
+    const { clause, params } = this.buildWhere(filter, columnTypes)
+    const sql = `DELETE FROM ${ident(collectionName)}${clause}`
+    const result = await this.pool.query(sql, params)
+    return result.rowCount ?? 0
+  }
+
+  // === Vector Search ===
+
+  async vectorSearch<TDoc = Record<string, unknown>>(
+    collectionName: string,
+    vector: number[],
+    options: VectorSearchOptions = {}
+  ): Promise<AdapterSearchResult<TDoc>[]> {
+    const { limit = 10, filter, includeFields, excludeFields } = options
+    const info = this.embedInfo.get(collectionName)
+    const embeddingField = info?.embeddingField ?? 'embedding'
+    const op = DISTANCE_OPS[info?.distance ?? 'cosine'].op
+
+    const params: unknown[] = [toVectorLiteral(vector)]
+    const { clause, params: whereParams } = this.buildWhere(filter ?? {}, info?.columnTypes, params.length)
+    params.push(...whereParams)
+    params.push(limit)
+
+    const sql =
+      `SELECT *, ${ident(embeddingField)} ${op} $1::vector AS _distance ` +
+      `FROM ${ident(collectionName)}${clause} ` +
+      `ORDER BY ${ident(embeddingField)} ${op} $1::vector ` +
+      `LIMIT $${params.length}`
+
+    const result = await this.pool.query(sql, params)
+    return result.rows.map(row => {
+      const distance = Number(row._distance)
+      const document = this.projectRow(row, embeddingField, includeFields, excludeFields)
+      return {
+        id: String((document as Record<string, unknown>)[info?.idField ?? 'id'] ?? ''),
+        score: distance,
+        document: document as TDoc
+      }
+    })
+  }
+
+  /**
+   * Semantic search by text: embeds the query via the adapter's EmbeddingProvider
+   * and runs vectorSearch. Convenience for read-only consumers (e.g. an MCP)
+   * that hold text queries, not vectors.
+   */
+  async searchByText<TDoc = Record<string, unknown>>(
+    collectionName: string,
+    text: string,
+    options: VectorSearchOptions = {}
+  ): Promise<AdapterSearchResult<TDoc>[]> {
+    if (!this.embeddingProvider) {
+      throw new Error('searchByText requires an EmbeddingProvider on the adapter')
+    }
+    const [vector] = await this.embeddingProvider.embed([text])
+    return this.vectorSearch<TDoc>(collectionName, vector, options)
+  }
+
+  // === Optional: Document Query & Partial Update ===
+
+  async searchDocumentsByFilter<TDoc = Record<string, unknown>>(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    options?: { includeFields?: string[]; limit?: number }
+  ): Promise<TDoc[]> {
+    const info = this.embedInfo.get(collectionName)
+    const embeddingField = info?.embeddingField ?? 'embedding'
+    const { clause, params } = this.buildWhere(filter, info?.columnTypes)
+    const limit = options?.limit ?? 250
+    params.push(limit)
+    const sql = `SELECT * FROM ${ident(collectionName)}${clause} LIMIT $${params.length}`
+    const result = await this.pool.query(sql, params)
+    return result.rows.map(row => this.projectRow(row, embeddingField, options?.includeFields) as TDoc)
+  }
+
+  async updateDocument(collectionName: string, documentId: string, partialDoc: Record<string, unknown>): Promise<void> {
+    const idField = this.embedInfo.get(collectionName)?.idField ?? 'id'
+    const keys = Object.keys(partialDoc)
+    if (keys.length === 0) return
+
+    const sets = keys.map((key, i) => `${ident(key)} = $${i + 1}`)
+    const params = keys.map(key => this.toParam(partialDoc[key]))
+    params.push(documentId)
+    const sql = `UPDATE ${ident(collectionName)} SET ${sets.join(', ')} WHERE ${ident(idField)} = $${params.length}`
+    await this.pool.query(sql, params)
+  }
+
+  async updateDocumentsByFilter(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    partialDoc: Record<string, unknown>
+  ): Promise<number> {
+    const keys = Object.keys(partialDoc)
+    if (keys.length === 0) return 0
+
+    const sets = keys.map((key, i) => `${ident(key)} = $${i + 1}`)
+    const params = keys.map(key => this.toParam(partialDoc[key]))
+    const columnTypes = this.embedInfo.get(collectionName)?.columnTypes
+    const { clause, params: whereParams } = this.buildWhere(filter, columnTypes, params.length)
+    params.push(...whereParams)
+    const sql = `UPDATE ${ident(collectionName)} SET ${sets.join(', ')}${clause}`
+    const result = await this.pool.query(sql, params)
+    return result.rowCount ?? 0
+  }
+
+  // === Private helpers ===
+
+  /** Resolve a vector per document: use a precomputed one, else embed embedFrom text. */
+  private async resolveVectors(
+    documents: IndexDocument[],
+    info?: CollectionEmbedInfo
+  ): Promise<Array<number[] | null>> {
+    const vectors: Array<number[] | null> = documents.map(doc => {
+      if (!info) return null
+      const existing = doc[info.embeddingField]
+      return Array.isArray(existing) && existing.every(v => typeof v === 'number') ? (existing as number[]) : null
+    })
+
+    if (!info || info.embedFrom.length === 0) return vectors
+
+    const toEmbedIndexes: number[] = []
+    const toEmbedTexts: string[] = []
+    for (let i = 0; i < documents.length; i++) {
+      if (vectors[i] !== null) continue
+      const text = info.embedFrom
+        .map(field => documents[i][field])
+        .filter(v => typeof v === 'string' && v.length > 0)
+        .join('\n')
+      if (text.length === 0) continue
+      toEmbedIndexes.push(i)
+      toEmbedTexts.push(text)
+    }
+
+    if (toEmbedTexts.length === 0) return vectors
+    if (!this.embeddingProvider) {
+      throw new Error(`Collection has embedFrom configured but no EmbeddingProvider was supplied to the adapter`)
+    }
+
+    const embedded = await this.embeddingProvider.embed(toEmbedTexts)
+    toEmbedIndexes.forEach((docIndex, k) => {
+      vectors[docIndex] = embedded[k]
+    })
+    return vectors
+  }
+
+  /** INSERT ... ON CONFLICT (id) DO UPDATE for one document. */
+  private async insertRow(
+    client: PoolClient,
+    collectionName: string,
+    document: IndexDocument,
+    vector: number[] | null,
+    info?: CollectionEmbedInfo
+  ): Promise<void> {
+    const idField = info?.idField ?? 'id'
+    const embeddingField = info?.embeddingField ?? 'embedding'
+
+    const columns: string[] = []
+    const placeholders: string[] = []
+    const params: unknown[] = []
+
+    for (const [key, value] of Object.entries(document)) {
+      if (key === embeddingField) continue // embedding handled below
+      columns.push(ident(key))
+      params.push(this.toParam(value))
+      placeholders.push(`$${params.length}`)
+    }
+
+    if (vector !== null) {
+      columns.push(ident(embeddingField))
+      params.push(toVectorLiteral(vector))
+      placeholders.push(`$${params.length}::vector`)
+    }
+
+    const updates = columns.filter(col => col !== ident(idField)).map(col => `${col} = EXCLUDED.${col}`)
+
+    const conflict =
+      updates.length > 0
+        ? `ON CONFLICT (${ident(idField)}) DO UPDATE SET ${updates.join(', ')}`
+        : `ON CONFLICT (${ident(idField)}) DO NOTHING`
+
+    const sql =
+      `INSERT INTO ${ident(collectionName)} (${columns.join(', ')}) ` +
+      `VALUES (${placeholders.join(', ')}) ${conflict}`
+
+    await client.query(sql, params)
+  }
+
+  /**
+   * Build a WHERE clause from a filter object with parameterized values. The
+   * operator is chosen by the column's SQL type: array columns (text[], e.g.
+   * taxonomy_slugs) use overlap/membership, scalar columns use equality/IN.
+   */
+  private buildWhere(
+    filter: Record<string, unknown>,
+    columnTypes: Record<string, PgFieldType> = {},
+    paramOffset = 0
+  ): { clause: string; params: unknown[] } {
+    const conditions: string[] = []
+    const params: unknown[] = []
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (value === undefined) continue
+      const isArrayColumn = columnTypes[key] === 'text[]'
+
+      if (isArrayColumn && Array.isArray(value)) {
+        // Array column + array filter → overlap (any of the values present).
+        params.push(value)
+        conditions.push(`${ident(key)} && $${paramOffset + params.length}::text[]`)
+      } else if (isArrayColumn) {
+        // Array column + scalar filter → membership.
+        params.push(value)
+        conditions.push(`$${paramOffset + params.length} = ANY(${ident(key)})`)
+      } else if (Array.isArray(value)) {
+        // Scalar column + multiple values → IN list.
+        params.push(value)
+        conditions.push(`${ident(key)} = ANY($${paramOffset + params.length}::text[])`)
+      } else {
+        // Scalar column + scalar value → equality.
+        params.push(this.toParam(value))
+        conditions.push(`${ident(key)} = $${paramOffset + params.length}`)
+      }
+    }
+
+    const clause = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : ''
+    return { clause, params }
+  }
+
+  /** Convert a JS value to a pg-bindable parameter (jsonb for plain objects). */
+  private toParam(value: unknown): unknown {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      return JSON.stringify(value)
+    }
+    return value
+  }
+
+  /** Strip the embedding column and internal fields, applying include/exclude. */
+  private projectRow(
+    row: Record<string, unknown>,
+    embeddingField: string,
+    includeFields?: string[],
+    excludeFields?: string[]
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(row)) {
+      if (key === embeddingField || key === '_distance') continue
+      if (includeFields && !includeFields.includes(key)) continue
+      if (excludeFields?.includes(key)) continue
+      out[key] = value
+    }
+    return out
+  }
+}

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
@@ -8,6 +8,13 @@ export interface PgvectorAdapterOptions {
   /** Embedding provider used to vectorize text at upsert time. Optional: if a */
   /** document already carries a precomputed vector, no provider is needed. */
   embeddingProvider?: EmbeddingProvider
+  /**
+   * Postgres schema to create/query the tables in (e.g. `pgvector`). Required and
+   * never `public`: these tables are raw (not ORM-managed), so they MUST live in
+   * a dedicated schema — otherwise a Payload/Drizzle schema push sees them as
+   * unmanaged and DROPs them.
+   */
+  schema: string
 }
 
 /** Map our PgFieldType to a concrete SQL column type. */
@@ -69,12 +76,22 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
   readonly name = 'pgvector'
   private readonly pool: Pool
   private readonly embeddingProvider?: EmbeddingProvider
+  private readonly schema: string
   /** Per-collection embedding metadata, captured during ensureCollection. */
   private readonly embedInfo = new Map<string, CollectionEmbedInfo>()
 
-  constructor(pool: Pool, options: PgvectorAdapterOptions = {}) {
+  constructor(pool: Pool, options: PgvectorAdapterOptions) {
+    if (!options.schema || options.schema === 'public') {
+      throw new Error('PgvectorAdapter requires a dedicated `schema` (not "public")')
+    }
     this.pool = pool
     this.embeddingProvider = options.embeddingProvider
+    this.schema = options.schema
+  }
+
+  /** Schema-qualified, quoted table reference: `"schema"."table"`. */
+  private relName(table: string): string {
+    return `${ident(this.schema)}.${ident(table)}`
   }
 
   async testConnection(): Promise<boolean> {
@@ -98,6 +115,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     const client = await this.pool.connect()
     try {
       await client.query('CREATE EXTENSION IF NOT EXISTS vector')
+      await client.query(`CREATE SCHEMA IF NOT EXISTS ${ident(this.schema)}`)
       await this.createTable(client, schema, idField)
       await this.ensureIndexes(client, schema, embeddingField, Boolean(embeddingFieldSchema), distance)
     } finally {
@@ -147,11 +165,11 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
       const pk = field.name === idField ? ' PRIMARY KEY' : ''
       columnDefs.push(`${ident(field.name)} ${sqlColumnType(field)}${pk}${nullable}`)
     }
-    await client.query(`CREATE TABLE IF NOT EXISTS ${ident(schema.name)} (\n  ${columnDefs.join(',\n  ')}\n)`)
+    await client.query(`CREATE TABLE IF NOT EXISTS ${this.relName(schema.name)} (\n  ${columnDefs.join(',\n  ')}\n)`)
 
     for (const field of schema.fields) {
       await client.query(
-        `ALTER TABLE ${ident(schema.name)} ADD COLUMN IF NOT EXISTS ${ident(field.name)} ${sqlColumnType(field)}`
+        `ALTER TABLE ${this.relName(schema.name)} ADD COLUMN IF NOT EXISTS ${ident(field.name)} ${sqlColumnType(field)}`
       )
     }
   }
@@ -170,7 +188,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
       const efc = schema.hnsw?.efConstruction ?? 64
       const indexName = `${schema.name}_${embeddingField}_hnsw`
       await client.query(
-        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${ident(schema.name)} ` +
+        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${this.relName(schema.name)} ` +
           `USING hnsw (${ident(embeddingField)} ${opclass}) WITH (m = ${m}, ef_construction = ${efc})`
       )
     }
@@ -180,20 +198,20 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
       const indexName = `${schema.name}_${field.name}_idx`
       const method = field.type === 'text[]' ? 'gin' : 'btree'
       await client.query(
-        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${ident(schema.name)} USING ${method} (${ident(field.name)})`
+        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${this.relName(schema.name)} USING ${method} (${ident(field.name)})`
       )
     }
   }
 
   async collectionExists(collectionName: string): Promise<boolean> {
     const result = await this.pool.query<{ exists: boolean }>('SELECT to_regclass($1) IS NOT NULL AS exists', [
-      collectionName
+      `${this.schema}.${collectionName}`
     ])
     return result.rows[0]?.exists ?? false
   }
 
   async deleteCollection(collectionName: string): Promise<void> {
-    await this.pool.query(`DROP TABLE IF EXISTS ${ident(collectionName)} CASCADE`)
+    await this.pool.query(`DROP TABLE IF EXISTS ${this.relName(collectionName)} CASCADE`)
     this.embedInfo.delete(collectionName)
     logger.info(`Deleted collection (table): ${collectionName}`)
   }
@@ -228,13 +246,13 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
 
   async deleteDocument(collectionName: string, documentId: string): Promise<void> {
     const idField = this.embedInfo.get(collectionName)?.idField ?? 'id'
-    await this.pool.query(`DELETE FROM ${ident(collectionName)} WHERE ${ident(idField)} = $1`, [documentId])
+    await this.pool.query(`DELETE FROM ${this.relName(collectionName)} WHERE ${ident(idField)} = $1`, [documentId])
   }
 
   async deleteDocumentsByFilter(collectionName: string, filter: Record<string, unknown>): Promise<number> {
     const columnTypes = this.embedInfo.get(collectionName)?.columnTypes
     const { clause, params } = this.buildWhere(filter, columnTypes)
-    const sql = `DELETE FROM ${ident(collectionName)}${clause}`
+    const sql = `DELETE FROM ${this.relName(collectionName)}${clause}`
     const result = await this.pool.query(sql, params)
     return result.rowCount ?? 0
   }
@@ -258,7 +276,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
 
     const sql =
       `SELECT *, ${ident(embeddingField)} ${op} $1::vector AS _distance ` +
-      `FROM ${ident(collectionName)}${clause} ` +
+      `FROM ${this.relName(collectionName)}${clause} ` +
       `ORDER BY ${ident(embeddingField)} ${op} $1::vector ` +
       `LIMIT $${params.length}`
 
@@ -303,7 +321,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     const { clause, params } = this.buildWhere(filter, info?.columnTypes)
     const limit = options?.limit ?? 250
     params.push(limit)
-    const sql = `SELECT * FROM ${ident(collectionName)}${clause} LIMIT $${params.length}`
+    const sql = `SELECT * FROM ${this.relName(collectionName)}${clause} LIMIT $${params.length}`
     const result = await this.pool.query(sql, params)
     return result.rows.map(row => this.projectRow(row, embeddingField, options?.includeFields) as TDoc)
   }
@@ -316,7 +334,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     const sets = keys.map((key, i) => `${ident(key)} = $${i + 1}`)
     const params = keys.map(key => this.toParam(partialDoc[key]))
     params.push(documentId)
-    const sql = `UPDATE ${ident(collectionName)} SET ${sets.join(', ')} WHERE ${ident(idField)} = $${params.length}`
+    const sql = `UPDATE ${this.relName(collectionName)} SET ${sets.join(', ')} WHERE ${ident(idField)} = $${params.length}`
     await this.pool.query(sql, params)
   }
 
@@ -333,7 +351,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
     const columnTypes = this.embedInfo.get(collectionName)?.columnTypes
     const { clause, params: whereParams } = this.buildWhere(filter, columnTypes, params.length)
     params.push(...whereParams)
-    const sql = `UPDATE ${ident(collectionName)} SET ${sets.join(', ')}${clause}`
+    const sql = `UPDATE ${this.relName(collectionName)} SET ${sets.join(', ')}${clause}`
     const result = await this.pool.query(sql, params)
     return result.rowCount ?? 0
   }
@@ -414,7 +432,7 @@ export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema>
         : `ON CONFLICT (${ident(idField)}) DO NOTHING`
 
     const sql =
-      `INSERT INTO ${ident(collectionName)} (${columns.join(', ')}) ` +
+      `INSERT INTO ${this.relName(collectionName)} (${columns.join(', ')}) ` +
       `VALUES (${placeholders.join(', ')}) ${conflict}`
 
     await client.query(sql, params)

--- a/packages/payload-pgvector/src/adapter/types.ts
+++ b/packages/payload-pgvector/src/adapter/types.ts
@@ -1,0 +1,61 @@
+import type { BaseCollectionSchema } from '@zetesis/payload-indexer'
+
+/**
+ * SQL column types we map indexer fields onto. Kept deliberately small — the
+ * indexer only needs scalars, text arrays (e.g. taxonomy_slugs), timestamps and
+ * the vector column.
+ */
+export type PgFieldType = 'text' | 'text[]' | 'int' | 'bigint' | 'bool' | 'timestamptz' | 'jsonb' | 'vector'
+
+/**
+ * A single column in a pgvector-backed collection (table).
+ */
+export interface PgFieldSchema {
+  name: string
+  type: PgFieldType
+  /** Required for `vector` columns: the embedding dimensionality (`vector(N)`). */
+  dimensions?: number
+  /** Create a btree/GIN index on this column. The vector column is handled separately (HNSW). */
+  index?: boolean
+  /** Whether the column is nullable. Defaults to true. */
+  optional?: boolean
+}
+
+/**
+ * pgvector-specific collection schema. Each collection maps to one Postgres
+ * table. Extends the indexer's BaseCollectionSchema so the IndexerAdapter
+ * contract is satisfied.
+ */
+export interface PgvectorCollectionSchema extends BaseCollectionSchema {
+  name: string
+  fields: PgFieldSchema[]
+  /** Primary key column. Defaults to `id`. */
+  idField?: string
+  /** Name of the `vector` column embeddings are stored in. Defaults to `embedding`. */
+  embeddingField?: string
+  /**
+   * Columns whose text is concatenated and embedded at upsert time when the
+   * document does not already carry a precomputed vector. Mirrors Typesense's
+   * `embed.from`. If omitted, the adapter never auto-embeds (vectors must be
+   * supplied in the document).
+   */
+  embedFrom?: string[]
+  /** HNSW index tuning for the embedding column. */
+  hnsw?: {
+    m?: number
+    efConstruction?: number
+    /** Distance operator class. Defaults to cosine. */
+    distance?: 'cosine' | 'l2' | 'ip'
+  }
+}
+
+/** Internal per-collection metadata captured from ensureCollection. */
+export interface CollectionEmbedInfo {
+  idField: string
+  embeddingField: string
+  embedFrom: string[]
+  dimensions: number
+  distance: 'cosine' | 'l2' | 'ip'
+  /** Column name → SQL type, used to pick the right filter operator (e.g. && vs =). */
+  columnTypes: Record<string, PgFieldType>
+}

--- a/packages/payload-pgvector/src/core/logging/logger.ts
+++ b/packages/payload-pgvector/src/core/logging/logger.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal namespaced logger. Kept dependency-free so the package stays isolated
+ * (mirrors payload-typesense's core/logging/logger but without extra deps).
+ */
+type LogArgs = unknown[]
+
+const prefix = '[payload-pgvector]'
+
+export const logger = {
+  info: (message: string, ...args: LogArgs): void => {
+    console.info(`${prefix} ${message}`, ...args)
+  },
+  warn: (message: string, ...args: LogArgs): void => {
+    console.warn(`${prefix} ${message}`, ...args)
+  },
+  error: (message: string, ...args: LogArgs): void => {
+    console.error(`${prefix} ${message}`, ...args)
+  }
+}

--- a/packages/payload-pgvector/src/embedding/provider.spec.ts
+++ b/packages/payload-pgvector/src/embedding/provider.spec.ts
@@ -67,4 +67,18 @@ describe('OpenAICompatibleEmbeddingProvider', () => {
 
     await expect(provider.embed(['a', 'b'])).resolves.toEqual([[1], [2]])
   })
+
+  it('throws on a misaligned batch (fewer embeddings than inputs)', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [{ embedding: [0.1], index: 0 }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    // Two inputs, one vector back → must fail loudly, not mispair text↔vector.
+    await expect(provider.embed(['a', 'b'])).rejects.toThrow(/count mismatch/)
+  })
 })

--- a/packages/payload-pgvector/src/embedding/provider.spec.ts
+++ b/packages/payload-pgvector/src/embedding/provider.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenAICompatibleEmbeddingProvider } from './provider'
+
+function fakeFetch() {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2], index: 0 }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+  )
+}
+
+const base = {
+  baseUrl: 'http://litellm:4000/v1/',
+  apiKey: 'sk-test',
+  model: 'embeddings-dev',
+  dimensions: 1536
+}
+
+describe('OpenAICompatibleEmbeddingProvider', () => {
+  it('omits dimensions by default (TEI/Ollama/ada-002 reject the param)', async () => {
+    const fetchImpl = fakeFetch()
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    await provider.embed(['hello'])
+
+    const body = JSON.parse((fetchImpl.mock.calls[0]?.[1] as { body: string }).body)
+    expect(body).not.toHaveProperty('dimensions')
+    expect(body).toMatchObject({ model: 'embeddings-dev', input: ['hello'] })
+    // trailing slash on baseUrl is trimmed
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('http://litellm:4000/v1/embeddings')
+  })
+
+  it('sends dimensions only when sendDimensions is enabled', async () => {
+    const fetchImpl = fakeFetch()
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, sendDimensions: true, fetchImpl })
+
+    await provider.embed(['hello'])
+
+    const body = JSON.parse((fetchImpl.mock.calls[0]?.[1] as { body: string }).body)
+    expect(body.dimensions).toBe(1536)
+  })
+
+  it('returns [] without calling fetch for an empty batch', async () => {
+    const fetchImpl = fakeFetch()
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    await expect(provider.embed([])).resolves.toEqual([])
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('reorders vectors by the response index', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              { embedding: [2], index: 1 },
+              { embedding: [1], index: 0 }
+            ]
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    )
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    await expect(provider.embed(['a', 'b'])).resolves.toEqual([[1], [2]])
+  })
+})

--- a/packages/payload-pgvector/src/embedding/provider.ts
+++ b/packages/payload-pgvector/src/embedding/provider.ts
@@ -1,0 +1,81 @@
+/**
+ * Embedding generation seam.
+ *
+ * pgvector — unlike Typesense — does NOT auto-embed: vectors must be produced
+ * app-side before they hit the database. `EmbeddingProvider` is the abstraction
+ * that does it. The default implementation talks to any OpenAI-compatible
+ * `/v1/embeddings` endpoint, so it works against OpenAI directly, a LiteLLM
+ * gateway, a local TEI/Ollama server, etc. — the package stays generic and the
+ * consumer points `baseUrl` wherever it routes embeddings.
+ */
+export interface EmbeddingProvider {
+  /**
+   * Stable identifier of the model the vectors are produced with. Index-time and
+   * query-time MUST use the same model + dimensions, or similarity is garbage.
+   */
+  readonly model: string
+
+  /** Dimensionality of the produced vectors (must match the `vector(N)` column). */
+  readonly dimensions: number
+
+  /** Embed a batch of texts. Order of the returned vectors matches the input. */
+  embed(texts: string[]): Promise<number[][]>
+}
+
+export interface OpenAICompatibleEmbeddingConfig {
+  /** Base URL of an OpenAI-compatible API, e.g. `http://litellm:4000/v1`. */
+  baseUrl: string
+  /** API key / virtual key sent as `Authorization: Bearer`. */
+  apiKey: string
+  /** Model name / alias to request, e.g. `embeddings-dev`. */
+  model: string
+  /** Vector dimensionality. Must match the target `vector(N)` column. */
+  dimensions: number
+  /** Optional fetch implementation override (testing). Defaults to global fetch. */
+  fetchImpl?: typeof fetch
+}
+
+interface OpenAIEmbeddingResponse {
+  data: Array<{ embedding: number[]; index: number }>
+}
+
+/**
+ * EmbeddingProvider backed by an OpenAI-compatible `/embeddings` endpoint.
+ */
+export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string
+  readonly dimensions: number
+  private readonly baseUrl: string
+  private readonly apiKey: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(config: OpenAICompatibleEmbeddingConfig) {
+    this.model = config.model
+    this.dimensions = config.dimensions
+    this.baseUrl = config.baseUrl.replace(/\/$/, '')
+    this.apiKey = config.apiKey
+    this.fetchImpl = config.fetchImpl ?? fetch
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return []
+
+    const response = await this.fetchImpl(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`
+      },
+      body: JSON.stringify({ model: this.model, input: texts })
+    })
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      throw new Error(`Embedding request failed (${response.status} ${response.statusText}): ${detail}`)
+    }
+
+    const json = (await response.json()) as OpenAIEmbeddingResponse
+    // Preserve request order — some gateways return out-of-order by `index`.
+    return json.data.sort((a, b) => a.index - b.index).map(item => item.embedding)
+  }
+}

--- a/packages/payload-pgvector/src/embedding/provider.ts
+++ b/packages/payload-pgvector/src/embedding/provider.ts
@@ -93,7 +93,15 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
     }
 
     const json = (await response.json()) as OpenAIEmbeddingResponse
+    // Fail loudly on a misaligned batch: callers pair vectors to inputs by
+    // position, so a short/over-long response would mispair text↔vector (or push
+    // an `undefined` vector downstream). Require one embedding per input.
+    if (!Array.isArray(json.data) || json.data.length !== texts.length) {
+      throw new Error(
+        `Embedding response count mismatch: requested ${texts.length}, got ${json.data?.length ?? 0}`
+      )
+    }
     // Preserve request order — some gateways return out-of-order by `index`.
-    return json.data.sort((a, b) => a.index - b.index).map(item => item.embedding)
+    return [...json.data].sort((a, b) => a.index - b.index).map(item => item.embedding)
   }
 }

--- a/packages/payload-pgvector/src/embedding/provider.ts
+++ b/packages/payload-pgvector/src/embedding/provider.ts
@@ -82,7 +82,9 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
         model: this.model,
         input: texts,
         ...(this.sendDimensions ? { dimensions: this.dimensions } : {})
-      })
+      }),
+      // Bound the request: a hung gateway must not block CMS saves or boot.
+      signal: AbortSignal.timeout(30_000)
     })
 
     if (!response.ok) {

--- a/packages/payload-pgvector/src/embedding/provider.ts
+++ b/packages/payload-pgvector/src/embedding/provider.ts
@@ -31,6 +31,14 @@ export interface OpenAICompatibleEmbeddingConfig {
   model: string
   /** Vector dimensionality. Must match the target `vector(N)` column. */
   dimensions: number
+  /**
+   * Send `dimensions` in the request body so a reduced-dim config produces
+   * vectors that fit the `vector(N)` column. Only the OpenAI `text-embedding-3-*`
+   * family (and gateways proxying them) honour it — ada-002, TEI, Ollama and
+   * most local servers reject the param, so this is OFF by default. Enable it
+   * only when the target model supports dimensionality reduction.
+   */
+  sendDimensions?: boolean
   /** Optional fetch implementation override (testing). Defaults to global fetch. */
   fetchImpl?: typeof fetch
 }
@@ -47,6 +55,7 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
   readonly dimensions: number
   private readonly baseUrl: string
   private readonly apiKey: string
+  private readonly sendDimensions: boolean
   private readonly fetchImpl: typeof fetch
 
   constructor(config: OpenAICompatibleEmbeddingConfig) {
@@ -54,6 +63,7 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
     this.dimensions = config.dimensions
     this.baseUrl = config.baseUrl.replace(/\/$/, '')
     this.apiKey = config.apiKey
+    this.sendDimensions = config.sendDimensions ?? false
     this.fetchImpl = config.fetchImpl ?? fetch
   }
 
@@ -66,7 +76,13 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${this.apiKey}`
       },
-      body: JSON.stringify({ model: this.model, input: texts })
+      // Request the configured dimensionality only when the target model honours
+      // it (text-embedding-3-*); other backends reject the param. See sendDimensions.
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+        ...(this.sendDimensions ? { dimensions: this.dimensions } : {})
+      })
     })
 
     if (!response.ok) {

--- a/packages/payload-pgvector/src/index.ts
+++ b/packages/payload-pgvector/src/index.ts
@@ -32,4 +32,8 @@ export { OpenAICompatibleEmbeddingProvider } from './embedding/provider'
 // Plugin (schema sync)
 export { createPgvectorPlugin } from './plugin/create-pgvector-plugin'
 export { deriveCollectionSchemas } from './plugin/derive-schema'
+export type { PgvectorMcpDescriptorOptions } from './plugin/mcp-descriptor'
+
+// MCP descriptor
+export { createPgvectorMcpDescriptor } from './plugin/mcp-descriptor'
 export type { PgvectorFieldMapping, PgvectorPluginConfig } from './plugin/types'

--- a/packages/payload-pgvector/src/index.ts
+++ b/packages/payload-pgvector/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @zetesis/payload-pgvector
+ *
+ * Postgres + pgvector search backend for Payload CMS. Implements the
+ * @zetesis/payload-indexer IndexerAdapter contract as a sibling of
+ * @zetesis/payload-typesense, with app-side embeddings via any OpenAI-compatible
+ * endpoint (OpenAI, a LiteLLM gateway, a local TEI/Ollama server, ...).
+ *
+ * Milestone 1: adapter + embedding provider. The features/search layer
+ * (hybrid, multi-collection, RAG endpoints) is built on top of this.
+ */
+
+export type { CreatePgvectorAdapterOptions } from './adapter/create-adapter'
+export { createPgvectorAdapter, createPgvectorAdapterFromPool } from './adapter/create-adapter'
+export type { PgvectorAdapterOptions } from './adapter/pgvector-adapter'
+// Adapter
+export { PgvectorAdapter } from './adapter/pgvector-adapter'
+
+// Schema types
+export type {
+  CollectionEmbedInfo,
+  PgFieldSchema,
+  PgFieldType,
+  PgvectorCollectionSchema
+} from './adapter/types'
+export type {
+  EmbeddingProvider,
+  OpenAICompatibleEmbeddingConfig
+} from './embedding/provider'
+// Embedding
+export { OpenAICompatibleEmbeddingProvider } from './embedding/provider'
+// Plugin (schema sync)
+export { createPgvectorPlugin } from './plugin/create-pgvector-plugin'
+export { deriveCollectionSchemas } from './plugin/derive-schema'
+export type { PgvectorFieldMapping, PgvectorPluginConfig } from './plugin/types'

--- a/packages/payload-pgvector/src/plugin/create-pgvector-plugin.ts
+++ b/packages/payload-pgvector/src/plugin/create-pgvector-plugin.ts
@@ -1,0 +1,43 @@
+import type { Config } from 'payload'
+import { logger } from '../core/logging/logger'
+import { deriveCollectionSchemas } from './derive-schema'
+import type { PgvectorPluginConfig } from './types'
+
+/**
+ * Schema-sync plugin for pgvector. Mirrors payload-typesense's createTypesenseRAGPlugin
+ * onInit step: on startup it ensures every configured table exists (CREATE
+ * EXTENSION + CREATE TABLE + HNSW index) via adapter.ensureCollection.
+ *
+ * It does NOT register sync hooks — pair it with createIndexerPlugin (same
+ * adapter) which handles document sync. The adapter generates embeddings at
+ * upsert time via its EmbeddingProvider.
+ *
+ * @example
+ * const adapter = createPgvectorAdapter({ connectionString, embedding: {...} })
+ * const { plugin: indexerPlugin } = createIndexerPlugin({ adapter, features: { sync: { enabled: true } }, collections })
+ * const pgvectorPlugin = createPgvectorPlugin({ adapter, collections, dimensions: 1536 })
+ * // plugins: [indexerPlugin, pgvectorPlugin]
+ */
+export const createPgvectorPlugin = (config: PgvectorPluginConfig) => {
+  return (payloadConfig: Config): Config => {
+    const schemas = deriveCollectionSchemas(config)
+
+    const incomingOnInit = payloadConfig.onInit
+    payloadConfig.onInit = async payload => {
+      if (incomingOnInit) {
+        await incomingOnInit(payload)
+      }
+
+      try {
+        logger.info(`Ensuring ${schemas.length} pgvector table(s)...`)
+        for (const schema of schemas) {
+          await config.adapter.ensureCollection(schema)
+        }
+      } catch (error) {
+        logger.error('Error ensuring pgvector tables', error)
+      }
+    }
+
+    return payloadConfig
+  }
+}

--- a/packages/payload-pgvector/src/plugin/derive-schema.spec.ts
+++ b/packages/payload-pgvector/src/plugin/derive-schema.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { PgFieldSchema } from '../adapter/types'
+import { deriveCollectionSchemas } from './derive-schema'
+import type { PgvectorPluginConfig } from './types'
+
+/**
+ * Pins the 3-way column contract that has no compile-time enforcement:
+ *   payload-indexer buildChunkDocument (what the syncer writes)
+ *     ↔ deriveCollectionSchemas (the table it builds, tested here)
+ *     ↔ mcp-pgvector buildSchema/filterColumns (what the probe reads + filters on).
+ * A rename in any leg silently mis-filters at runtime; this test makes the
+ * derive-schema leg fail loudly instead.
+ */
+const chunkedCollections = {
+  posts: [
+    {
+      enabled: true,
+      tableName: 'posts_pgvector_chunk',
+      syncDepth: 1,
+      embedding: {
+        fields: [],
+        chunking: { strategy: 'markdown', size: 2000, overlap: 300 },
+        autoEmbed: { from: ['chunk_text'], modelConfig: {} }
+      },
+      fields: [
+        { name: 'title', type: 'text' },
+        { name: 'slug', type: 'text', index: true },
+        { name: 'taxonomy_slugs', type: 'text[]', index: true, optional: true }
+      ]
+    }
+  ]
+}
+
+function derive() {
+  const [schema] = deriveCollectionSchemas({
+    collections: chunkedCollections,
+    dimensions: 1536
+  } as unknown as PgvectorPluginConfig)
+  const byName = new Map<string, PgFieldSchema>(schema.fields.map(f => [f.name, f]))
+  return { schema, byName }
+}
+
+describe('deriveCollectionSchemas — chunk table contract', () => {
+  it('names the table and embeds from chunk_text', () => {
+    const { schema } = derive()
+    expect(schema.name).toBe('posts_pgvector_chunk')
+    expect(schema.embedFrom).toEqual(['chunk_text'])
+    expect(schema.idField).toBe('id')
+  })
+
+  it('exposes the columns mcp-pgvector filters and reads on, with matching types', () => {
+    const { byName } = derive()
+    // Standard chunk columns the probe relies on (parent_doc_id, slug, chunk_text).
+    expect(byName.get('parent_doc_id')?.type).toBe('text')
+    expect(byName.get('chunk_text')?.type).toBe('text')
+    expect(byName.get('chunk_index')?.type).toBe('int')
+    expect(byName.get('slug')?.type).toBe('text')
+    // User scoping column used as the non-overridable taxonomy filter.
+    expect(byName.get('taxonomy_slugs')?.type).toBe('text[]')
+  })
+
+  it('merges the user index flag onto the standard slug column instead of dropping it', () => {
+    const { byName } = derive()
+    expect(byName.get('slug')?.index).toBe(true)
+    // taxonomy_slugs (user field) keeps its index too.
+    expect(byName.get('taxonomy_slugs')?.index).toBe(true)
+  })
+
+  it('appends the embedding vector column at the configured dimensionality', () => {
+    const { byName } = derive()
+    expect(byName.get('embedding')).toMatchObject({ type: 'vector', dimensions: 1536 })
+  })
+})

--- a/packages/payload-pgvector/src/plugin/derive-schema.ts
+++ b/packages/payload-pgvector/src/plugin/derive-schema.ts
@@ -1,0 +1,73 @@
+import type { PgFieldSchema, PgvectorCollectionSchema } from '../adapter/types'
+import type { PgvectorPluginConfig } from './types'
+
+/**
+ * Standard columns the payload-indexer sync emits for CHUNKED collections.
+ * Timestamps are epoch milliseconds (number) → bigint. Must stay in sync with
+ * payload-indexer's document-syncer buildChunkDocument().
+ */
+const chunkStandardFields = (): PgFieldSchema[] => [
+  { name: 'id', type: 'text' },
+  { name: 'parent_doc_id', type: 'text', index: true },
+  { name: 'chunk_index', type: 'int' },
+  { name: 'chunk_text', type: 'text' },
+  { name: 'is_chunk', type: 'bool' },
+  { name: 'headers', type: 'text[]', optional: true },
+  { name: 'createdAt', type: 'bigint', optional: true },
+  { name: 'updatedAt', type: 'bigint', optional: true },
+  { name: 'publishedAt', type: 'bigint', optional: true },
+  { name: 'content_hash', type: 'text', optional: true },
+  { name: 'slug', type: 'text', optional: true }
+]
+
+/** Standard columns the sync emits for FULL-DOCUMENT collections. */
+const docStandardFields = (): PgFieldSchema[] => [
+  { name: 'id', type: 'text' },
+  { name: 'slug', type: 'text', optional: true },
+  { name: 'createdAt', type: 'bigint', optional: true },
+  { name: 'updatedAt', type: 'bigint', optional: true },
+  { name: 'publishedAt', type: 'bigint', optional: true },
+  { name: 'content_hash', type: 'text', optional: true }
+]
+
+/**
+ * Derive pgvector table schemas from the indexer collections config. Adds the
+ * standard sync columns + the embedding vector column to the user-defined
+ * fields, so the table matches exactly what the syncer upserts.
+ */
+export const deriveCollectionSchemas = (config: PgvectorPluginConfig): PgvectorCollectionSchema[] => {
+  const { collections, dimensions, embeddingField = 'embedding', distance = 'cosine' } = config
+  const schemas: PgvectorCollectionSchema[] = []
+
+  for (const [slug, tableConfigs] of Object.entries(collections)) {
+    for (const tableConfig of tableConfigs) {
+      if (!tableConfig.enabled) continue
+
+      const chunked = Boolean(tableConfig.embedding?.chunking)
+      const standard = chunked ? chunkStandardFields() : docStandardFields()
+      const standardNames = new Set(standard.map(f => f.name))
+
+      const userFields: PgFieldSchema[] = tableConfig.fields
+        .filter(field => !standardNames.has(field.name))
+        .map(field => ({
+          name: field.name,
+          type: field.type,
+          index: field.index,
+          optional: field.optional ?? true
+        }))
+
+      const embeddingColumn: PgFieldSchema = { name: embeddingField, type: 'vector', dimensions }
+
+      schemas.push({
+        name: tableConfig.tableName ?? slug,
+        idField: 'id',
+        embeddingField,
+        embedFrom: chunked ? ['chunk_text'] : [],
+        fields: [...standard, ...userFields, embeddingColumn],
+        hnsw: { distance }
+      })
+    }
+  }
+
+  return schemas
+}

--- a/packages/payload-pgvector/src/plugin/derive-schema.ts
+++ b/packages/payload-pgvector/src/plugin/derive-schema.ts
@@ -46,6 +46,15 @@ export const deriveCollectionSchemas = (config: PgvectorPluginConfig): PgvectorC
       const chunked = Boolean(tableConfig.embedding?.chunking)
       const standard = chunked ? chunkStandardFields() : docStandardFields()
       const standardNames = new Set(standard.map(f => f.name))
+      const userByName = new Map(tableConfig.fields.map(f => [f.name, f]))
+
+      // Merge the user's index/optional flags onto standard columns they also
+      // declare (e.g. index:true on slug), instead of silently dropping them.
+      const mergedStandard: PgFieldSchema[] = standard.map(s => {
+        const u = userByName.get(s.name)
+        if (!u) return s
+        return { ...s, index: u.index ?? s.index, optional: u.optional ?? s.optional }
+      })
 
       const userFields: PgFieldSchema[] = tableConfig.fields
         .filter(field => !standardNames.has(field.name))
@@ -63,7 +72,7 @@ export const deriveCollectionSchemas = (config: PgvectorPluginConfig): PgvectorC
         idField: 'id',
         embeddingField,
         embedFrom: chunked ? ['chunk_text'] : [],
-        fields: [...standard, ...userFields, embeddingColumn],
+        fields: [...mergedStandard, ...userFields, embeddingColumn],
         hnsw: { distance }
       })
     }

--- a/packages/payload-pgvector/src/plugin/mcp-descriptor.ts
+++ b/packages/payload-pgvector/src/plugin/mcp-descriptor.ts
@@ -15,7 +15,7 @@ export interface PgvectorMcpDescriptorOptions {
  */
 export const createPgvectorMcpDescriptor = (opts: PgvectorMcpDescriptorOptions): McpDescriptor => ({
   id: opts.id ?? 'pgvector_search',
-  displayName: opts.displayName ?? 'pgvector Search',
+  displayName: opts.displayName ?? 'pgvector Search (experimental)',
   url: opts.url,
   transport: 'http',
   forwardHeaders: ['x-taxonomy-slugs'],

--- a/packages/payload-pgvector/src/plugin/mcp-descriptor.ts
+++ b/packages/payload-pgvector/src/plugin/mcp-descriptor.ts
@@ -8,16 +8,16 @@ export interface PgvectorMcpDescriptorOptions {
 }
 
 /**
- * MCP descriptor for the pgvector search backend. mcp-pgvector is intentionally
- * thin (filters + limit are tool arguments, not headers), so it exposes no
- * header-mapped tunables yet — the descriptor still lets the app register it in
- * the gateway alongside Typesense.
+ * MCP descriptor for the pgvector search backend. mcp-pgvector is thin (no
+ * tunable knobs), but it DOES honour the trusted `x-taxonomy-slugs` scope header
+ * — so the gateway must forward it, otherwise a scoped token/agent would read
+ * the whole corpus.
  */
 export const createPgvectorMcpDescriptor = (opts: PgvectorMcpDescriptorOptions): McpDescriptor => ({
   id: opts.id ?? 'pgvector_search',
   displayName: opts.displayName ?? 'pgvector Search',
   url: opts.url,
   transport: 'http',
-  forwardHeaders: [],
+  forwardHeaders: ['x-taxonomy-slugs'],
   retrievalOptions: []
 })

--- a/packages/payload-pgvector/src/plugin/mcp-descriptor.ts
+++ b/packages/payload-pgvector/src/plugin/mcp-descriptor.ts
@@ -1,0 +1,23 @@
+import type { McpDescriptor } from '@zetesis/payload-indexer'
+
+export interface PgvectorMcpDescriptorOptions {
+  /** Reachable MCP endpoint, e.g. `http://mcp-pgvector:3041/mcp`. */
+  url: string
+  id?: string
+  displayName?: string
+}
+
+/**
+ * MCP descriptor for the pgvector search backend. mcp-pgvector is intentionally
+ * thin (filters + limit are tool arguments, not headers), so it exposes no
+ * header-mapped tunables yet — the descriptor still lets the app register it in
+ * the gateway alongside Typesense.
+ */
+export const createPgvectorMcpDescriptor = (opts: PgvectorMcpDescriptorOptions): McpDescriptor => ({
+  id: opts.id ?? 'pgvector_search',
+  displayName: opts.displayName ?? 'pgvector Search',
+  url: opts.url,
+  transport: 'http',
+  forwardHeaders: [],
+  retrievalOptions: []
+})

--- a/packages/payload-pgvector/src/plugin/types.ts
+++ b/packages/payload-pgvector/src/plugin/types.ts
@@ -1,0 +1,36 @@
+import type { FieldMapping, IndexableCollectionConfig } from '@zetesis/payload-indexer'
+import type { PgvectorAdapter } from '../adapter/pgvector-adapter'
+import type { PgFieldType } from '../adapter/types'
+
+/**
+ * Field mapping for pgvector collections. `type` is the SQL column type used to
+ * build the table. Extends the indexer's base FieldMapping (name/payloadField/
+ * transform), mirroring how TypesenseFieldMapping extends it.
+ */
+export interface PgvectorFieldMapping extends FieldMapping {
+  /** SQL column type for this field. */
+  type: PgFieldType
+  /** Create a btree (scalar) / GIN (text[]) index on this column. */
+  index?: boolean
+  /** Whether the column is nullable. Defaults to true. */
+  optional?: boolean
+}
+
+/**
+ * Config for the pgvector schema-sync plugin. Pair it with createIndexerPlugin
+ * (which handles the actual document sync via hooks). This plugin only ensures
+ * the tables exist on startup — the equivalent of payload-typesense's onInit
+ * schema sync.
+ */
+export interface PgvectorPluginConfig {
+  /** The pgvector adapter (same instance passed to createIndexerPlugin). */
+  adapter: PgvectorAdapter
+  /** Collections to ensure tables for. */
+  collections: IndexableCollectionConfig<PgvectorFieldMapping>
+  /** Embedding dimensionality of the vector column (must match the provider). */
+  dimensions: number
+  /** Name of the vector column. Defaults to `embedding`. */
+  embeddingField?: string
+  /** Distance metric for the HNSW index. Defaults to `cosine`. */
+  distance?: 'cosine' | 'l2' | 'ip'
+}

--- a/packages/payload-pgvector/tsconfig.json
+++ b/packages/payload-pgvector/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "./src" },
+  "references": [{ "path": "../payload-indexer" }],
+  "include": ["src/**/*"]
+}

--- a/packages/payload-pgvector/tsdown.config.ts
+++ b/packages/payload-pgvector/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { resolve: true },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  outDir: 'dist',
+  tsconfig: './tsconfig.json',
+  external: ['@zetesis/payload-indexer', 'payload', 'pg']
+})

--- a/packages/payload-typesense/README.md
+++ b/packages/payload-typesense/README.md
@@ -285,7 +285,7 @@ We are actively working to improve the modularity and flexibility of the plugin.
 *   **LLMs:** Add support for Anthropic (Claude), Mistral, and local LLMs.
 
 ### 4. Admin UI
-*   ~~Dashboard within Payload Admin to view Typesense collection status.~~ **Done** -- `_syncStatus` virtual field via `payload-indexer`
+*   ~~Dashboard within Payload Admin to view Typesense collection status.~~ **Done** -- `_syncStatus_typesense` virtual field via `payload-indexer`
 *   ~~Buttons to manually trigger re-sync or re-indexing.~~ **Done** -- "Sync Now" button in document sidebar
 *   Visual management of RAG agents.
 

--- a/packages/payload-typesense/src/index.ts
+++ b/packages/payload-typesense/src/index.ts
@@ -99,3 +99,10 @@ export {
   DEFAULT_SEARCH_LIMIT,
   DEFAULT_SESSION_TTL_SEC
 } from './core/config/constants'
+
+// ============================================================================
+// MCP DESCRIPTOR
+// ============================================================================
+
+export type { TypesenseMcpDescriptorOptions } from './mcp/descriptor'
+export { createTypesenseMcpDescriptor } from './mcp/descriptor'

--- a/packages/payload-typesense/src/mcp/descriptor.ts
+++ b/packages/payload-typesense/src/mcp/descriptor.ts
@@ -1,0 +1,50 @@
+import type { McpDescriptor, McpRetrievalOption } from '@zetesis/payload-indexer'
+
+export interface TypesenseMcpDescriptorOptions {
+  /** Reachable MCP endpoint, e.g. `http://mcp:3030/mcp`. */
+  url: string
+  id?: string
+  displayName?: string
+}
+
+/** Agent-tunable knobs the Typesense MCP honours, each mapped to a header. */
+const RETRIEVAL_OPTIONS: McpRetrievalOption[] = [
+  {
+    key: 'hybridAlpha',
+    header: 'x-hybrid-alpha',
+    type: 'number',
+    label: 'Hybrid alpha',
+    description: '0 = pure vector, 1 = pure keyword (RRF weight).',
+    defaultValue: 0.9
+  },
+  { key: 'rerankerKind', header: 'x-reranker-kind', type: 'text', label: 'Reranker kind', defaultValue: 'none' },
+  { key: 'rerankerModel', header: 'x-reranker-model', type: 'text', label: 'Reranker model' },
+  { key: 'inputK', header: 'x-input-k', type: 'number', label: 'Vector recall (k)' },
+  { key: 'topK', header: 'x-top-k', type: 'number', label: 'Top K returned' },
+  { key: 'queryRewriteTemplate', header: 'x-query-rewrite-template', type: 'text', label: 'Query rewrite template' }
+]
+
+/** Context headers the MCP consumes per request (not agent knobs, but must forward). */
+const CONTEXT_HEADERS = [
+  'x-tenant-slug',
+  'x-taxonomy-slugs',
+  'x-folder-slugs',
+  'x-retrieval-profile',
+  'x-retrieval-profiles',
+  'x-group-profiles',
+  'x-learned-head'
+]
+
+/**
+ * MCP descriptor for the Typesense search backend. The app supplies the
+ * deployment URL; the rest (tunable options + forwarded headers) is fixed by
+ * what mcp-typesense honours.
+ */
+export const createTypesenseMcpDescriptor = (opts: TypesenseMcpDescriptorOptions): McpDescriptor => ({
+  id: opts.id ?? 'typesense_search',
+  displayName: opts.displayName ?? 'Typesense Search',
+  url: opts.url,
+  transport: 'http',
+  forwardHeaders: [...CONTEXT_HEADERS, ...RETRIEVAL_OPTIONS.map(o => o.header)],
+  retrievalOptions: RETRIEVAL_OPTIONS
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@zetesis/payload-lexical-blocks-builder':
         specifier: workspace:*
         version: link:../../packages/payload-lexical-blocks-builder
+      '@zetesis/payload-pgvector':
+        specifier: workspace:*
+        version: link:../../packages/payload-pgvector
       '@zetesis/payload-taxonomies':
         specifier: workspace:*
         version: link:../../packages/payload-taxonomies
@@ -210,6 +213,37 @@ importers:
         specifier: ^5.0.0
         version: 5.7.3
 
+  packages/mcp-pgvector:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@zetesis/payload-pgvector':
+        specifier: workspace:*
+        version: link:../payload-pgvector
+      pg:
+        specifier: ^8.13.1
+        version: 8.16.3
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.5.4
+        version: 22.19.13
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+      tsdown:
+        specifier: ^0.16.5
+        version: 0.16.8(typescript@5.7.3)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   packages/mcp-typesense:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -263,7 +297,7 @@ importers:
         version: 2.1.0
       drizzle-orm:
         specifier: '>=0.36'
-        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.10.2)(bun-types@1.3.11)(pg@8.16.3)
+        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(pg@8.16.3)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -303,7 +337,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: '>=0.36'
-        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.10.2)(bun-types@1.3.11)(pg@8.16.3)
+        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(pg@8.16.3)
       tailwind-merge:
         specifier: ^3.0.0
         version: 3.5.0
@@ -451,6 +485,37 @@ importers:
         version: 0.16.8(typescript@5.7.3)
       typescript:
         specifier: ^5.0.0
+        version: 5.7.3
+
+  packages/payload-pgvector:
+    dependencies:
+      '@zetesis/payload-indexer':
+        specifier: workspace:*
+        version: link:../payload-indexer
+      payload:
+        specifier: ^3.81.0
+        version: 3.81.0(graphql@16.13.1)(typescript@5.7.3)
+      pg:
+        specifier: ^8.13.1
+        version: 8.16.3
+      zod:
+        specifier: ^4.1.11
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.5.4
+        version: 22.19.13
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+      tsdown:
+        specifier: ^0.16.5
+        version: 0.16.8(typescript@5.7.3)
+      typescript:
+        specifier: 5.7.3
         version: 5.7.3
 
   packages/payload-taxonomies:
@@ -3605,6 +3670,9 @@ packages:
 
   '@types/pg@8.10.2':
     resolution: {integrity: sha512-MKFs9P6nJ+LAeHLU3V0cODEOgyThJ3OAnmOlsZsxux6sfQs3HRXR5bBn7xG5DjckEFhTAxsXi7k7cd0pCMxpJw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
@@ -10831,6 +10899,12 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 4.1.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.13
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
       '@types/react': 19.1.8
@@ -11714,6 +11788,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.10.2
+      bun-types: 1.3.11
+      pg: 8.16.3
+
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(pg@8.16.3):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/pg': 8.20.0
       bun-types: 1.3.11
       pg: 8.16.3
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,6 +56,12 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node"
     },
+    "packages/payload-pgvector": {
+      "package-name": "@zetesis/payload-pgvector",
+      "component": "payload-pgvector",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node"
+    },
     "packages/payload-taxonomies": {
       "package-name": "@zetesis/payload-taxonomies",
       "component": "payload-taxonomies",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
   "references": [
     { "path": "./packages/agent-ui" },
     { "path": "./packages/payload-indexer" },
+    { "path": "./packages/mcp-pgvector" },
     { "path": "./packages/payload-lexical-blocks-builder" },
+    { "path": "./packages/payload-pgvector" },
     { "path": "./packages/payload-taxonomies" },
     { "path": "./packages/payload-typesense" }
   ],

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,5 +4,6 @@ export default [
   'packages/payload-agents-core',
   'packages/payload-agents-metrics',
   'packages/payload-indexer',
+  'packages/payload-pgvector',
   'packages/payload-typesense'
 ]

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,4 +1,5 @@
 export default [
+  'packages/mcp-pgvector',
   'packages/mcp-typesense',
   'packages/nexus-queue',
   'packages/payload-agents-core',


### PR DESCRIPTION
> **Draft — not for merge yet.** Adds a Postgres + pgvector indexing/search backend that runs **in parallel** with Typesense for side-by-side evaluation. Nothing about Typesense is removed or changed in behavior.

## What this adds

- **`@zetesis/payload-pgvector`** (new OSS package) — implements the `payload-indexer` `IndexerAdapter` over Postgres + pgvector, sibling of `payload-typesense`. Embeddings are generated app-side via any OpenAI-compatible endpoint (a LiteLLM gateway here). Includes:
  - `PgvectorAdapter` (ensureCollection = `CREATE EXTENSION` + table + HNSW; type-aware SQL filters; `vectorSearch`/`searchByText`).
  - `OpenAICompatibleEmbeddingProvider` (configurable `base_url`).
  - `createPgvectorPlugin` (onInit schema sync) + `deriveCollectionSchemas` (derives the SQL table from the indexer collections config, incl. the standard chunk columns).
- **`payload-indexer`** — namespacing so two indexers can coexist on the same collections. **Breaking**: sync-status field is now `_syncStatus_<adapter>` and endpoints `/api/sync-status-<adapter>/...`.
- **`@zetesis/mcp-pgvector`** (new private package) — a deliberately thin, pgvector-native MCP (`search_collections`, `get_chunks_by_parent`, `get_chunks_by_ids`). Built to compare retrieval against `mcp-typesense` **without** sharing its Typesense-shaped contract (see "why thin" below).
- **`apps/server`** — wires the pgvector indexer alongside Typesense so the same `posts` collection syncs to both.
- **devcontainer** — `pgvector/pgvector:pg17` image + an `embeddings-dev` LiteLLM model.

## Why a thin throwaway MCP instead of one abstraction

Abstracting `mcp-typesense` behind a shared `SearchProvider` is not a code refactor — it's a contract migration. The MCP's behavior is a semantic contract with the agent shaped by Typesense quirks (`total_found` as a vector-k cap, hybrid RRF/`alpha`, score scales) that don't map cleanly to pgvector. A permanent dual-backend abstraction is a maintenance trap; it's only worth it as a one-way migration when Typesense is being retired. So for evaluation we keep them separate.

## Verified (devcontainer, end-to-end)

- Both indexers init on boot; re-saving a post syncs to **both** `posts_chunk` (Typesense) and `posts_pgvector_chunk` (pgvector) with a real 1536-dim embedding via LiteLLM.
- `mcp-pgvector` over real MCP protocol: client handshake → `search_collections` embeds the query via LiteLLM → SQL → returns the chunk.
- `pnpm lint`, `pnpm tsc --noEmit`, and per-package `build` all clean. (Full `next build` not run; the dev server boots and indexes successfully.)

## Not in scope (follow-ups if pgvector wins the A/B)

- Hybrid (tsvector + vector fusion), facets/grouping for parity.
- Contract-neutralization migration + retiring Typesense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)