### PR TITLE
feat: pgvector adapter + thin MCP server (A/B vs Typesense)

### DIFF
--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -8,6 +8,10 @@ TYPESENSE_HOST=typesense
 TYPESENSE_PORT=8108
 TYPESENSE_PROTOCOL=http
 
+# Active search backend — drives BOTH the indexer plugin in apps/server and the
+# wrapper in apps/mcp. Flip to `pgvector` to index into and search pgvector.
+SEARCH_BACKEND=typesense
+
 # MCP
 MCP_PORT=3030
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,11 @@
 services:
   db:
-    image: postgres:17-alpine
+    # pgvector image (Debian/glibc) instead of postgres:17-alpine: provides the
+    # `vector` extension so @zetesis/payload-pgvector can be evaluated locally.
+    # Still a plain Postgres — the extension is enabled via `CREATE EXTENSION vector`.
+    # NOTE: switching from the alpine (musl) image requires recreating the volume
+    # (`docker compose down -v`) — the data dirs are not compatible.
+    image: pgvector/pgvector:pg17
     restart: always
     volumes:
       - postgres_data:/var/lib/postgresql/data
@@ -134,7 +139,7 @@ services:
     environment:
       LITELLM_URL: http://litellm:4000
       LITELLM_CATALOG_JSON: >-
-        [{"name":"chat-estandar","model":"openai/gpt-4o-mini","description":"Chat general — rápido y económico","requiresKey":"openai","tier":"standard"},{"name":"chat-premium","model":"anthropic/claude-sonnet-4-6","description":"Máxima calidad para agentes de cara al cliente","requiresKey":"anthropic","tier":"premium"},{"name":"razonador","model":"openai/o4-mini","description":"Razonamiento y análisis","requiresKey":"openai","tier":"standard"},{"name":"economico","model":"gemini/gemini-2.5-flash","description":"Volúmenes altos a mínimo coste","requiresKey":"google","tier":"economy"}]
+        [{"name":"chat-estandar","model":"openai/gpt-4o-mini","description":"Chat general — rápido y económico","requiresKey":"openai","tier":"standard"},{"name":"chat-premium","model":"anthropic/claude-sonnet-4-6","description":"Máxima calidad para agentes de cara al cliente","requiresKey":"anthropic","tier":"premium"},{"name":"razonador","model":"openai/o4-mini","description":"Razonamiento y análisis","requiresKey":"openai","tier":"standard"},{"name":"economico","model":"gemini/gemini-2.5-flash","description":"Volúmenes altos a mínimo coste","requiresKey":"google","tier":"economy"},{"name":"embeddings-dev","model":"openai/text-embedding-3-small","description":"Embeddings para retrieval vectorial (payload-pgvector). Alias estable: pinéalo en index y query","requiresKey":"openai","tier":"standard"}]
     entrypoint: ["python"]
     command: ["/app/bootstrap_catalog.py"]
     volumes:

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -10,6 +10,7 @@
     "start": "bun src/index.ts"
   },
   "dependencies": {
+    "@zetesis/mcp-pgvector": "workspace:*",
     "@zetesis/mcp-typesense": "workspace:*"
   },
   "devDependencies": {

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,14 +1,17 @@
 /**
- * MCP server using @zetesis/mcp-typesense.
+ * MCP server — selects its search backend from `SEARCH_BACKEND` so it always
+ * matches the indexer plugin active in `apps/server`:
  *
- * Thin wrapper around `@zetesis/mcp-typesense` with env-var config.
- * All the runtime (tools, resources, transport, sampling) lives in the
- * package; this file is just:
- * - Env-var reading
- * - Collection topology (posts_chunk, books_chunk)
- * - Server instructions and guide markdown
+ *   SEARCH_BACKEND=typesense → @zetesis/mcp-typesense (default)
+ *   SEARCH_BACKEND=pgvector  → @zetesis/mcp-pgvector
+ *
+ * Both apps read the same env var, so the read side (this MCP) and the write
+ * side (the indexer plugin in apps/server) can never desync onto different
+ * backends. All runtime (tools, resources, transport) lives in the packages;
+ * this file is just env-var reading + collection topology.
  */
 
+import { createPgvectorMcpServer } from '@zetesis/mcp-pgvector'
 import {
   createMcpServer,
   DEFAULT_GUIDE,
@@ -17,62 +20,106 @@ import {
 
 const PAYLOAD_API_URL = process.env.PAYLOAD_API_URL || 'http://localhost:3000'
 const PORT = parseInt(process.env.MCP_PORT || '3001', 10)
+const SEARCH_BACKEND =
+  process.env.SEARCH_BACKEND === 'pgvector' ? 'pgvector' : 'typesense'
 
-const mcp = createMcpServer({
-  server: {
-    name: 'mcp-typesense',
-    version: '0.1.0',
-    instructions: DEFAULT_INSTRUCTIONS,
-  },
-  transport: {
-    port: PORT,
-  },
-  typesense: {
-    host: process.env.TYPESENSE_HOST || '127.0.0.1',
-    port: parseInt(process.env.TYPESENSE_PORT || '8108', 10),
-    protocol: (process.env.TYPESENSE_PROTOCOL as 'http' | 'https') || 'http',
-    apiKey: process.env.TYPESENSE_API_KEY || 'xyz',
-  },
-  embeddings: {
-    provider: 'openai',
-    apiKey: process.env.OPENAI_API_KEY || '',
-    model: 'text-embedding-3-small',
-    dimensions: 1536,
-  },
-  collections: [
-    {
-      key: 'posts',
-      displayName: 'Posts (Chunks)',
-      chunkCollection: 'posts_chunk',
-      parentCollection: 'posts',
-      chunkSearchFields: ['chunk_text', 'title'],
-      chunkFacetFields: ['tenant', 'taxonomy_slugs', 'folder_slugs', 'parent_doc_id', 'headers'],
-      kind: 'document',
+function createTypesenseBackend() {
+  return createMcpServer({
+    server: {
+      name: 'mcp-typesense',
+      version: '0.1.0',
+      instructions: DEFAULT_INSTRUCTIONS,
     },
-    {
-      key: 'books',
-      displayName: 'Books (Chunks)',
-      chunkCollection: 'books_chunk',
-      parentCollection: 'books',
-      chunkSearchFields: ['chunk_text', 'title'],
-      chunkFacetFields: ['tenant', 'taxonomy_slugs', 'folder_slugs', 'parent_doc_id', 'headers'],
-      kind: 'book',
+    transport: {
+      port: PORT,
     },
-  ],
-  taxonomy: {
-    source: { type: 'payload-rest', baseUrl: PAYLOAD_API_URL },
-  },
-  content: {
-    source: { type: 'payload-rest', baseUrl: PAYLOAD_API_URL },
-  },
-  resources: {
-    guide: DEFAULT_GUIDE,
-  },
-  auth: {
-    type: 'header',
-    headerName: 'x-tenant-slug',
-  },
-})
+    typesense: {
+      host: process.env.TYPESENSE_HOST || '127.0.0.1',
+      port: parseInt(process.env.TYPESENSE_PORT || '8108', 10),
+      protocol: (process.env.TYPESENSE_PROTOCOL as 'http' | 'https') || 'http',
+      apiKey: process.env.TYPESENSE_API_KEY || 'xyz',
+    },
+    embeddings: {
+      provider: 'openai',
+      apiKey: process.env.OPENAI_API_KEY || '',
+      model: 'text-embedding-3-small',
+      dimensions: 1536,
+    },
+    collections: [
+      {
+        key: 'posts',
+        displayName: 'Posts (Chunks)',
+        chunkCollection: 'posts_chunk',
+        parentCollection: 'posts',
+        chunkSearchFields: ['chunk_text', 'title'],
+        chunkFacetFields: ['tenant', 'taxonomy_slugs', 'folder_slugs', 'parent_doc_id', 'headers'],
+        kind: 'document',
+      },
+      {
+        key: 'books',
+        displayName: 'Books (Chunks)',
+        chunkCollection: 'books_chunk',
+        parentCollection: 'books',
+        chunkSearchFields: ['chunk_text', 'title'],
+        chunkFacetFields: ['tenant', 'taxonomy_slugs', 'folder_slugs', 'parent_doc_id', 'headers'],
+        kind: 'book',
+      },
+    ],
+    taxonomy: {
+      source: { type: 'payload-rest', baseUrl: PAYLOAD_API_URL },
+    },
+    content: {
+      source: { type: 'payload-rest', baseUrl: PAYLOAD_API_URL },
+    },
+    resources: {
+      guide: DEFAULT_GUIDE,
+    },
+    auth: {
+      type: 'header',
+      headerName: 'x-tenant-slug',
+    },
+  })
+}
+
+function createPgvectorBackend() {
+  return createPgvectorMcpServer({
+    server: {
+      name: 'mcp-pgvector',
+      version: '0.1.0',
+      instructions:
+        'Thin pgvector search probe. Query by concept (no author/meta words). Scores are raw vector distances ' +
+        '(lower = closer) — do not threshold. Filters map to SQL WHERE; array columns (taxonomy_slugs) use overlap.',
+    },
+    transport: { port: PORT },
+    connectionString: process.env.DATABASE_URL || '',
+    schema: process.env.MCP_PGVECTOR_SCHEMA || 'pgvector',
+    embedding: {
+      // MUST match the app-side indexer (same model + dimensions) or similarity
+      // is garbage. The indexer routes through the LiteLLM `embeddings-dev` alias.
+      baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
+      apiKey: process.env.LITELLM_MASTER_KEY || '',
+      model: process.env.MCP_PGVECTOR_EMBED_MODEL || 'embeddings-dev',
+      dimensions: parseInt(process.env.MCP_PGVECTOR_EMBED_DIMS || '1536', 10),
+      sendDimensions: process.env.MCP_PGVECTOR_SEND_DIMS !== 'false',
+    },
+    requireScope: process.env.MCP_PGVECTOR_REQUIRE_SCOPE === 'true',
+    collections: [
+      {
+        name: 'posts_pgvector_chunk',
+        displayName: 'Posts (pgvector)',
+        distance: 'cosine',
+        filterColumns: {
+          parent_doc_id: 'text',
+          slug: 'text',
+          taxonomy_slugs: 'text[]',
+        },
+      },
+    ],
+  })
+}
+
+const mcp =
+  SEARCH_BACKEND === 'pgvector' ? createPgvectorBackend() : createTypesenseBackend()
 
 await mcp.listen()
-console.error(`MCP server running on http://0.0.0.0:${mcp.port}`)
+console.error(`MCP server [${SEARCH_BACKEND}] running on http://0.0.0.0:${mcp.port}`)

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -24,6 +24,7 @@
     "@zetesis/payload-documents": "workspace:*",
     "@zetesis/payload-indexer": "workspace:*",
     "@zetesis/payload-lexical-blocks-builder": "workspace:*",
+    "@zetesis/payload-pgvector": "workspace:*",
     "@zetesis/payload-taxonomies": "workspace:*",
     "@zetesis/payload-typesense": "workspace:*",
     "@toon-format/toon": "^2.1.0",

--- a/apps/server/src/payload.config.ts
+++ b/apps/server/src/payload.config.ts
@@ -14,6 +14,7 @@ import { Posts } from './collections/Posts'
 import { Taxonomies } from './collections/Taxonomies'
 import { Users } from './collections/Users'
 import { defaultLocale, locales } from './i18n/locales'
+import { pgvectorPlugin } from './plugins/pgvector'
 import { typesensePlugin } from './plugins/typesense'
 
 const filename = fileURLToPath(import.meta.url)
@@ -55,8 +56,11 @@ export default buildConfig({
   },
   plugins: (() => {
     const metrics = metricsPlugin({ multiTenant: false, basePath: '/metrics' })
+    // Single active search backend, selected by the same env var apps/mcp reads,
+    // so the write side (this indexer) and the read side (the MCP) never desync.
+    const searchPlugin = process.env.SEARCH_BACKEND === 'pgvector' ? pgvectorPlugin : typesensePlugin
     return [
-      typesensePlugin,
+      searchPlugin,
       agentPlugin({
         runtimeUrl: process.env.AGENT_RUNTIME_URL || 'http://localhost:8000',
         runtimeSecret: process.env.INTERNAL_SECRET,

--- a/apps/server/src/plugins/pgvector/collections.ts
+++ b/apps/server/src/plugins/pgvector/collections.ts
@@ -1,0 +1,42 @@
+import type { IndexableCollectionConfig } from '@zetesis/payload-indexer'
+import type { PgvectorFieldMapping } from '@zetesis/payload-pgvector'
+import { createDynamicContentTransform, transformCategories } from '../typesense/transforms'
+
+/**
+ * pgvector indexing config — mirrors the Typesense `posts_chunk` table so both
+ * backends index the same content in parallel. Only the chunked table is
+ * configured (it's the one that gets embedded + vector-searched). Field `type`
+ * is the SQL column type; the standard chunk columns (parent_doc_id,
+ * chunk_text, timestamps, ...) and the `embedding vector(N)` column are added
+ * automatically by the schema derivation.
+ */
+export const pgvectorCollections: IndexableCollectionConfig<PgvectorFieldMapping> = {
+  posts: [
+    {
+      enabled: true,
+      tableName: 'posts_pgvector_chunk',
+      displayName: 'Posts (pgvector)',
+      syncDepth: 1,
+      embedding: {
+        fields: [{ field: 'content', transform: createDynamicContentTransform() }],
+        chunking: { strategy: 'markdown', size: 2000, overlap: 300 },
+        // pgvector embeds app-side via the adapter's EmbeddingProvider; this
+        // autoEmbed block is unused by the backend but required by the type.
+        autoEmbed: { from: ['chunk_text'], modelConfig: {} }
+      },
+      fields: [
+        { name: 'title', type: 'text' },
+        { name: 'slug', type: 'text', index: true },
+        { name: 'publishedAt', type: 'bigint', optional: true },
+        {
+          name: 'taxonomy_slugs',
+          type: 'text[]',
+          index: true,
+          optional: true,
+          transform: transformCategories,
+          payloadField: 'categories'
+        }
+      ]
+    }
+  ]
+}

--- a/apps/server/src/plugins/pgvector/config.ts
+++ b/apps/server/src/plugins/pgvector/config.ts
@@ -1,0 +1,25 @@
+import type { OpenAICompatibleEmbeddingConfig } from '@zetesis/payload-pgvector'
+
+/** Postgres connection for the pgvector tables (same DB as Payload). */
+export const pgvectorConnectionString = process.env.DATABASE_URL || ''
+
+/**
+ * Dedicated Postgres schema for the pgvector tables. Keeps them OUT of `public`
+ * so Payload/Drizzle's schema push doesn't treat them as unmanaged and drop them.
+ */
+export const pgvectorSchema = 'pgvector'
+
+/**
+ * Embedding routed through the LiteLLM gateway (OpenAI-compatible). The
+ * `embeddings-dev` alias is seeded in the devcontainer LiteLLM catalog and
+ * pins `text-embedding-3-small` (1536 dims). Index-time and query-time MUST use
+ * this same alias.
+ */
+export const pgvectorEmbedding: OpenAICompatibleEmbeddingConfig = {
+  baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
+  apiKey: process.env.LITELLM_MASTER_KEY || '',
+  model: 'embeddings-dev',
+  dimensions: 1536,
+  // text-embedding-3-small honours dimensionality reduction, so pin it explicitly.
+  sendDimensions: true
+}

--- a/apps/server/src/plugins/pgvector/index.ts
+++ b/apps/server/src/plugins/pgvector/index.ts
@@ -1,0 +1,38 @@
+import { createIndexerPlugin } from '@zetesis/payload-indexer'
+import { createPgvectorAdapter, createPgvectorPlugin } from '@zetesis/payload-pgvector'
+import type { Config } from 'payload'
+import { pgvectorCollections } from './collections'
+import { pgvectorConnectionString, pgvectorEmbedding, pgvectorSchema } from './config'
+
+export { pgvectorCollections } from './collections'
+
+// Shared adapter instance: createIndexerPlugin uses it for document sync (hooks),
+// createPgvectorPlugin uses it for schema sync (onInit ensureCollection).
+const adapter = createPgvectorAdapter({
+  connectionString: pgvectorConnectionString,
+  embedding: pgvectorEmbedding,
+  schema: pgvectorSchema
+})
+
+const { plugin: indexerPlugin } = createIndexerPlugin({
+  adapter,
+  features: {
+    sync: {
+      enabled: true,
+      defaultColumns: ['title', '_syncStatus', 'slug']
+    }
+  },
+  collections: pgvectorCollections
+})
+
+const schemaPlugin = createPgvectorPlugin({
+  adapter,
+  collections: pgvectorCollections,
+  dimensions: pgvectorEmbedding.dimensions
+})
+
+export const pgvectorPlugin = (config: Config): Config => {
+  config = indexerPlugin(config)
+  config = schemaPlugin(config)
+  return config
+}

--- a/packages/mcp-pgvector/README.md
+++ b/packages/mcp-pgvector/README.md
@@ -1,0 +1,37 @@
+# @zetesis/mcp-pgvector
+
+A deliberately **thin** MCP server over a pgvector-backed index
+(`@zetesis/payload-pgvector`). Built for **A/B comparison against
+`@zetesis/mcp-typesense`** — it does NOT share a search contract with it
+(score scale, total counts, no hybrid/RRF, no facets are pgvector-native on
+purpose). Private/internal (not published).
+
+Three read tools: `search_collections`, `get_chunks_by_parent`, `get_chunks_by_ids`.
+
+## Run (standalone, for evaluation)
+
+Index some content into the `pgvector` schema (via `@zetesis/payload-pgvector` +
+`createIndexerPlugin`, or a seed that calls `adapter.upsertDocuments`), then:
+
+```bash
+DATABASE_URL=postgres://... \
+LITELLM_PROXY_URL=http://litellm:4000/v1 \
+LITELLM_MASTER_KEY=... \
+MCP_PGVECTOR_PORT=3041 \
+node dist/standalone.mjs
+# → [mcp-pgvector] running on http://0.0.0.0:3041/mcp
+```
+
+Then point an MCP client (or LiteLLM) at `http://localhost:3041/mcp` and compare
+results against the Typesense MCP for the same queries.
+
+## Security
+
+- The trusted `x-taxonomy-slugs` header scopes every query as a **non-overridable**
+  `taxonomy_slugs` filter (a client cannot widen it).
+- `MCP_PGVECTOR_REQUIRE_SCOPE=true` denies unscoped requests (deny-by-default) where
+  every caller is expected to be tenant-scoped.
+- Collection names are **allowlisted** to the configured tables; the SQL identifier
+  guard alone would otherwise let any table in the schema be queried.
+- Listens on `0.0.0.0` with no auth of its own — run it behind a trusted proxy /
+  NetworkPolicy, never directly exposed.

--- a/packages/mcp-pgvector/README.md
+++ b/packages/mcp-pgvector/README.md
@@ -27,8 +27,10 @@ results against the Typesense MCP for the same queries.
 
 ## Security
 
-- The trusted `x-taxonomy-slugs` header scopes every query as a **non-overridable**
-  `taxonomy_slugs` filter (a client cannot widen it).
+- Trusted headers scope every query as **non-overridable** filters (a client cannot
+  widen them): `x-tenant-slug` → a hard `tenant` boundary, `x-taxonomy-slugs` → an
+  optional `taxonomy_slugs` refinement. For a multi-tenant deployment the table must
+  have a `tenant` column and the proxy must always inject `x-tenant-slug`.
 - `MCP_PGVECTOR_REQUIRE_SCOPE=true` denies unscoped requests (deny-by-default) where
   every caller is expected to be tenant-scoped.
 - Collection names are **allowlisted** to the configured tables; the SQL identifier

--- a/packages/mcp-pgvector/package.json
+++ b/packages/mcp-pgvector/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@zetesis/mcp-pgvector",
+  "version": "0.0.0",
+  "description": "Thin MCP server over a pgvector-backed index (@zetesis/payload-pgvector). Built for A/B comparison against mcp-typesense — deliberately minimal, no shared search contract.",
+  "license": "MIT",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./dist/index.d.mts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "start": "node dist/standalone.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@zetesis/payload-pgvector": "workspace:*",
+    "pg": "^8.13.1",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.4",
+    "@types/pg": "^8.11.10",
+    "rimraf": "3.0.2",
+    "tsdown": "^0.16.5",
+    "typescript": "5.7.3"
+  },
+  "engines": {
+    "node": ">=22",
+    "pnpm": "^9 || ^10"
+  }
+}

--- a/packages/mcp-pgvector/src/index.ts
+++ b/packages/mcp-pgvector/src/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @zetesis/mcp-pgvector
+ *
+ * Thin MCP server over a pgvector index, for A/B comparison against
+ * @zetesis/mcp-typesense. Intentionally minimal and pgvector-native — it does
+ * not emulate Typesense's retrieval semantics.
+ */
+
+export type {
+  PgvectorMcpCollection,
+  PgvectorMcpConfig,
+  PgvectorMcpHandle
+} from './server'
+export { createPgvectorMcpServer } from './server'

--- a/packages/mcp-pgvector/src/scope.spec.ts
+++ b/packages/mcp-pgvector/src/scope.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseScopeHeader, scopeDenied, scopeFilter } from './scope'
+import { parseScopeHeader, parseTenantHeader, scopeDenied, scopeFilter } from './scope'
 
 describe('parseScopeHeader', () => {
   it('splits, trims and drops empties', () => {
@@ -16,27 +16,49 @@ describe('parseScopeHeader', () => {
   })
 })
 
+describe('parseTenantHeader', () => {
+  it('returns the trimmed single slug (first value of an array)', () => {
+    expect(parseTenantHeader(' acme ')).toBe('acme')
+    expect(parseTenantHeader(['acme', 'other'])).toBe('acme')
+  })
+
+  it('returns null for missing or empty', () => {
+    expect(parseTenantHeader(undefined)).toBeNull()
+    expect(parseTenantHeader('')).toBeNull()
+    expect(parseTenantHeader('   ')).toBeNull()
+  })
+})
+
 describe('scopeFilter', () => {
-  it('forces taxonomy_slugs from the scope, overriding any client value', () => {
-    expect(scopeFilter({ taxonomy_slugs: ['mises'], parent_doc_id: '1' }, ['bastos'])).toEqual({
-      taxonomy_slugs: ['bastos'],
+  it('forces tenant + taxonomy_slugs, overriding any client value', () => {
+    expect(
+      scopeFilter(
+        { tenant: 'evil', taxonomy_slugs: ['mises'], parent_doc_id: '1' },
+        { tenant: 'acme', taxonomySlugs: ['bastos'] }
+      )
+    ).toEqual({ tenant: 'acme', taxonomy_slugs: ['bastos'], parent_doc_id: '1' })
+  })
+
+  it('forces tenant even with no taxonomy (hard boundary)', () => {
+    expect(scopeFilter({ parent_doc_id: '1' }, { tenant: 'acme', taxonomySlugs: [] })).toEqual({
+      tenant: 'acme',
       parent_doc_id: '1'
     })
   })
 
-  it('leaves the filter untouched when there is no scope', () => {
-    expect(scopeFilter({ parent_doc_id: '1' }, [])).toEqual({ parent_doc_id: '1' })
+  it('leaves the filter untouched when fully unscoped (single-tenant, broad)', () => {
+    expect(scopeFilter({ parent_doc_id: '1' }, { tenant: null, taxonomySlugs: [] })).toEqual({ parent_doc_id: '1' })
   })
 })
 
 describe('scopeDenied (deny-by-default)', () => {
-  it('denies an unscoped request only when the server requires a scope', () => {
-    expect(scopeDenied([], true)).toBe(true)
-    expect(scopeDenied([], false)).toBe(false)
+  it('denies only a fully-unscoped request when the server requires a scope', () => {
+    expect(scopeDenied({ tenant: null, taxonomySlugs: [] }, true)).toBe(true)
+    expect(scopeDenied({ tenant: null, taxonomySlugs: [] }, false)).toBe(false)
   })
 
-  it('never denies a scoped request', () => {
-    expect(scopeDenied(['bastos'], true)).toBe(false)
-    expect(scopeDenied(['bastos'], false)).toBe(false)
+  it('never denies a request scoped by tenant or taxonomy', () => {
+    expect(scopeDenied({ tenant: 'acme', taxonomySlugs: [] }, true)).toBe(false)
+    expect(scopeDenied({ tenant: null, taxonomySlugs: ['bastos'] }, true)).toBe(false)
   })
 })

--- a/packages/mcp-pgvector/src/scope.spec.ts
+++ b/packages/mcp-pgvector/src/scope.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { parseScopeHeader, scopeDenied, scopeFilter } from './scope'
+
+describe('parseScopeHeader', () => {
+  it('splits, trims and drops empties', () => {
+    expect(parseScopeHeader(' bastos , mises ,,')).toEqual(['bastos', 'mises'])
+  })
+
+  it('joins an array header before parsing', () => {
+    expect(parseScopeHeader(['bastos', 'mises'])).toEqual(['bastos', 'mises'])
+  })
+
+  it('returns [] for missing or empty header', () => {
+    expect(parseScopeHeader(undefined)).toEqual([])
+    expect(parseScopeHeader('')).toEqual([])
+  })
+})
+
+describe('scopeFilter', () => {
+  it('forces taxonomy_slugs from the scope, overriding any client value', () => {
+    expect(scopeFilter({ taxonomy_slugs: ['mises'], parent_doc_id: '1' }, ['bastos'])).toEqual({
+      taxonomy_slugs: ['bastos'],
+      parent_doc_id: '1'
+    })
+  })
+
+  it('leaves the filter untouched when there is no scope', () => {
+    expect(scopeFilter({ parent_doc_id: '1' }, [])).toEqual({ parent_doc_id: '1' })
+  })
+})
+
+describe('scopeDenied (deny-by-default)', () => {
+  it('denies an unscoped request only when the server requires a scope', () => {
+    expect(scopeDenied([], true)).toBe(true)
+    expect(scopeDenied([], false)).toBe(false)
+  })
+
+  it('never denies a scoped request', () => {
+    expect(scopeDenied(['bastos'], true)).toBe(false)
+    expect(scopeDenied(['bastos'], false)).toBe(false)
+  })
+})

--- a/packages/mcp-pgvector/src/scope.ts
+++ b/packages/mcp-pgvector/src/scope.ts
@@ -1,11 +1,20 @@
 /**
- * Trusted taxonomy-scope logic for mcp-pgvector, kept pure and unit-testable.
+ * Trusted scope logic for mcp-pgvector, kept pure and unit-testable. The
+ * security-critical decision of WHAT a request may read lives here, not inline
+ * in the HTTP/tool handlers.
  *
- * The security-critical decision of WHAT a request may read lives here, not
- * inline in the HTTP/tool handlers. The scope arrives via the trusted
- * `x-taxonomy-slugs` header (injected by the Payload proxy / forwarded by
- * LiteLLM); a client cannot widen it.
+ * Two trusted headers (injected by the Payload proxy / forwarded by LiteLLM):
+ *   - `x-tenant-slug`    → a HARD tenant boundary (a single slug)
+ *   - `x-taxonomy-slugs` → an OPTIONAL content refinement (a slug list)
+ * Both are forced as NON-overridable filters — a client cannot widen them.
  */
+
+export interface RequestScope {
+  /** Hard tenant boundary; null on a single-tenant deployment. */
+  tenant: string | null
+  /** Optional taxonomy refinement; empty = the whole (tenant's) corpus. */
+  taxonomySlugs: string[]
+}
 
 /** Parse the `x-taxonomy-slugs` header into a clean slug list. */
 export function parseScopeHeader(raw: string | string[] | undefined): string[] {
@@ -17,21 +26,32 @@ export function parseScopeHeader(raw: string | string[] | undefined): string[] {
     .filter(Boolean)
 }
 
-/**
- * Force the scope onto a filter as a NON-overridable `taxonomy_slugs` filter —
- * the scope always wins over any client-supplied `taxonomy_slugs`. With no
- * scope the filter is returned unchanged (see {@link scopeDenied} for the
- * deny-by-default guard that must gate this case).
- */
-export function scopeFilter(filter: Record<string, unknown>, scope: string[]): Record<string, unknown> {
-  return scope.length > 0 ? { ...filter, taxonomy_slugs: scope } : filter
+/** Parse the `x-tenant-slug` header into a single slug (or null). */
+export function parseTenantHeader(raw: string | string[] | undefined): string | null {
+  const value = Array.isArray(raw) ? raw[0] : raw
+  const tenant = value?.trim()
+  return tenant ? tenant : null
 }
 
 /**
- * Deny-by-default guard. When the server is configured to require a scope and a
- * request carries none, it must read NOTHING rather than the whole corpus.
- * Callers check this before querying and short-circuit to an empty result.
+ * Force the scope onto a filter as NON-overridable filters — the trusted scope
+ * always wins over any client-supplied `tenant` / `taxonomy_slugs`. A null
+ * tenant / empty taxonomy leaves that dimension unconstrained (single-tenant
+ * deployment / a deliberately broad token). {@link scopeDenied} guards the
+ * fully-unscoped case.
  */
-export function scopeDenied(scope: string[], requireScope: boolean): boolean {
-  return requireScope && scope.length === 0
+export function scopeFilter(filter: Record<string, unknown>, scope: RequestScope): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...filter }
+  if (scope.tenant) out.tenant = scope.tenant
+  if (scope.taxonomySlugs.length > 0) out.taxonomy_slugs = scope.taxonomySlugs
+  return out
+}
+
+/**
+ * Deny-by-default guard. When the server requires a scope and a request carries
+ * NONE (no tenant and no taxonomy), it must read nothing rather than the whole
+ * corpus. Callers check this before querying and short-circuit to empty.
+ */
+export function scopeDenied(scope: RequestScope, requireScope: boolean): boolean {
+  return requireScope && !scope.tenant && scope.taxonomySlugs.length === 0
 }

--- a/packages/mcp-pgvector/src/scope.ts
+++ b/packages/mcp-pgvector/src/scope.ts
@@ -1,0 +1,37 @@
+/**
+ * Trusted taxonomy-scope logic for mcp-pgvector, kept pure and unit-testable.
+ *
+ * The security-critical decision of WHAT a request may read lives here, not
+ * inline in the HTTP/tool handlers. The scope arrives via the trusted
+ * `x-taxonomy-slugs` header (injected by the Payload proxy / forwarded by
+ * LiteLLM); a client cannot widen it.
+ */
+
+/** Parse the `x-taxonomy-slugs` header into a clean slug list. */
+export function parseScopeHeader(raw: string | string[] | undefined): string[] {
+  const value = Array.isArray(raw) ? raw.join(',') : raw
+  if (!value) return []
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Force the scope onto a filter as a NON-overridable `taxonomy_slugs` filter —
+ * the scope always wins over any client-supplied `taxonomy_slugs`. With no
+ * scope the filter is returned unchanged (see {@link scopeDenied} for the
+ * deny-by-default guard that must gate this case).
+ */
+export function scopeFilter(filter: Record<string, unknown>, scope: string[]): Record<string, unknown> {
+  return scope.length > 0 ? { ...filter, taxonomy_slugs: scope } : filter
+}
+
+/**
+ * Deny-by-default guard. When the server is configured to require a scope and a
+ * request carries none, it must read NOTHING rather than the whole corpus.
+ * Callers check this before querying and short-circuit to an empty result.
+ */
+export function scopeDenied(scope: string[], requireScope: boolean): boolean {
+  return requireScope && scope.length === 0
+}

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -21,7 +21,7 @@ import {
   type PgvectorCollectionSchema
 } from '@zetesis/payload-pgvector'
 import { z } from 'zod'
-import { parseScopeHeader, scopeDenied, scopeFilter } from './scope'
+import { parseScopeHeader, parseTenantHeader, type RequestScope, scopeDenied, scopeFilter } from './scope'
 
 /** A searchable pgvector table exposed by the MCP. */
 export interface PgvectorMcpCollection {
@@ -87,24 +87,25 @@ const buildSchema = (c: PgvectorMcpCollection, dimensions: number): PgvectorColl
 const text = (value: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] })
 
 /**
- * Per-request taxonomy scope, read from the trusted `x-taxonomy-slugs` header
- * (injected by the Payload proxy / forwarded by LiteLLM). The MCP applies it as a
- * NON-overridable filter so a scoped caller cannot read outside it; `requireScope`
- * additionally denies unscoped requests (see scope.ts).
+ * Per-request trusted scope, read from the `x-tenant-slug` (hard boundary) and
+ * `x-taxonomy-slugs` (optional refinement) headers — injected by the Payload
+ * proxy / forwarded by LiteLLM. The MCP applies both as NON-overridable filters
+ * so a caller cannot read outside its scope; `requireScope` additionally denies
+ * fully-unscoped requests (see scope.ts).
  */
-const scopeStore = new AsyncLocalStorage<{ taxonomySlugs: string[]; requireScope: boolean }>()
-const currentScope = (): { taxonomySlugs: string[]; requireScope: boolean } =>
-  scopeStore.getStore() ?? { taxonomySlugs: [], requireScope: false }
+const scopeStore = new AsyncLocalStorage<{ scope: RequestScope; requireScope: boolean }>()
+const current = (): { scope: RequestScope; requireScope: boolean } =>
+  scopeStore.getStore() ?? { scope: { tenant: null, taxonomySlugs: [] }, requireScope: false }
 
-/** Force the scope onto a filter object — the scope always wins over client input. */
+/** Force the trusted scope (tenant + taxonomy) onto a filter — it always wins over client input. */
 function applyScope(filter: Record<string, unknown>): Record<string, unknown> {
-  return scopeFilter(filter, currentScope().taxonomySlugs)
+  return scopeFilter(filter, current().scope)
 }
 
-/** Deny-by-default: true when this request must read nothing (no scope, scope required). */
+/** Deny-by-default: true when this request must read nothing (no scope at all, scope required). */
 function denied(): boolean {
-  const { taxonomySlugs, requireScope } = currentScope()
-  return scopeDenied(taxonomySlugs, requireScope)
+  const { scope, requireScope } = current()
+  return scopeDenied(scope, requireScope)
 }
 
 function registerTools(server: McpServer, adapter: PgvectorAdapter, collections: PgvectorMcpCollection[]): void {
@@ -249,9 +250,13 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
       return
     }
 
-    // Trusted scope from the header, applied to every tool call this request makes.
-    const taxonomySlugs = parseScopeHeader(req.headers['x-taxonomy-slugs'])
-    const scope = { taxonomySlugs, requireScope }
+    // Trusted scope from the headers (tenant boundary + optional taxonomy),
+    // applied to every tool call this request makes.
+    const scope: RequestScope = {
+      tenant: parseTenantHeader(req.headers['x-tenant-slug']),
+      taxonomySlugs: parseScopeHeader(req.headers['x-taxonomy-slugs'])
+    }
+    const ctx = { scope, requireScope }
 
     const sessionId = req.headers['mcp-session-id'] as string | undefined
     if (sessionId) {
@@ -262,11 +267,11 @@ export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpH
           .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }))
         return
       }
-      await scopeStore.run(scope, () => transport.handleRequest(req, res))
+      await scopeStore.run(ctx, () => transport.handleRequest(req, res))
       return
     }
     const transport = await createSession()
-    await scopeStore.run(scope, () => transport.handleRequest(req, res))
+    await scopeStore.run(ctx, () => transport.handleRequest(req, res))
   }
 
   let httpServer: HttpServer | null = null

--- a/packages/mcp-pgvector/src/server.ts
+++ b/packages/mcp-pgvector/src/server.ts
@@ -1,0 +1,312 @@
+/**
+ * createPgvectorMcpServer: a deliberately thin MCP server over a pgvector index.
+ *
+ * Built for A/B comparison against @zetesis/mcp-typesense. It does NOT share a
+ * search contract with it — semantics (score scale, total counts, no
+ * hybrid/RRF, no facets) are pgvector-native on purpose. Three read tools:
+ * search_collections, get_chunks_by_parent, get_chunks_by_ids.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks'
+import { randomUUID } from 'node:crypto'
+import { createServer, type Server as HttpServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import {
+  createPgvectorAdapter,
+  type OpenAICompatibleEmbeddingConfig,
+  type PgFieldSchema,
+  type PgFieldType,
+  type PgvectorAdapter,
+  type PgvectorCollectionSchema
+} from '@zetesis/payload-pgvector'
+import { z } from 'zod'
+import { parseScopeHeader, scopeDenied, scopeFilter } from './scope'
+
+/** A searchable pgvector table exposed by the MCP. */
+export interface PgvectorMcpCollection {
+  /** Table name, e.g. `posts_pgvector_chunk`. */
+  name: string
+  displayName?: string
+  /** Vector column. Defaults to `embedding`. */
+  embeddingField?: string
+  /** Distance metric (must match how the table was indexed). Defaults to `cosine`. */
+  distance?: 'cosine' | 'l2' | 'ip'
+  /** Primary key column. Defaults to `id`. */
+  idField?: string
+  /** Columns usable in `filters`, mapped to their SQL type (picks the operator). */
+  filterColumns?: Record<string, PgFieldType>
+}
+
+export interface PgvectorMcpConfig {
+  server: { name: string; version: string; instructions?: string }
+  transport?: { port?: number; host?: string }
+  /** Postgres connection string. */
+  connectionString: string
+  /** Required dedicated Postgres schema the tables live in (e.g. `pgvector`). Must match how they were indexed. */
+  schema: string
+  /** Embedding config (OpenAI-compatible, e.g. a LiteLLM gateway). */
+  embedding: OpenAICompatibleEmbeddingConfig
+  collections: PgvectorMcpCollection[]
+  /**
+   * Deny-by-default defense in depth: when true, a request that arrives WITHOUT
+   * an `x-taxonomy-slugs` scope reads nothing instead of the whole corpus. The
+   * Payload proxy already refuses unscoped tokens, so this guards the case where
+   * the MCP is reached directly. Default false to keep the package generic (a
+   * deployment where some callers are legitimately unscoped). Enable it whenever
+   * every caller is expected to be tenant-scoped.
+   */
+  requireScope?: boolean
+}
+
+export interface PgvectorMcpHandle {
+  readonly port: number
+  listen(): Promise<void>
+  close(): Promise<void>
+}
+
+const DEFAULT_PORT = 3041
+const DEFAULT_HOST = '0.0.0.0'
+
+const buildSchema = (c: PgvectorMcpCollection, dimensions: number): PgvectorCollectionSchema => {
+  const embeddingField = c.embeddingField ?? 'embedding'
+  const fields: PgFieldSchema[] = [
+    { name: embeddingField, type: 'vector', dimensions },
+    ...Object.entries(c.filterColumns ?? {}).map(([name, type]) => ({ name, type }))
+  ]
+  return {
+    name: c.name,
+    idField: c.idField ?? 'id',
+    embeddingField,
+    embedFrom: [],
+    fields,
+    hnsw: { distance: c.distance ?? 'cosine' }
+  }
+}
+
+const text = (value: unknown) => ({ content: [{ type: 'text' as const, text: JSON.stringify(value, null, 2) }] })
+
+/**
+ * Per-request taxonomy scope, read from the trusted `x-taxonomy-slugs` header
+ * (injected by the Payload proxy / forwarded by LiteLLM). The MCP applies it as a
+ * NON-overridable filter so a scoped caller cannot read outside it; `requireScope`
+ * additionally denies unscoped requests (see scope.ts).
+ */
+const scopeStore = new AsyncLocalStorage<{ taxonomySlugs: string[]; requireScope: boolean }>()
+const currentScope = (): { taxonomySlugs: string[]; requireScope: boolean } =>
+  scopeStore.getStore() ?? { taxonomySlugs: [], requireScope: false }
+
+/** Force the scope onto a filter object — the scope always wins over client input. */
+function applyScope(filter: Record<string, unknown>): Record<string, unknown> {
+  return scopeFilter(filter, currentScope().taxonomySlugs)
+}
+
+/** Deny-by-default: true when this request must read nothing (no scope, scope required). */
+function denied(): boolean {
+  const { taxonomySlugs, requireScope } = currentScope()
+  return scopeDenied(taxonomySlugs, requireScope)
+}
+
+function registerTools(server: McpServer, adapter: PgvectorAdapter, collections: PgvectorMcpCollection[]): void {
+  const names = collections.map(c => c.name)
+  const nameList = names.join(', ')
+  // Allowlist: a client may only name a configured collection. Without this the
+  // SQL ident guard alone would let any table in the pgvector schema be queried.
+  const known = new Set(names)
+
+  server.registerTool(
+    'search_collections',
+    {
+      description:
+        `Semantic vector search over pgvector chunk tables (${nameList}). Embeds the query and orders by vector distance. ` +
+        'Scores are raw pgvector distances (lower = closer); do NOT threshold on them. Filters map to SQL WHERE ' +
+        '(array columns like taxonomy_slugs use overlap). No hybrid/lexical mode, no facets — this is a thin pgvector probe.',
+      inputSchema: {
+        query: z.string().describe('Concept query (will be embedded). Keep it to the concept, no author/meta words.'),
+        collection: z.string().optional().describe(`Single table to search. Defaults to all: ${nameList}`),
+        filters: z
+          .record(z.union([z.string(), z.array(z.string())]))
+          .optional()
+          .describe('SQL filters, e.g. { "taxonomy_slugs": ["bastos"] } (array=overlap) or { "parent_doc_id": "1" }.'),
+        limit: z.number().int().positive().max(100).optional().describe('Max hits (default 10).')
+      }
+    },
+    async input => {
+      if (denied()) return text({ hits: [], total: 0 })
+      if (input.collection && !known.has(input.collection)) {
+        return text({ error: `Unknown collection: ${input.collection}. Known: ${nameList}`, hits: [], total: 0 })
+      }
+      const targets = input.collection ? [input.collection] : names
+      const limit = input.limit ?? 10
+      // Scope wins over client-supplied taxonomy_slugs — cannot be widened.
+      const filter = applyScope({ ...(input.filters ?? {}) })
+      const hits: Array<{ collection: string; id: string; score: number; document: Record<string, unknown> }> = []
+      for (const name of targets) {
+        const results = await adapter.searchByText(name, input.query, { limit, filter })
+        for (const r of results) hits.push({ collection: name, id: r.id, score: r.score, document: r.document })
+      }
+      hits.sort((a, b) => a.score - b.score)
+      return text({ hits: hits.slice(0, limit), total: hits.length })
+    }
+  )
+
+  server.registerTool(
+    'get_chunks_by_parent',
+    {
+      description:
+        'Fetch all chunks of a parent document, ordered by chunk_index. Use to read a full doc after search.',
+      inputSchema: {
+        collection: z.string().describe(`Chunk table: ${nameList}`),
+        parent_doc_id: z.string().describe('Parent document id')
+      }
+    },
+    async input => {
+      if (denied()) return text({ chunks: [], total: 0 })
+      if (!known.has(input.collection)) {
+        return text({ error: `Unknown collection: ${input.collection}. Known: ${nameList}`, chunks: [], total: 0 })
+      }
+      // Order by chunk_index in SQL + a high explicit cap, so a large document
+      // returns its chunks in order and we can flag truncation instead of silently
+      // dropping the middle (the default 250 with no ORDER BY did exactly that).
+      const CAP = 5000
+      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
+        input.collection,
+        applyScope({ parent_doc_id: input.parent_doc_id }),
+        { orderBy: 'chunk_index', limit: CAP }
+      )
+      return text({ chunks: rows, total: rows.length, truncated: rows.length >= CAP })
+    }
+  )
+
+  server.registerTool(
+    'get_chunks_by_ids',
+    {
+      description:
+        'Fetch specific chunks by their ids. Use to read full content of chunks found via search_collections.',
+      inputSchema: {
+        collection: z.string().describe(`Chunk table: ${nameList}`),
+        ids: z.array(z.string()).min(1).describe('Chunk ids to fetch')
+      }
+    },
+    async input => {
+      if (denied()) return text({ chunks: [], total: 0 })
+      if (!known.has(input.collection)) {
+        return text({ error: `Unknown collection: ${input.collection}. Known: ${nameList}`, chunks: [], total: 0 })
+      }
+      // Cap at the number of ids requested so we never silently drop any.
+      const rows = await adapter.searchDocumentsByFilter<Record<string, unknown>>(
+        input.collection,
+        applyScope({ id: input.ids }),
+        { limit: input.ids.length }
+      )
+      return text({ chunks: rows, total: rows.length })
+    }
+  )
+}
+
+export function createPgvectorMcpServer(config: PgvectorMcpConfig): PgvectorMcpHandle {
+  const adapter = createPgvectorAdapter({
+    connectionString: config.connectionString,
+    schema: config.schema,
+    embedding: config.embedding
+  })
+  // Register metadata (no DDL) so filters + vectorSearch resolve correctly.
+  for (const c of config.collections) {
+    adapter.registerCollection(buildSchema(c, config.embedding.dimensions))
+  }
+
+  const sessions = new Map<string, StreamableHTTPServerTransport>()
+  const port = config.transport?.port ?? DEFAULT_PORT
+  const host = config.transport?.host ?? DEFAULT_HOST
+  const requireScope = config.requireScope ?? false
+
+  async function createSession(): Promise<StreamableHTTPServerTransport> {
+    const server = new McpServer(
+      { name: config.server.name, version: config.server.version },
+      { instructions: config.server.instructions }
+    )
+    registerTools(server, adapter, config.collections)
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: id => sessions.set(id, transport),
+      onsessionclosed: id => sessions.delete(id)
+    })
+    await server.connect(transport)
+    return transport
+  }
+
+  async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? '/', `http://localhost:${port}`)
+    if (url.pathname === '/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ status: 'ok' }))
+      return
+    }
+    if (url.pathname !== '/mcp') {
+      res.writeHead(404)
+      res.end('Not Found')
+      return
+    }
+
+    // Trusted scope from the header, applied to every tool call this request makes.
+    const taxonomySlugs = parseScopeHeader(req.headers['x-taxonomy-slugs'])
+    const scope = { taxonomySlugs, requireScope }
+
+    const sessionId = req.headers['mcp-session-id'] as string | undefined
+    if (sessionId) {
+      const transport = sessions.get(sessionId)
+      if (!transport) {
+        res
+          .writeHead(404)
+          .end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32001, message: 'Session not found' }, id: null }))
+        return
+      }
+      await scopeStore.run(scope, () => transport.handleRequest(req, res))
+      return
+    }
+    const transport = await createSession()
+    await scopeStore.run(scope, () => transport.handleRequest(req, res))
+  }
+
+  let httpServer: HttpServer | null = null
+  let resolvedPort = port
+
+  return {
+    get port() {
+      return resolvedPort
+    },
+    async listen() {
+      if (httpServer) return
+      const server = createServer((req, res) => {
+        handleRequest(req, res).catch(err => {
+          console.error('[mcp-pgvector] Unhandled request error:', err)
+          if (!res.headersSent) {
+            res.writeHead(500, { 'Content-Type': 'application/json' })
+            res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'Internal error' }, id: null }))
+          }
+        })
+      })
+      httpServer = server
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(port, host, () => {
+          const addr = server.address()
+          if (addr && typeof addr === 'object') resolvedPort = addr.port
+          server.removeListener('error', reject)
+          resolve()
+        })
+      })
+    },
+    async close() {
+      const server = httpServer
+      if (!server) return
+      await new Promise<void>((resolve, reject) => {
+        server.close(err => (err ? reject(err) : resolve()))
+      })
+      httpServer = null
+      sessions.clear()
+      await adapter.close()
+    }
+  }
+}

--- a/packages/mcp-pgvector/src/standalone.ts
+++ b/packages/mcp-pgvector/src/standalone.ts
@@ -1,0 +1,53 @@
+/**
+ * Standalone runner — wires createPgvectorMcpServer from env vars so you can run
+ * it directly for A/B comparison:
+ *
+ *   DATABASE_URL=... LITELLM_PROXY_URL=... LITELLM_MASTER_KEY=... \
+ *   node dist/standalone.mjs
+ */
+import { createPgvectorMcpServer } from './server'
+
+const PORT = Number.parseInt(process.env.MCP_PGVECTOR_PORT || '3041', 10)
+
+const mcp = createPgvectorMcpServer({
+  server: {
+    name: 'mcp-pgvector',
+    version: '0.0.0',
+    instructions:
+      'Thin pgvector search probe. Query by concept (no author/meta words). Scores are raw vector distances ' +
+      '(lower = closer) — do not threshold. Filters map to SQL WHERE; array columns (taxonomy_slugs) use overlap.'
+  },
+  transport: { port: PORT },
+  connectionString: process.env.DATABASE_URL || '',
+  schema: process.env.MCP_PGVECTOR_SCHEMA || 'pgvector',
+  embedding: {
+    baseUrl: process.env.LITELLM_PROXY_URL || 'http://litellm:4000/v1',
+    apiKey: process.env.LITELLM_MASTER_KEY || '',
+    model: process.env.MCP_PGVECTOR_EMBED_MODEL || 'embeddings-dev',
+    dimensions: Number.parseInt(process.env.MCP_PGVECTOR_EMBED_DIMS || '1536', 10),
+    // MUST match index-time: query and index embeddings have to use the same
+    // model + dimensions or similarity is garbage. Defaults ON to match the
+    // app-side indexer default (text-embedding-3-*); set MCP_PGVECTOR_SEND_DIMS=false
+    // for models that reject the param (e.g. BGE-M3) — and keep the indexer in sync.
+    sendDimensions: process.env.MCP_PGVECTOR_SEND_DIMS !== 'false'
+  },
+  // Off by default: unscoped requests are allowed (a token without taxonomies is
+  // a deliberately broad reader). Set MCP_PGVECTOR_REQUIRE_SCOPE=true to deny
+  // unscoped requests where every caller is expected to be tenant-scoped.
+  requireScope: process.env.MCP_PGVECTOR_REQUIRE_SCOPE === 'true',
+  collections: [
+    {
+      name: 'posts_pgvector_chunk',
+      displayName: 'Posts (pgvector)',
+      distance: 'cosine',
+      filterColumns: {
+        parent_doc_id: 'text',
+        slug: 'text',
+        taxonomy_slugs: 'text[]'
+      }
+    }
+  ]
+})
+
+await mcp.listen()
+console.error(`[mcp-pgvector] running on http://0.0.0.0:${mcp.port}/mcp`)

--- a/packages/mcp-pgvector/tsconfig.json
+++ b/packages/mcp-pgvector/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "./src" },
+  "references": [{ "path": "../payload-pgvector" }],
+  "include": ["src/**/*"]
+}

--- a/packages/mcp-pgvector/tsdown.config.ts
+++ b/packages/mcp-pgvector/tsdown.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts', 'src/standalone.ts'],
+  format: ['esm'],
+  dts: { resolve: true },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  outDir: 'dist',
+  tsconfig: './tsconfig.json',
+  // Bundle the workspace @zetesis/* deps (their dev exports point at TS source,
+  // which Node can't load) so the compiled artifact actually runs. Keep real npm
+  // deps external — Node resolves them from node_modules at runtime.
+  noExternal: [/^@zetesis\//],
+  external: ['@modelcontextprotocol/sdk', 'pg', 'zod', 'payload']
+})

--- a/packages/payload-indexer/src/client/components/SyncStatusField.tsx
+++ b/packages/payload-indexer/src/client/components/SyncStatusField.tsx
@@ -6,6 +6,16 @@ import { useCallback, useState } from 'react'
 
 type SyncStatus = 'synced' | 'outdated' | 'not-indexed' | 'error'
 
+/**
+ * Injected via `admin.components.Field.clientProps` by the indexer plugin.
+ * Both are namespaced per adapter so Typesense and pgvector render distinct
+ * headings and call distinct REST endpoints.
+ */
+type SyncStatusFieldClientProps = {
+  basePath?: string
+  instanceLabel?: string
+}
+
 const pillStyle: Record<SyncStatus, 'success' | 'error' | 'warning' | undefined> = {
   synced: 'success',
   outdated: 'warning',
@@ -45,7 +55,10 @@ const descStyle: React.CSSProperties = {
   opacity: 0.7
 }
 
-export const SyncStatusField: SelectFieldClientComponent = ({ path }) => {
+export const SyncStatusField: SelectFieldClientComponent = props => {
+  const { path } = props
+  const { basePath = '/api/sync-status', instanceLabel = 'Search Sync' } =
+    props as unknown as SyncStatusFieldClientProps
   const { value, setValue } = useField<string>({ path })
   const { id, collectionSlug } = useDocumentInfo()
   const [syncing, setSyncing] = useState(false)
@@ -56,7 +69,7 @@ export const SyncStatusField: SelectFieldClientComponent = ({ path }) => {
 
     setSyncing(true)
     try {
-      const res = await fetch(`/api/sync-status/${collectionSlug}/${id}/sync`, { method: 'POST' })
+      const res = await fetch(`${basePath}/${collectionSlug}/${id}/sync`, { method: 'POST' })
       const data = (await res.json()) as { success?: boolean; status?: string; error?: string }
 
       if (data.success) {
@@ -72,12 +85,12 @@ export const SyncStatusField: SelectFieldClientComponent = ({ path }) => {
     } finally {
       setSyncing(false)
     }
-  }, [id, collectionSlug, syncing, setValue])
+  }, [id, collectionSlug, syncing, setValue, basePath])
 
   return (
     <div style={containerStyle}>
       <div style={headerStyle}>
-        <strong>Typesense Sync</strong>
+        <strong>{instanceLabel}</strong>
         <Pill pillStyle={pillStyle[status]} size="small">
           {labels[status]}
         </Pill>

--- a/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
+++ b/packages/payload-indexer/src/plugin/create-indexer-plugin.ts
@@ -65,6 +65,16 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
   const { adapter, features, collections } = config
   const logger = new Logger({ enabled: true, prefix: '[payload-indexer]' })
 
+  // Only one indexer backend is active at a time (selected upstream), so the
+  // field name and endpoint path stay stable (`_syncStatus`, `/sync-status`) —
+  // there's no parallel indexer to collide with. The label still reflects the
+  // active adapter so the admin shows e.g. "Pgvector Sync" vs "Typesense Sync".
+  const namespacing: SyncStatusNamespacing = {
+    fieldName: '_syncStatus',
+    label: `${capitalize(adapter.name)} Sync`,
+    endpointBasePath: '/sync-status'
+  }
+
   const plugin = (payloadConfig: Config): Config => {
     if (payloadConfig.collections && features.sync?.enabled) {
       payloadConfig.collections = applySyncHooks(payloadConfig.collections, config, adapter)
@@ -75,7 +85,11 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
     }
 
     if (features.sync?.enabled) {
-      const syncStatusEndpoints = createSyncStatusEndpoints({ adapter, collections })
+      const syncStatusEndpoints = createSyncStatusEndpoints({
+        adapter,
+        collections,
+        basePath: namespacing.endpointBasePath
+      })
       payloadConfig.endpoints = [...(payloadConfig.endpoints || []), ...syncStatusEndpoints]
 
       if (payloadConfig.collections) {
@@ -83,7 +97,8 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
           payloadConfig.collections,
           collections,
           adapter,
-          features.sync
+          features.sync,
+          namespacing
         )
       }
 
@@ -95,6 +110,16 @@ export function createIndexerPlugin<TFieldMapping extends FieldMapping>(
 
   return { plugin, adapter }
 }
+
+/** Per-instance naming for the sync-status field and endpoints. */
+interface SyncStatusNamespacing {
+  fieldName: string
+  label: string
+  endpointBasePath: string
+}
+
+const capitalize = (value: string): string =>
+  value.length === 0 ? value : `${value[0].toUpperCase()}${value.slice(1)}`
 
 /**
  * Creates an afterRead hook that computes sync status by comparing content hashes with the index
@@ -121,13 +146,15 @@ function createSyncStatusAfterRead(adapter: IndexerAdapter, collectionSlug: stri
 }
 
 /**
- * Injects the _syncStatus virtual field into collections that have indexer tables configured
+ * Injects the adapter-namespaced sync-status virtual field (`_syncStatus_<adapter>`)
+ * into collections that have indexer tables configured.
  */
 function injectSyncStatusField(
   payloadCollections: CollectionConfig[],
   indexedCollections: Record<string, TableConfig[]>,
   adapter: IndexerAdapter,
-  syncConfig?: SyncFeatureConfig
+  syncConfig: SyncFeatureConfig | undefined,
+  namespacing: SyncStatusNamespacing
 ): CollectionConfig[] {
   return payloadCollections.map(collection => {
     const tableConfigs = indexedCollections[collection.slug]
@@ -148,8 +175,8 @@ function injectSyncStatusField(
       fields: [
         ...(collection.fields || []),
         {
-          name: '_syncStatus',
-          label: 'Typesense Sync',
+          name: namespacing.fieldName,
+          label: namespacing.label,
           type: 'select' as const,
           virtual: true,
           options: [
@@ -164,7 +191,13 @@ function injectSyncStatusField(
           admin: {
             position: 'sidebar',
             components: {
-              Field: '@zetesis/payload-indexer/client#SyncStatusField',
+              Field: {
+                path: '@zetesis/payload-indexer/client#SyncStatusField',
+                clientProps: {
+                  basePath: `/api${namespacing.endpointBasePath}`,
+                  instanceLabel: namespacing.label
+                }
+              },
               Cell: '@zetesis/payload-indexer/client#SyncStatusCell'
             }
           }

--- a/packages/payload-indexer/src/sync-status/create-sync-status-endpoint.ts
+++ b/packages/payload-indexer/src/sync-status/create-sync-status-endpoint.ts
@@ -12,6 +12,12 @@ import { checkBatchSyncStatus, checkSyncStatus } from './sync-status-service'
 interface SyncStatusEndpointConfig {
   adapter: IndexerAdapter
   collections: Record<string, TableConfig[]>
+  /**
+   * Path prefix for the registered endpoints (e.g. `/sync-status-typesense`).
+   * Namespaced per adapter so multiple indexer plugins don't collide on the
+   * same REST path. Must match the `basePath` the client field component uses.
+   */
+  basePath: string
 }
 
 /**
@@ -58,12 +64,12 @@ const findDocumentWithAccessCheck = async (
  * - ids (comma-separated doc IDs)
  */
 export const createSyncStatusEndpoints = (config: SyncStatusEndpointConfig): Endpoint[] => {
-  const { adapter, collections } = config
+  const { adapter, collections, basePath } = config
 
   return [
     // Single document sync status
     {
-      path: '/sync-status/:collection/:id',
+      path: `${basePath}/:collection/:id`,
       method: 'get',
       handler: async (req: PayloadRequest) => {
         if (!req.user) {
@@ -100,7 +106,7 @@ export const createSyncStatusEndpoints = (config: SyncStatusEndpointConfig): End
     },
     // Batch sync status for collection
     {
-      path: '/sync-status/:collection',
+      path: `${basePath}/:collection`,
       method: 'get',
       handler: async (req: PayloadRequest) => {
         if (!req.user) {
@@ -172,7 +178,7 @@ export const createSyncStatusEndpoints = (config: SyncStatusEndpointConfig): End
     },
     // Trigger sync for a single document
     {
-      path: '/sync-status/:collection/:id/sync',
+      path: `${basePath}/:collection/:id/sync`,
       method: 'post',
       handler: async (req: PayloadRequest) => {
         if (!req.user) {

--- a/packages/payload-pgvector/README.md
+++ b/packages/payload-pgvector/README.md
@@ -1,0 +1,60 @@
+# @zetesis/payload-pgvector
+
+A Postgres + **pgvector** search backend for Payload CMS. Implements the
+`@zetesis/payload-indexer` `IndexerAdapter` contract — a sibling of
+`@zetesis/payload-typesense` — with **app-side embeddings** via any
+OpenAI-compatible endpoint (OpenAI, a LiteLLM gateway, a local TEI/Ollama
+server, …). Unlike Typesense, pgvector does not embed for you: vectors are
+produced app-side before they hit the database.
+
+## Install
+
+```bash
+pnpm add @zetesis/payload-pgvector @zetesis/payload-indexer pg
+```
+
+Requires the `vector` extension and a **dedicated schema** (never `public`, so a
+Payload/Drizzle schema push can't treat the raw tables as unmanaged and drop them):
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE SCHEMA IF NOT EXISTS pgvector;
+```
+
+## Usage
+
+```ts
+import { createPgvectorAdapter, createPgvectorPlugin } from '@zetesis/payload-pgvector'
+import { createIndexerPlugin } from '@zetesis/payload-indexer'
+
+const adapter = createPgvectorAdapter({
+  connectionString: process.env.DATABASE_URL!,
+  schema: 'pgvector', // required, dedicated
+  embedding: {
+    baseUrl: process.env.LITELLM_PROXY_URL!, // any OpenAI-compatible /embeddings
+    apiKey: process.env.EMBEDDINGS_API_KEY!,
+    model: 'text-embedding-3-small',
+    dimensions: 1536,
+    sendDimensions: true // text-embedding-3-* honour it; off for ada-002/TEI/Ollama
+  }
+})
+
+// Document sync (hooks) + schema sync (ensure tables on init):
+const { plugin: indexerPlugin } = createIndexerPlugin({ adapter, features: { sync: { enabled: true } }, collections })
+const schemaPlugin = createPgvectorPlugin({ adapter, collections, dimensions: 1536 })
+// add both to your Payload `plugins`
+```
+
+Query (read-only consumers, e.g. an MCP server):
+
+```ts
+const hits = await adapter.searchByText('posts_chunk', 'justicia sin estado', { limit: 10 })
+```
+
+## Notes
+
+- **Atomic reindex**: `replaceDocumentsByFilter` embeds *before* deleting and runs
+  delete+insert in one transaction, so a failed reindex never wipes the old index.
+- **Schema sync is additive** (`CREATE/ADD … IF NOT EXISTS`) and warns on incompatible
+  drift (vector dimension / HNSW distance) — change those by dropping & recreating.
+- Index-time and query-time **must** use the same model + dimensions, or similarity is garbage.

--- a/packages/payload-pgvector/package.json
+++ b/packages/payload-pgvector/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@zetesis/payload-pgvector",
+  "version": "0.0.0",
+  "description": "A Payload CMS search adapter backed by Postgres + pgvector. Sibling of @zetesis/payload-typesense: implements the payload-indexer IndexerAdapter contract over pgvector, with app-side embeddings via any OpenAI-compatible endpoint (e.g. a LiteLLM gateway).",
+  "license": "MIT",
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "main": "./src/index.ts",
+  "types": "./dist/index.d.mts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsdown",
+    "dev": "tsdown --watch",
+    "clean": "rimraf -g {dist,*.tsbuildinfo}",
+    "prepublishOnly": "pnpm clean && pnpm build"
+  },
+  "devDependencies": {
+    "@types/node": "^22.5.4",
+    "@types/pg": "^8.11.10",
+    "rimraf": "3.0.2",
+    "tsdown": "^0.16.5",
+    "typescript": "5.7.3"
+  },
+  "peerDependencies": {
+    "payload": "^3.81.0"
+  },
+  "engines": {
+    "pnpm": "^9 || ^10"
+  },
+  "dependencies": {
+    "@zetesis/payload-indexer": "workspace:*",
+    "pg": "^8.13.1",
+    "zod": "^4.1.11"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    },
+    "main": "./dist/index.mjs",
+    "types": "./dist/index.d.mts",
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  }
+}

--- a/packages/payload-pgvector/src/adapter/create-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/create-adapter.ts
@@ -1,0 +1,53 @@
+import type { Pool, PoolConfig } from 'pg'
+import pg from 'pg'
+import {
+  type EmbeddingProvider,
+  type OpenAICompatibleEmbeddingConfig,
+  OpenAICompatibleEmbeddingProvider
+} from '../embedding/provider'
+import { PgvectorAdapter } from './pgvector-adapter'
+
+const { Pool: PoolCtor } = pg
+
+export interface CreatePgvectorAdapterOptions {
+  /** Postgres connection. Either a connection string or a node-pg Pool config. */
+  connectionString?: string
+  poolConfig?: PoolConfig
+  /**
+   * Embedding provider, or a shorthand OpenAI-compatible config (e.g. pointing at
+   * a LiteLLM gateway). Optional: omit when documents arrive pre-vectorized.
+   */
+  embeddingProvider?: EmbeddingProvider
+  embedding?: OpenAICompatibleEmbeddingConfig
+  /** Required dedicated Postgres schema (e.g. `pgvector`). Never `public` — keeps these raw tables out of the ORM-managed schema. */
+  schema: string
+}
+
+/**
+ * Build a PgvectorAdapter from a connection string/pool config. Mirrors
+ * createTypesenseAdapter. The returned adapter plugs straight into
+ * createIndexerPlugin from @zetesis/payload-indexer.
+ */
+export const createPgvectorAdapter = (options: CreatePgvectorAdapterOptions): PgvectorAdapter => {
+  if (!options.connectionString && !options.poolConfig) {
+    throw new Error('createPgvectorAdapter requires connectionString or poolConfig')
+  }
+
+  const pool = new PoolCtor(options.poolConfig ?? { connectionString: options.connectionString })
+
+  const embeddingProvider =
+    options.embeddingProvider ??
+    (options.embedding ? new OpenAICompatibleEmbeddingProvider(options.embedding) : undefined)
+
+  // This adapter created the pool, so it owns it and may end it on close().
+  return new PgvectorAdapter(pool, { embeddingProvider, schema: options.schema, ownsPool: true })
+}
+
+/**
+ * Build a PgvectorAdapter from an existing node-pg Pool. Use when the app already
+ * owns the connection (e.g. sharing Payload's pool).
+ */
+export const createPgvectorAdapterFromPool = (
+  pool: Pool,
+  options: { embeddingProvider?: EmbeddingProvider; schema: string }
+): PgvectorAdapter => new PgvectorAdapter(pool, options)

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../core/logging/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+}))
+
+import { logger } from '../core/logging/logger'
+import { PgvectorAdapter } from './pgvector-adapter'
+import type { PgvectorCollectionSchema } from './types'
+
+/** Fake node-pg Pool/Client that records every query for assertions. */
+class FakePool {
+  queries: { text: string; params?: unknown[] }[] = []
+  rows: Record<string, unknown>[] = []
+
+  async query(text: string, params?: unknown[]) {
+    this.queries.push({ text, params })
+    return { rows: this.rows, rowCount: this.rows.length }
+  }
+
+  async connect() {
+    return { query: (t: string, p?: unknown[]) => this.query(t, p), release: () => {} }
+  }
+
+  find(substr: string) {
+    return this.queries.find(q => q.text.includes(substr))
+  }
+
+  last() {
+    return this.queries[this.queries.length - 1]
+  }
+}
+
+const schema: PgvectorCollectionSchema = {
+  name: 'chunks',
+  idField: 'id',
+  embeddingField: 'embedding',
+  embedFrom: ['chunk_text'],
+  fields: [
+    { name: 'id', type: 'text' },
+    { name: 'parent_doc_id', type: 'text', index: true },
+    { name: 'chunk_text', type: 'text' },
+    { name: 'taxonomy_slugs', type: 'text[]', index: true, optional: true },
+    { name: 'embedding', type: 'vector', dimensions: 3 }
+  ]
+}
+
+describe('PgvectorAdapter', () => {
+  let pool: FakePool
+  let adapter: PgvectorAdapter
+
+  beforeEach(() => {
+    pool = new FakePool()
+    adapter = new PgvectorAdapter(pool as never, { schema: 'pgvector' })
+    adapter.registerCollection(schema)
+  })
+
+  describe('schema isolation', () => {
+    it('requires a dedicated schema and rejects "public"', () => {
+      expect(() => new PgvectorAdapter(pool as never, { schema: 'public' })).toThrow()
+      expect(() => new PgvectorAdapter(pool as never, { schema: '' })).toThrow()
+    })
+
+    it('schema-qualifies every table reference', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3])
+      expect(pool.last().text).toContain('FROM "pgvector"."chunks"')
+    })
+  })
+
+  describe('buildWhere operator matrix (chosen by column type)', () => {
+    it('text[] column + array value → overlap &&', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { taxonomy_slugs: ['bastos', 'mises'] } })
+      expect(pool.last().text).toContain('"taxonomy_slugs" && $2::text[]')
+    })
+
+    it('text[] column + scalar value → membership = ANY(col)', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { taxonomy_slugs: 'bastos' } })
+      expect(pool.last().text).toContain('$2 = ANY("taxonomy_slugs")')
+    })
+
+    it('scalar column + scalar value → equality', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { parent_doc_id: 'd1' } })
+      expect(pool.last().text).toContain('"parent_doc_id" = $2')
+    })
+
+    it('scalar column + array value → IN list', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { parent_doc_id: ['d1', 'd2'] } })
+      expect(pool.last().text).toContain('"parent_doc_id" = ANY($2::text[])')
+    })
+  })
+
+  describe('vectorSearch param threading', () => {
+    it('orders params: $1 vector, then WHERE, then LIMIT', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { filter: { parent_doc_id: 'd1' }, limit: 7 })
+      const { text, params } = pool.last()
+      expect(text).toContain('$1::vector')
+      expect(text).toMatch(/LIMIT \$3$/)
+      expect(params).toEqual(['[0.1,0.2,0.3]', 'd1', 7])
+    })
+
+    it('always excludes null embeddings even with no filter', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3], { limit: 4 })
+      // Without this, NULL distance → Number(null)=0 would rank unembedded rows first.
+      expect(pool.last().text).toContain('WHERE "embedding" IS NOT NULL')
+      expect(pool.last().params).toEqual(['[0.1,0.2,0.3]', 4])
+    })
+
+    it('uses the cosine operator <=> by default', async () => {
+      await adapter.vectorSearch('chunks', [0.1, 0.2, 0.3])
+      expect(pool.last().text).toContain('<=>')
+    })
+  })
+
+  describe('ensureCollection incompatible-schema warnings', () => {
+    it('warns when the existing embedding column dimension differs from config', async () => {
+      vi.mocked(logger.warn).mockClear()
+      pool.rows = [{ dim: 1024 }] // pg_attribute reports the existing column as vector(1024)
+      await adapter.ensureCollection(schema) // schema declares vector(3)
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('vector(1024) but config wants vector(3)')
+      )
+    })
+
+    it('does not warn when the dimension matches (no existing column)', async () => {
+      vi.mocked(logger.warn).mockClear()
+      pool.rows = [] // column doesn't exist yet
+      await adapter.ensureCollection(schema)
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('replaceDocumentsByFilter (atomic reindex)', () => {
+    it('runs delete + insert in one transaction (BEGIN → DELETE → INSERT → COMMIT)', async () => {
+      await adapter.replaceDocumentsByFilter('chunks', { parent_doc_id: 'd1' }, [
+        // precomputed embedding so no EmbeddingProvider is needed for the test
+        { id: '1', parent_doc_id: 'd1', chunk_text: 'a', embedding: [0.1, 0.2, 0.3] }
+      ])
+      const texts = pool.queries.map(q => q.text)
+      const begin = texts.findIndex(t => t.includes('BEGIN'))
+      const del = texts.findIndex(t => t.startsWith('DELETE'))
+      const ins = texts.findIndex(t => t.includes('INSERT INTO'))
+      const commit = texts.findIndex(t => t.includes('COMMIT'))
+      expect(begin).toBeGreaterThanOrEqual(0)
+      expect(begin).toBeLessThan(del)
+      expect(del).toBeLessThan(ins)
+      expect(ins).toBeLessThan(commit)
+      expect(texts[del]).toContain('DELETE FROM "pgvector"."chunks"')
+      expect(texts[del]).toContain('"parent_doc_id" =')
+    })
+
+    it('rolls back when an insert fails (old chunks are not lost)', async () => {
+      const failPool = new FakePool()
+      failPool.query = async (text: string, params?: unknown[]) => {
+        failPool.queries.push({ text, params })
+        if (text.includes('INSERT INTO')) throw new Error('insert boom')
+        return { rows: failPool.rows, rowCount: failPool.rows.length }
+      }
+      const a = new PgvectorAdapter(failPool as never, { schema: 'pgvector' })
+      a.registerCollection(schema)
+
+      await expect(
+        a.replaceDocumentsByFilter('chunks', { parent_doc_id: 'd1' }, [
+          { id: '1', parent_doc_id: 'd1', chunk_text: 'a', embedding: [0.1, 0.2, 0.3] }
+        ])
+      ).rejects.toThrow('insert boom')
+
+      const texts = failPool.queries.map(q => q.text)
+      expect(texts.some(t => t.includes('ROLLBACK'))).toBe(true)
+      expect(texts.some(t => t.includes('COMMIT'))).toBe(false)
+    })
+  })
+
+  describe('upsert', () => {
+    it('builds INSERT ... ON CONFLICT DO UPDATE excluding the id column', async () => {
+      await adapter.upsertDocument('chunks', {
+        id: '1',
+        parent_doc_id: 'd1',
+        taxonomy_slugs: ['x'],
+        embedding: [0.1, 0.2, 0.3]
+      })
+      const insert = pool.find('INSERT INTO')
+      expect(insert?.text).toContain('INSERT INTO "pgvector"."chunks"')
+      expect(insert?.text).toContain('ON CONFLICT ("id") DO UPDATE SET')
+      expect(insert?.text).toContain('"parent_doc_id" = EXCLUDED."parent_doc_id"')
+      // the id column must NOT be in the SET list
+      expect(insert?.text).not.toContain('"id" = EXCLUDED."id"')
+      // a precomputed embedding is cast to ::vector
+      expect(insert?.text).toContain('::vector')
+    })
+  })
+
+  describe('SQL-injection guard', () => {
+    it('rejects a malicious table name via the identifier validator', async () => {
+      await expect(adapter.ensureCollection({ ...schema, name: 'x"; DROP TABLE y; --' })).rejects.toThrow(
+        /Invalid SQL identifier/
+      )
+    })
+  })
+})

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.spec.ts
@@ -116,9 +116,7 @@ describe('PgvectorAdapter', () => {
       vi.mocked(logger.warn).mockClear()
       pool.rows = [{ dim: 1024 }] // pg_attribute reports the existing column as vector(1024)
       await adapter.ensureCollection(schema) // schema declares vector(3)
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('vector(1024) but config wants vector(3)')
-      )
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('vector(1024) but config wants vector(3)'))
     })
 
     it('does not warn when the dimension matches (no existing column)', async () => {

--- a/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
+++ b/packages/payload-pgvector/src/adapter/pgvector-adapter.ts
@@ -1,0 +1,612 @@
+import type { AdapterSearchResult, IndexDocument, IndexerAdapter, VectorSearchOptions } from '@zetesis/payload-indexer'
+import type { Pool, PoolClient } from 'pg'
+import { logger } from '../core/logging/logger'
+import type { EmbeddingProvider } from '../embedding/provider'
+import type { CollectionEmbedInfo, PgFieldSchema, PgFieldType, PgvectorCollectionSchema } from './types'
+
+export interface PgvectorAdapterOptions {
+  /** Embedding provider used to vectorize text at upsert time. Optional: if a */
+  /** document already carries a precomputed vector, no provider is needed. */
+  embeddingProvider?: EmbeddingProvider
+  /**
+   * Postgres schema to create/query the tables in (e.g. `pgvector`). Required and
+   * never `public`: these tables are raw (not ORM-managed), so they MUST live in
+   * a dedicated schema — otherwise a Payload/Drizzle schema push sees them as
+   * unmanaged and DROPs them.
+   */
+  schema: string
+  /**
+   * Whether this adapter owns the pool and may end it on close(). True when the
+   * adapter created the pool itself; false (default) when an external pool was
+   * passed in (e.g. Payload's), so close() leaves it alone.
+   */
+  ownsPool?: boolean
+}
+
+/** Map our PgFieldType to a concrete SQL column type. */
+const sqlColumnType = (field: PgFieldSchema): string => {
+  switch (field.type) {
+    case 'text':
+      return 'text'
+    case 'text[]':
+      return 'text[]'
+    case 'int':
+      return 'integer'
+    case 'bigint':
+      return 'bigint'
+    case 'bool':
+      return 'boolean'
+    case 'timestamptz':
+      return 'timestamptz'
+    case 'jsonb':
+      return 'jsonb'
+    case 'vector':
+      if (!field.dimensions) {
+        throw new Error(`vector column "${field.name}" requires "dimensions"`)
+      }
+      return `vector(${field.dimensions})`
+    default: {
+      const exhaustive: never = field.type
+      throw new Error(`Unsupported field type: ${String(exhaustive)}`)
+    }
+  }
+}
+
+const DISTANCE_OPS: Record<CollectionEmbedInfo['distance'], { op: string; opclass: string }> = {
+  cosine: { op: '<=>', opclass: 'vector_cosine_ops' },
+  l2: { op: '<->', opclass: 'vector_l2_ops' },
+  ip: { op: '<#>', opclass: 'vector_ip_ops' }
+}
+
+/** Quote a SQL identifier (table/column). Validates to avoid injection via schema. */
+const ident = (name: string): string => {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid SQL identifier: ${name}`)
+  }
+  return `"${name}"`
+}
+
+/** Format a number[] as a pgvector literal: [1,2,3]. */
+const toVectorLiteral = (vector: number[]): string => `[${vector.join(',')}]`
+
+/**
+ * Postgres + pgvector implementation of the IndexerAdapter contract.
+ *
+ * Sibling of TypesenseAdapter. The crucial difference: pgvector does not embed,
+ * so this adapter produces vectors app-side via an EmbeddingProvider at upsert
+ * time (unless the document already carries one). Query-side embedding is done
+ * by the caller; vectorSearch() receives a precomputed vector, matching the
+ * IndexerAdapter signature.
+ */
+export class PgvectorAdapter implements IndexerAdapter<PgvectorCollectionSchema> {
+  readonly name = 'pgvector'
+  private readonly pool: Pool
+  private readonly embeddingProvider?: EmbeddingProvider
+  private readonly schema: string
+  private readonly ownsPool: boolean
+  /** Per-collection embedding metadata, captured during ensureCollection. */
+  private readonly embedInfo = new Map<string, CollectionEmbedInfo>()
+
+  constructor(pool: Pool, options: PgvectorAdapterOptions) {
+    if (!options.schema || options.schema === 'public') {
+      throw new Error('PgvectorAdapter requires a dedicated `schema` (not "public")')
+    }
+    this.pool = pool
+    this.embeddingProvider = options.embeddingProvider
+    this.schema = options.schema
+    this.ownsPool = options.ownsPool ?? false
+  }
+
+  /** Release the connection pool when this adapter owns it (no-op for an external pool). */
+  async close(): Promise<void> {
+    if (this.ownsPool) await this.pool.end()
+  }
+
+  /** Schema-qualified, quoted table reference: `"schema"."table"`. */
+  private relName(table: string): string {
+    return `${ident(this.schema)}.${ident(table)}`
+  }
+
+  async testConnection(): Promise<boolean> {
+    try {
+      await this.pool.query('SELECT 1')
+      return true
+    } catch (error) {
+      logger.error('pgvector connection test failed', error)
+      return false
+    }
+  }
+
+  // === Schema Management ===
+
+  async ensureCollection(schema: PgvectorCollectionSchema): Promise<void> {
+    const idField = schema.idField ?? 'id'
+    const embeddingField = schema.embeddingField ?? 'embedding'
+    const distance = schema.hnsw?.distance ?? 'cosine'
+    const embeddingFieldSchema = schema.fields.find(f => f.name === embeddingField)
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('CREATE EXTENSION IF NOT EXISTS vector')
+      await client.query(`CREATE SCHEMA IF NOT EXISTS ${ident(this.schema)}`)
+      await this.createTable(client, schema, idField)
+      await this.warnOnIncompatibleSchema(client, schema, embeddingField, distance)
+      await this.ensureIndexes(client, schema, embeddingField, Boolean(embeddingFieldSchema), distance)
+    } finally {
+      client.release()
+    }
+
+    this.registerCollection(schema)
+    logger.info(`Ensured collection (table): ${schema.name}`)
+  }
+
+  /**
+   * Register a collection's metadata (id/embedding field, distance, column
+   * types) WITHOUT running any DDL. ensureCollection calls this after creating
+   * the table; consumers that only read (e.g. a search server) can call it on
+   * an existing table so filters and vectorSearch resolve correctly.
+   */
+  registerCollection(schema: PgvectorCollectionSchema): void {
+    const idField = schema.idField ?? 'id'
+    const embeddingField = schema.embeddingField ?? 'embedding'
+    const distance = schema.hnsw?.distance ?? 'cosine'
+    const embeddingFieldSchema = schema.fields.find(f => f.name === embeddingField)
+
+    const columnTypes: Record<string, PgFieldType> = {}
+    for (const field of schema.fields) {
+      columnTypes[field.name] = field.type
+    }
+
+    this.embedInfo.set(schema.name, {
+      idField,
+      embeddingField,
+      embedFrom: schema.embedFrom ?? [],
+      dimensions: embeddingFieldSchema?.dimensions ?? this.embeddingProvider?.dimensions ?? 0,
+      distance,
+      columnTypes
+    })
+  }
+
+  /** CREATE TABLE (id guaranteed as PK) + additive ADD COLUMN for pre-existing tables. */
+  private async createTable(client: PoolClient, schema: PgvectorCollectionSchema, idField: string): Promise<void> {
+    const hasIdField = schema.fields.some(f => f.name === idField)
+    const columnDefs: string[] = []
+    if (!hasIdField) {
+      columnDefs.push(`${ident(idField)} text PRIMARY KEY`)
+    }
+    for (const field of schema.fields) {
+      const nullable = field.optional === false ? ' NOT NULL' : ''
+      const pk = field.name === idField ? ' PRIMARY KEY' : ''
+      columnDefs.push(`${ident(field.name)} ${sqlColumnType(field)}${pk}${nullable}`)
+    }
+    await client.query(`CREATE TABLE IF NOT EXISTS ${this.relName(schema.name)} (\n  ${columnDefs.join(',\n  ')}\n)`)
+
+    for (const field of schema.fields) {
+      await client.query(
+        `ALTER TABLE ${this.relName(schema.name)} ADD COLUMN IF NOT EXISTS ${ident(field.name)} ${sqlColumnType(field)}`
+      )
+    }
+  }
+
+  /**
+   * The schema sync is additive (CREATE/ADD ... IF NOT EXISTS), so it can't change
+   * an embedding column's dimension or an HNSW index's distance once they exist.
+   * Detect those incompatible drifts and warn loudly — the operator must drop &
+   * recreate (and reindex) to apply them; silently they'd break inserts/searches
+   * or degrade relevance.
+   */
+  private async warnOnIncompatibleSchema(
+    client: PoolClient,
+    schema: PgvectorCollectionSchema,
+    embeddingField: string,
+    distance: CollectionEmbedInfo['distance']
+  ): Promise<void> {
+    const expectedDim = schema.fields.find(f => f.name === embeddingField)?.dimensions
+    if (expectedDim) {
+      // For a pgvector column, atttypmod holds the declared dimension (-1 if none).
+      const { rows } = await client.query<{ dim: number }>(
+        `SELECT a.atttypmod AS dim FROM pg_attribute a
+         JOIN pg_class c ON a.attrelid = c.oid
+         JOIN pg_namespace n ON c.relnamespace = n.oid
+         WHERE n.nspname = $1 AND c.relname = $2 AND a.attname = $3 AND NOT a.attisdropped`,
+        [this.schema, schema.name, embeddingField]
+      )
+      const actualDim = rows[0]?.dim
+      if (typeof actualDim === 'number' && actualDim > 0 && actualDim !== expectedDim) {
+        logger.warn(
+          `[${schema.name}] embedding column "${embeddingField}" is vector(${actualDim}) but config wants vector(${expectedDim}). ` +
+            'The additive schema sync will NOT change it — drop & recreate the table and reindex to switch dimensions.'
+        )
+      }
+    }
+
+    const indexName = `${schema.name}_${embeddingField}_hnsw`
+    const expectedOpclass = DISTANCE_OPS[distance].opclass
+    const { rows } = await client.query<{ def: string }>(
+      `SELECT pg_get_indexdef(ic.oid) AS def FROM pg_class ic
+       JOIN pg_namespace n ON ic.relnamespace = n.oid
+       WHERE n.nspname = $1 AND ic.relname = $2`,
+      [this.schema, indexName]
+    )
+    const def = rows[0]?.def
+    if (def && !def.includes(expectedOpclass)) {
+      logger.warn(
+        `[${schema.name}] HNSW index "${indexName}" exists with a different distance metric (config: ${distance}/${expectedOpclass}). ` +
+          "CREATE INDEX IF NOT EXISTS won't rebuild it — drop the index to switch distance."
+      )
+    }
+  }
+
+  /** HNSW index on the embedding column + btree/GIN indexes on flagged columns. */
+  private async ensureIndexes(
+    client: PoolClient,
+    schema: PgvectorCollectionSchema,
+    embeddingField: string,
+    hasEmbedding: boolean,
+    distance: CollectionEmbedInfo['distance']
+  ): Promise<void> {
+    if (hasEmbedding) {
+      const { opclass } = DISTANCE_OPS[distance]
+      const m = schema.hnsw?.m ?? 16
+      const efc = schema.hnsw?.efConstruction ?? 64
+      const indexName = `${schema.name}_${embeddingField}_hnsw`
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${this.relName(schema.name)} ` +
+          `USING hnsw (${ident(embeddingField)} ${opclass}) WITH (m = ${m}, ef_construction = ${efc})`
+      )
+    }
+
+    for (const field of schema.fields) {
+      if (!field.index || field.name === embeddingField) continue
+      const indexName = `${schema.name}_${field.name}_idx`
+      const method = field.type === 'text[]' ? 'gin' : 'btree'
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS ${ident(indexName)} ON ${this.relName(schema.name)} USING ${method} (${ident(field.name)})`
+      )
+    }
+  }
+
+  async collectionExists(collectionName: string): Promise<boolean> {
+    const result = await this.pool.query<{ exists: boolean }>('SELECT to_regclass($1) IS NOT NULL AS exists', [
+      `${this.schema}.${collectionName}`
+    ])
+    return result.rows[0]?.exists ?? false
+  }
+
+  async deleteCollection(collectionName: string): Promise<void> {
+    await this.pool.query(`DROP TABLE IF EXISTS ${this.relName(collectionName)} CASCADE`)
+    this.embedInfo.delete(collectionName)
+    logger.info(`Deleted collection (table): ${collectionName}`)
+  }
+
+  // === Document Operations ===
+
+  async upsertDocument(collectionName: string, document: IndexDocument): Promise<void> {
+    await this.upsertDocuments(collectionName, [document])
+  }
+
+  async upsertDocuments(collectionName: string, documents: IndexDocument[]): Promise<void> {
+    if (documents.length === 0) return
+
+    const info = this.embedInfo.get(collectionName)
+    const vectors = await this.resolveVectors(documents, info)
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      for (let i = 0; i < documents.length; i++) {
+        await this.insertRow(client, collectionName, documents[i], vectors[i], info)
+      }
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      logger.error(`Failed to upsert ${documents.length} document(s) to ${collectionName}`, error)
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  /**
+   * Atomically replace the rows matching `filter` with `documents`. Embeddings
+   * are resolved FIRST (before any delete), then delete + insert run in a single
+   * transaction. If embedding fails, nothing is deleted; if any insert fails, the
+   * delete rolls back — a reindex can never leave a document with no chunks.
+   */
+  async replaceDocumentsByFilter(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    documents: IndexDocument[]
+  ): Promise<void> {
+    const info = this.embedInfo.get(collectionName)
+    // Embed before touching the table — a gateway failure must not lose the index.
+    const vectors = await this.resolveVectors(documents, info)
+    const { clause, params } = this.buildWhere(filter, info?.columnTypes)
+
+    const client = await this.pool.connect()
+    try {
+      await client.query('BEGIN')
+      await client.query(`DELETE FROM ${this.relName(collectionName)}${clause}`, params)
+      for (let i = 0; i < documents.length; i++) {
+        await this.insertRow(client, collectionName, documents[i], vectors[i], info)
+      }
+      await client.query('COMMIT')
+    } catch (error) {
+      await client.query('ROLLBACK')
+      logger.error(`Failed to replace documents in ${collectionName}`, error)
+      throw error
+    } finally {
+      client.release()
+    }
+  }
+
+  async deleteDocument(collectionName: string, documentId: string): Promise<void> {
+    const idField = this.embedInfo.get(collectionName)?.idField ?? 'id'
+    await this.pool.query(`DELETE FROM ${this.relName(collectionName)} WHERE ${ident(idField)} = $1`, [documentId])
+  }
+
+  async deleteDocumentsByFilter(collectionName: string, filter: Record<string, unknown>): Promise<number> {
+    const columnTypes = this.embedInfo.get(collectionName)?.columnTypes
+    const { clause, params } = this.buildWhere(filter, columnTypes)
+    const sql = `DELETE FROM ${this.relName(collectionName)}${clause}`
+    const result = await this.pool.query(sql, params)
+    return result.rowCount ?? 0
+  }
+
+  // === Vector Search ===
+
+  async vectorSearch<TDoc = Record<string, unknown>>(
+    collectionName: string,
+    vector: number[],
+    options: VectorSearchOptions = {}
+  ): Promise<AdapterSearchResult<TDoc>[]> {
+    const { limit = 10, filter, includeFields, excludeFields } = options
+    const info = this.embedInfo.get(collectionName)
+    const embeddingField = info?.embeddingField ?? 'embedding'
+    const op = DISTANCE_OPS[info?.distance ?? 'cosine'].op
+
+    const params: unknown[] = [toVectorLiteral(vector)]
+    const { clause, params: whereParams } = this.buildWhere(filter ?? {}, info?.columnTypes, params.length)
+    params.push(...whereParams)
+    params.push(limit)
+
+    // Exclude rows with no embedding: `NULL <=> v` is NULL → Number(null) === 0
+    // would rank an unembedded row as a perfect match. They can't take part in a
+    // vector search anyway.
+    const notNull = `${ident(embeddingField)} IS NOT NULL`
+    const where = clause ? `${clause} AND ${notNull}` : ` WHERE ${notNull}`
+
+    const sql =
+      `SELECT *, ${ident(embeddingField)} ${op} $1::vector AS _distance ` +
+      `FROM ${this.relName(collectionName)}${where} ` +
+      `ORDER BY ${ident(embeddingField)} ${op} $1::vector ` +
+      `LIMIT $${params.length}`
+
+    const result = await this.pool.query(sql, params)
+    return result.rows
+      .map(row => {
+        const distance = Number(row._distance)
+        const document = this.projectRow(row, embeddingField, includeFields, excludeFields)
+        return {
+          id: String((document as Record<string, unknown>)[info?.idField ?? 'id'] ?? ''),
+          score: distance,
+          document: document as TDoc
+        }
+      })
+      .filter(r => Number.isFinite(r.score))
+  }
+
+  /**
+   * Semantic search by text: embeds the query via the adapter's EmbeddingProvider
+   * and runs vectorSearch. Convenience for read-only consumers (e.g. an MCP)
+   * that hold text queries, not vectors.
+   */
+  async searchByText<TDoc = Record<string, unknown>>(
+    collectionName: string,
+    text: string,
+    options: VectorSearchOptions = {}
+  ): Promise<AdapterSearchResult<TDoc>[]> {
+    if (!this.embeddingProvider) {
+      throw new Error('searchByText requires an EmbeddingProvider on the adapter')
+    }
+    const [vector] = await this.embeddingProvider.embed([text])
+    return this.vectorSearch<TDoc>(collectionName, vector, options)
+  }
+
+  // === Optional: Document Query & Partial Update ===
+
+  async searchDocumentsByFilter<TDoc = Record<string, unknown>>(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    options?: { includeFields?: string[]; limit?: number; orderBy?: string }
+  ): Promise<TDoc[]> {
+    const info = this.embedInfo.get(collectionName)
+    const embeddingField = info?.embeddingField ?? 'embedding'
+    const { clause, params } = this.buildWhere(filter, info?.columnTypes)
+    // Deterministic order when requested — without it Postgres returns an
+    // arbitrary subset under LIMIT, silently dropping rows for large documents.
+    const orderClause = options?.orderBy ? ` ORDER BY ${ident(options.orderBy)}` : ''
+    const limit = options?.limit ?? 250
+    params.push(limit)
+    const sql = `SELECT * FROM ${this.relName(collectionName)}${clause}${orderClause} LIMIT $${params.length}`
+    const result = await this.pool.query(sql, params)
+    return result.rows.map(row => this.projectRow(row, embeddingField, options?.includeFields) as TDoc)
+  }
+
+  async updateDocument(collectionName: string, documentId: string, partialDoc: Record<string, unknown>): Promise<void> {
+    const idField = this.embedInfo.get(collectionName)?.idField ?? 'id'
+    const keys = Object.keys(partialDoc)
+    if (keys.length === 0) return
+
+    const sets = keys.map((key, i) => `${ident(key)} = $${i + 1}`)
+    const params = keys.map(key => this.toParam(partialDoc[key]))
+    params.push(documentId)
+    const sql = `UPDATE ${this.relName(collectionName)} SET ${sets.join(', ')} WHERE ${ident(idField)} = $${params.length}`
+    await this.pool.query(sql, params)
+  }
+
+  async updateDocumentsByFilter(
+    collectionName: string,
+    filter: Record<string, unknown>,
+    partialDoc: Record<string, unknown>
+  ): Promise<number> {
+    const keys = Object.keys(partialDoc)
+    if (keys.length === 0) return 0
+
+    const sets = keys.map((key, i) => `${ident(key)} = $${i + 1}`)
+    const params = keys.map(key => this.toParam(partialDoc[key]))
+    const columnTypes = this.embedInfo.get(collectionName)?.columnTypes
+    const { clause, params: whereParams } = this.buildWhere(filter, columnTypes, params.length)
+    params.push(...whereParams)
+    const sql = `UPDATE ${this.relName(collectionName)} SET ${sets.join(', ')}${clause}`
+    const result = await this.pool.query(sql, params)
+    return result.rowCount ?? 0
+  }
+
+  // === Private helpers ===
+
+  /** Resolve a vector per document: use a precomputed one, else embed embedFrom text. */
+  private async resolveVectors(
+    documents: IndexDocument[],
+    info?: CollectionEmbedInfo
+  ): Promise<Array<number[] | null>> {
+    const vectors: Array<number[] | null> = documents.map(doc => {
+      if (!info) return null
+      const existing = doc[info.embeddingField]
+      return Array.isArray(existing) && existing.every(v => typeof v === 'number') ? (existing as number[]) : null
+    })
+
+    if (!info || info.embedFrom.length === 0) return vectors
+
+    const toEmbedIndexes: number[] = []
+    const toEmbedTexts: string[] = []
+    for (let i = 0; i < documents.length; i++) {
+      if (vectors[i] !== null) continue
+      const text = info.embedFrom
+        .map(field => documents[i][field])
+        .filter(v => typeof v === 'string' && v.length > 0)
+        .join('\n')
+      if (text.length === 0) continue
+      toEmbedIndexes.push(i)
+      toEmbedTexts.push(text)
+    }
+
+    if (toEmbedTexts.length === 0) return vectors
+    if (!this.embeddingProvider) {
+      throw new Error(`Collection has embedFrom configured but no EmbeddingProvider was supplied to the adapter`)
+    }
+
+    const embedded = await this.embeddingProvider.embed(toEmbedTexts)
+    toEmbedIndexes.forEach((docIndex, k) => {
+      vectors[docIndex] = embedded[k]
+    })
+    return vectors
+  }
+
+  /** INSERT ... ON CONFLICT (id) DO UPDATE for one document. */
+  private async insertRow(
+    client: PoolClient,
+    collectionName: string,
+    document: IndexDocument,
+    vector: number[] | null,
+    info?: CollectionEmbedInfo
+  ): Promise<void> {
+    const idField = info?.idField ?? 'id'
+    const embeddingField = info?.embeddingField ?? 'embedding'
+
+    const columns: string[] = []
+    const placeholders: string[] = []
+    const params: unknown[] = []
+
+    for (const [key, value] of Object.entries(document)) {
+      if (key === embeddingField) continue // embedding handled below
+      columns.push(ident(key))
+      params.push(this.toParam(value))
+      placeholders.push(`$${params.length}`)
+    }
+
+    if (vector !== null) {
+      columns.push(ident(embeddingField))
+      params.push(toVectorLiteral(vector))
+      placeholders.push(`$${params.length}::vector`)
+    }
+
+    const updates = columns.filter(col => col !== ident(idField)).map(col => `${col} = EXCLUDED.${col}`)
+
+    const conflict =
+      updates.length > 0
+        ? `ON CONFLICT (${ident(idField)}) DO UPDATE SET ${updates.join(', ')}`
+        : `ON CONFLICT (${ident(idField)}) DO NOTHING`
+
+    const sql =
+      `INSERT INTO ${this.relName(collectionName)} (${columns.join(', ')}) ` +
+      `VALUES (${placeholders.join(', ')}) ${conflict}`
+
+    await client.query(sql, params)
+  }
+
+  /**
+   * Build a WHERE clause from a filter object with parameterized values. The
+   * operator is chosen by the column's SQL type: array columns (text[], e.g.
+   * taxonomy_slugs) use overlap/membership, scalar columns use equality/IN.
+   */
+  private buildWhere(
+    filter: Record<string, unknown>,
+    columnTypes: Record<string, PgFieldType> = {},
+    paramOffset = 0
+  ): { clause: string; params: unknown[] } {
+    const conditions: string[] = []
+    const params: unknown[] = []
+
+    for (const [key, value] of Object.entries(filter)) {
+      if (value === undefined) continue
+      const isArrayColumn = columnTypes[key] === 'text[]'
+
+      if (isArrayColumn && Array.isArray(value)) {
+        // Array column + array filter → overlap (any of the values present).
+        params.push(value)
+        conditions.push(`${ident(key)} && $${paramOffset + params.length}::text[]`)
+      } else if (isArrayColumn) {
+        // Array column + scalar filter → membership.
+        params.push(value)
+        conditions.push(`$${paramOffset + params.length} = ANY(${ident(key)})`)
+      } else if (Array.isArray(value)) {
+        // Scalar column + multiple values → IN list.
+        params.push(value)
+        conditions.push(`${ident(key)} = ANY($${paramOffset + params.length}::text[])`)
+      } else {
+        // Scalar column + scalar value → equality.
+        params.push(this.toParam(value))
+        conditions.push(`${ident(key)} = $${paramOffset + params.length}`)
+      }
+    }
+
+    const clause = conditions.length > 0 ? ` WHERE ${conditions.join(' AND ')}` : ''
+    return { clause, params }
+  }
+
+  /** Convert a JS value to a pg-bindable parameter (jsonb for plain objects). */
+  private toParam(value: unknown): unknown {
+    if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+      return JSON.stringify(value)
+    }
+    return value
+  }
+
+  /** Strip the embedding column and internal fields, applying include/exclude. */
+  private projectRow(
+    row: Record<string, unknown>,
+    embeddingField: string,
+    includeFields?: string[],
+    excludeFields?: string[]
+  ): Record<string, unknown> {
+    const out: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(row)) {
+      if (key === embeddingField || key === '_distance') continue
+      if (includeFields && !includeFields.includes(key)) continue
+      if (excludeFields?.includes(key)) continue
+      out[key] = value
+    }
+    return out
+  }
+}

--- a/packages/payload-pgvector/src/adapter/types.ts
+++ b/packages/payload-pgvector/src/adapter/types.ts
@@ -1,0 +1,61 @@
+import type { BaseCollectionSchema } from '@zetesis/payload-indexer'
+
+/**
+ * SQL column types we map indexer fields onto. Kept deliberately small — the
+ * indexer only needs scalars, text arrays (e.g. taxonomy_slugs), timestamps and
+ * the vector column.
+ */
+export type PgFieldType = 'text' | 'text[]' | 'int' | 'bigint' | 'bool' | 'timestamptz' | 'jsonb' | 'vector'
+
+/**
+ * A single column in a pgvector-backed collection (table).
+ */
+export interface PgFieldSchema {
+  name: string
+  type: PgFieldType
+  /** Required for `vector` columns: the embedding dimensionality (`vector(N)`). */
+  dimensions?: number
+  /** Create a btree/GIN index on this column. The vector column is handled separately (HNSW). */
+  index?: boolean
+  /** Whether the column is nullable. Defaults to true. */
+  optional?: boolean
+}
+
+/**
+ * pgvector-specific collection schema. Each collection maps to one Postgres
+ * table. Extends the indexer's BaseCollectionSchema so the IndexerAdapter
+ * contract is satisfied.
+ */
+export interface PgvectorCollectionSchema extends BaseCollectionSchema {
+  name: string
+  fields: PgFieldSchema[]
+  /** Primary key column. Defaults to `id`. */
+  idField?: string
+  /** Name of the `vector` column embeddings are stored in. Defaults to `embedding`. */
+  embeddingField?: string
+  /**
+   * Columns whose text is concatenated and embedded at upsert time when the
+   * document does not already carry a precomputed vector. Mirrors Typesense's
+   * `embed.from`. If omitted, the adapter never auto-embeds (vectors must be
+   * supplied in the document).
+   */
+  embedFrom?: string[]
+  /** HNSW index tuning for the embedding column. */
+  hnsw?: {
+    m?: number
+    efConstruction?: number
+    /** Distance operator class. Defaults to cosine. */
+    distance?: 'cosine' | 'l2' | 'ip'
+  }
+}
+
+/** Internal per-collection metadata captured from ensureCollection. */
+export interface CollectionEmbedInfo {
+  idField: string
+  embeddingField: string
+  embedFrom: string[]
+  dimensions: number
+  distance: 'cosine' | 'l2' | 'ip'
+  /** Column name → SQL type, used to pick the right filter operator (e.g. && vs =). */
+  columnTypes: Record<string, PgFieldType>
+}

--- a/packages/payload-pgvector/src/core/logging/logger.ts
+++ b/packages/payload-pgvector/src/core/logging/logger.ts
@@ -1,0 +1,19 @@
+/**
+ * Minimal namespaced logger. Kept dependency-free so the package stays isolated
+ * (mirrors payload-typesense's core/logging/logger but without extra deps).
+ */
+type LogArgs = unknown[]
+
+const prefix = '[payload-pgvector]'
+
+export const logger = {
+  info: (message: string, ...args: LogArgs): void => {
+    console.info(`${prefix} ${message}`, ...args)
+  },
+  warn: (message: string, ...args: LogArgs): void => {
+    console.warn(`${prefix} ${message}`, ...args)
+  },
+  error: (message: string, ...args: LogArgs): void => {
+    console.error(`${prefix} ${message}`, ...args)
+  }
+}

--- a/packages/payload-pgvector/src/embedding/provider.spec.ts
+++ b/packages/payload-pgvector/src/embedding/provider.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenAICompatibleEmbeddingProvider } from './provider'
+
+function fakeFetch() {
+  return vi.fn(
+    async () =>
+      new Response(JSON.stringify({ data: [{ embedding: [0.1, 0.2], index: 0 }] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' }
+      })
+  )
+}
+
+const base = {
+  baseUrl: 'http://litellm:4000/v1/',
+  apiKey: 'sk-test',
+  model: 'embeddings-dev',
+  dimensions: 1536
+}
+
+describe('OpenAICompatibleEmbeddingProvider', () => {
+  it('omits dimensions by default (TEI/Ollama/ada-002 reject the param)', async () => {
+    const fetchImpl = fakeFetch()
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    await provider.embed(['hello'])
+
+    const body = JSON.parse((fetchImpl.mock.calls[0]?.[1] as { body: string }).body)
+    expect(body).not.toHaveProperty('dimensions')
+    expect(body).toMatchObject({ model: 'embeddings-dev', input: ['hello'] })
+    // trailing slash on baseUrl is trimmed
+    expect(fetchImpl.mock.calls[0]?.[0]).toBe('http://litellm:4000/v1/embeddings')
+  })
+
+  it('sends dimensions only when sendDimensions is enabled', async () => {
+    const fetchImpl = fakeFetch()
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, sendDimensions: true, fetchImpl })
+
+    await provider.embed(['hello'])
+
+    const body = JSON.parse((fetchImpl.mock.calls[0]?.[1] as { body: string }).body)
+    expect(body.dimensions).toBe(1536)
+  })
+
+  it('returns [] without calling fetch for an empty batch', async () => {
+    const fetchImpl = fakeFetch()
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    await expect(provider.embed([])).resolves.toEqual([])
+    expect(fetchImpl).not.toHaveBeenCalled()
+  })
+
+  it('reorders vectors by the response index', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            data: [
+              { embedding: [2], index: 1 },
+              { embedding: [1], index: 0 }
+            ]
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+    )
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    await expect(provider.embed(['a', 'b'])).resolves.toEqual([[1], [2]])
+  })
+
+  it('throws on a misaligned batch (fewer embeddings than inputs)', async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [{ embedding: [0.1], index: 0 }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        })
+    )
+    const provider = new OpenAICompatibleEmbeddingProvider({ ...base, fetchImpl })
+
+    // Two inputs, one vector back → must fail loudly, not mispair text↔vector.
+    await expect(provider.embed(['a', 'b'])).rejects.toThrow(/count mismatch/)
+  })
+})

--- a/packages/payload-pgvector/src/embedding/provider.ts
+++ b/packages/payload-pgvector/src/embedding/provider.ts
@@ -97,9 +97,7 @@ export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
     // position, so a short/over-long response would mispair text↔vector (or push
     // an `undefined` vector downstream). Require one embedding per input.
     if (!Array.isArray(json.data) || json.data.length !== texts.length) {
-      throw new Error(
-        `Embedding response count mismatch: requested ${texts.length}, got ${json.data?.length ?? 0}`
-      )
+      throw new Error(`Embedding response count mismatch: requested ${texts.length}, got ${json.data?.length ?? 0}`)
     }
     // Preserve request order — some gateways return out-of-order by `index`.
     return [...json.data].sort((a, b) => a.index - b.index).map(item => item.embedding)

--- a/packages/payload-pgvector/src/embedding/provider.ts
+++ b/packages/payload-pgvector/src/embedding/provider.ts
@@ -1,0 +1,107 @@
+/**
+ * Embedding generation seam.
+ *
+ * pgvector — unlike Typesense — does NOT auto-embed: vectors must be produced
+ * app-side before they hit the database. `EmbeddingProvider` is the abstraction
+ * that does it. The default implementation talks to any OpenAI-compatible
+ * `/v1/embeddings` endpoint, so it works against OpenAI directly, a LiteLLM
+ * gateway, a local TEI/Ollama server, etc. — the package stays generic and the
+ * consumer points `baseUrl` wherever it routes embeddings.
+ */
+export interface EmbeddingProvider {
+  /**
+   * Stable identifier of the model the vectors are produced with. Index-time and
+   * query-time MUST use the same model + dimensions, or similarity is garbage.
+   */
+  readonly model: string
+
+  /** Dimensionality of the produced vectors (must match the `vector(N)` column). */
+  readonly dimensions: number
+
+  /** Embed a batch of texts. Order of the returned vectors matches the input. */
+  embed(texts: string[]): Promise<number[][]>
+}
+
+export interface OpenAICompatibleEmbeddingConfig {
+  /** Base URL of an OpenAI-compatible API, e.g. `http://litellm:4000/v1`. */
+  baseUrl: string
+  /** API key / virtual key sent as `Authorization: Bearer`. */
+  apiKey: string
+  /** Model name / alias to request, e.g. `embeddings-dev`. */
+  model: string
+  /** Vector dimensionality. Must match the target `vector(N)` column. */
+  dimensions: number
+  /**
+   * Send `dimensions` in the request body so a reduced-dim config produces
+   * vectors that fit the `vector(N)` column. Only the OpenAI `text-embedding-3-*`
+   * family (and gateways proxying them) honour it — ada-002, TEI, Ollama and
+   * most local servers reject the param, so this is OFF by default. Enable it
+   * only when the target model supports dimensionality reduction.
+   */
+  sendDimensions?: boolean
+  /** Optional fetch implementation override (testing). Defaults to global fetch. */
+  fetchImpl?: typeof fetch
+}
+
+interface OpenAIEmbeddingResponse {
+  data: Array<{ embedding: number[]; index: number }>
+}
+
+/**
+ * EmbeddingProvider backed by an OpenAI-compatible `/embeddings` endpoint.
+ */
+export class OpenAICompatibleEmbeddingProvider implements EmbeddingProvider {
+  readonly model: string
+  readonly dimensions: number
+  private readonly baseUrl: string
+  private readonly apiKey: string
+  private readonly sendDimensions: boolean
+  private readonly fetchImpl: typeof fetch
+
+  constructor(config: OpenAICompatibleEmbeddingConfig) {
+    this.model = config.model
+    this.dimensions = config.dimensions
+    this.baseUrl = config.baseUrl.replace(/\/$/, '')
+    this.apiKey = config.apiKey
+    this.sendDimensions = config.sendDimensions ?? false
+    this.fetchImpl = config.fetchImpl ?? fetch
+  }
+
+  async embed(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return []
+
+    const response = await this.fetchImpl(`${this.baseUrl}/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`
+      },
+      // Request the configured dimensionality only when the target model honours
+      // it (text-embedding-3-*); other backends reject the param. See sendDimensions.
+      body: JSON.stringify({
+        model: this.model,
+        input: texts,
+        ...(this.sendDimensions ? { dimensions: this.dimensions } : {})
+      }),
+      // Bound the request: a hung gateway must not block CMS saves or boot.
+      signal: AbortSignal.timeout(30_000)
+    })
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '')
+      throw new Error(`Embedding request failed (${response.status} ${response.statusText}): ${detail}`)
+    }
+
+    const json = (await response.json()) as OpenAIEmbeddingResponse
+    // Fail loudly on a misaligned batch: callers pair vectors to inputs by
+    // position, so a short/over-long response would mispair text↔vector (or push
+    // an `undefined` vector downstream). Require one embedding per input.
+    if (!Array.isArray(json.data) || json.data.length !== texts.length) {
+      throw new Error(
+        `Embedding response count mismatch: requested ${texts.length}, got ${json.data?.length ?? 0}`
+      )
+    }
+    // Preserve request order — some gateways return out-of-order by `index`.
+    return [...json.data].sort((a, b) => a.index - b.index).map(item => item.embedding)
+  }
+}

--- a/packages/payload-pgvector/src/index.ts
+++ b/packages/payload-pgvector/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @zetesis/payload-pgvector
+ *
+ * Postgres + pgvector search backend for Payload CMS. Implements the
+ * @zetesis/payload-indexer IndexerAdapter contract as a sibling of
+ * @zetesis/payload-typesense, with app-side embeddings via any OpenAI-compatible
+ * endpoint (OpenAI, a LiteLLM gateway, a local TEI/Ollama server, ...).
+ *
+ * Milestone 1: adapter + embedding provider. The features/search layer
+ * (hybrid, multi-collection, RAG endpoints) is built on top of this.
+ */
+
+export type { CreatePgvectorAdapterOptions } from './adapter/create-adapter'
+export { createPgvectorAdapter, createPgvectorAdapterFromPool } from './adapter/create-adapter'
+export type { PgvectorAdapterOptions } from './adapter/pgvector-adapter'
+// Adapter
+export { PgvectorAdapter } from './adapter/pgvector-adapter'
+
+// Schema types
+export type {
+  CollectionEmbedInfo,
+  PgFieldSchema,
+  PgFieldType,
+  PgvectorCollectionSchema
+} from './adapter/types'
+export type {
+  EmbeddingProvider,
+  OpenAICompatibleEmbeddingConfig
+} from './embedding/provider'
+// Embedding
+export { OpenAICompatibleEmbeddingProvider } from './embedding/provider'
+// Plugin (schema sync)
+export { createPgvectorPlugin } from './plugin/create-pgvector-plugin'
+export { deriveCollectionSchemas } from './plugin/derive-schema'
+export type { PgvectorFieldMapping, PgvectorPluginConfig } from './plugin/types'

--- a/packages/payload-pgvector/src/plugin/create-pgvector-plugin.ts
+++ b/packages/payload-pgvector/src/plugin/create-pgvector-plugin.ts
@@ -1,0 +1,43 @@
+import type { Config } from 'payload'
+import { logger } from '../core/logging/logger'
+import { deriveCollectionSchemas } from './derive-schema'
+import type { PgvectorPluginConfig } from './types'
+
+/**
+ * Schema-sync plugin for pgvector. Mirrors payload-typesense's createTypesenseRAGPlugin
+ * onInit step: on startup it ensures every configured table exists (CREATE
+ * EXTENSION + CREATE TABLE + HNSW index) via adapter.ensureCollection.
+ *
+ * It does NOT register sync hooks — pair it with createIndexerPlugin (same
+ * adapter) which handles document sync. The adapter generates embeddings at
+ * upsert time via its EmbeddingProvider.
+ *
+ * @example
+ * const adapter = createPgvectorAdapter({ connectionString, embedding: {...} })
+ * const { plugin: indexerPlugin } = createIndexerPlugin({ adapter, features: { sync: { enabled: true } }, collections })
+ * const pgvectorPlugin = createPgvectorPlugin({ adapter, collections, dimensions: 1536 })
+ * // plugins: [indexerPlugin, pgvectorPlugin]
+ */
+export const createPgvectorPlugin = (config: PgvectorPluginConfig) => {
+  return (payloadConfig: Config): Config => {
+    const schemas = deriveCollectionSchemas(config)
+
+    const incomingOnInit = payloadConfig.onInit
+    payloadConfig.onInit = async payload => {
+      if (incomingOnInit) {
+        await incomingOnInit(payload)
+      }
+
+      try {
+        logger.info(`Ensuring ${schemas.length} pgvector table(s)...`)
+        for (const schema of schemas) {
+          await config.adapter.ensureCollection(schema)
+        }
+      } catch (error) {
+        logger.error('Error ensuring pgvector tables', error)
+      }
+    }
+
+    return payloadConfig
+  }
+}

--- a/packages/payload-pgvector/src/plugin/derive-schema.spec.ts
+++ b/packages/payload-pgvector/src/plugin/derive-schema.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { PgFieldSchema } from '../adapter/types'
+import { deriveCollectionSchemas } from './derive-schema'
+import type { PgvectorPluginConfig } from './types'
+
+/**
+ * Pins the 3-way column contract that has no compile-time enforcement:
+ *   payload-indexer buildChunkDocument (what the syncer writes)
+ *     ↔ deriveCollectionSchemas (the table it builds, tested here)
+ *     ↔ mcp-pgvector buildSchema/filterColumns (what the probe reads + filters on).
+ * A rename in any leg silently mis-filters at runtime; this test makes the
+ * derive-schema leg fail loudly instead.
+ */
+const chunkedCollections = {
+  posts: [
+    {
+      enabled: true,
+      tableName: 'posts_pgvector_chunk',
+      syncDepth: 1,
+      embedding: {
+        fields: [],
+        chunking: { strategy: 'markdown', size: 2000, overlap: 300 },
+        autoEmbed: { from: ['chunk_text'], modelConfig: {} }
+      },
+      fields: [
+        { name: 'title', type: 'text' },
+        { name: 'slug', type: 'text', index: true },
+        { name: 'taxonomy_slugs', type: 'text[]', index: true, optional: true }
+      ]
+    }
+  ]
+}
+
+function derive() {
+  const [schema] = deriveCollectionSchemas({
+    collections: chunkedCollections,
+    dimensions: 1536
+  } as unknown as PgvectorPluginConfig)
+  const byName = new Map<string, PgFieldSchema>(schema.fields.map(f => [f.name, f]))
+  return { schema, byName }
+}
+
+describe('deriveCollectionSchemas — chunk table contract', () => {
+  it('names the table and embeds from chunk_text', () => {
+    const { schema } = derive()
+    expect(schema.name).toBe('posts_pgvector_chunk')
+    expect(schema.embedFrom).toEqual(['chunk_text'])
+    expect(schema.idField).toBe('id')
+  })
+
+  it('exposes the columns mcp-pgvector filters and reads on, with matching types', () => {
+    const { byName } = derive()
+    // Standard chunk columns the probe relies on (parent_doc_id, slug, chunk_text).
+    expect(byName.get('parent_doc_id')?.type).toBe('text')
+    expect(byName.get('chunk_text')?.type).toBe('text')
+    expect(byName.get('chunk_index')?.type).toBe('int')
+    expect(byName.get('slug')?.type).toBe('text')
+    // User scoping column used as the non-overridable taxonomy filter.
+    expect(byName.get('taxonomy_slugs')?.type).toBe('text[]')
+  })
+
+  it('merges the user index flag onto the standard slug column instead of dropping it', () => {
+    const { byName } = derive()
+    expect(byName.get('slug')?.index).toBe(true)
+    // taxonomy_slugs (user field) keeps its index too.
+    expect(byName.get('taxonomy_slugs')?.index).toBe(true)
+  })
+
+  it('appends the embedding vector column at the configured dimensionality', () => {
+    const { byName } = derive()
+    expect(byName.get('embedding')).toMatchObject({ type: 'vector', dimensions: 1536 })
+  })
+})

--- a/packages/payload-pgvector/src/plugin/derive-schema.ts
+++ b/packages/payload-pgvector/src/plugin/derive-schema.ts
@@ -1,0 +1,82 @@
+import type { PgFieldSchema, PgvectorCollectionSchema } from '../adapter/types'
+import type { PgvectorPluginConfig } from './types'
+
+/**
+ * Standard columns the payload-indexer sync emits for CHUNKED collections.
+ * Timestamps are epoch milliseconds (number) → bigint. Must stay in sync with
+ * payload-indexer's document-syncer buildChunkDocument().
+ */
+const chunkStandardFields = (): PgFieldSchema[] => [
+  { name: 'id', type: 'text' },
+  { name: 'parent_doc_id', type: 'text', index: true },
+  { name: 'chunk_index', type: 'int' },
+  { name: 'chunk_text', type: 'text' },
+  { name: 'is_chunk', type: 'bool' },
+  { name: 'headers', type: 'text[]', optional: true },
+  { name: 'createdAt', type: 'bigint', optional: true },
+  { name: 'updatedAt', type: 'bigint', optional: true },
+  { name: 'publishedAt', type: 'bigint', optional: true },
+  { name: 'content_hash', type: 'text', optional: true },
+  { name: 'slug', type: 'text', optional: true }
+]
+
+/** Standard columns the sync emits for FULL-DOCUMENT collections. */
+const docStandardFields = (): PgFieldSchema[] => [
+  { name: 'id', type: 'text' },
+  { name: 'slug', type: 'text', optional: true },
+  { name: 'createdAt', type: 'bigint', optional: true },
+  { name: 'updatedAt', type: 'bigint', optional: true },
+  { name: 'publishedAt', type: 'bigint', optional: true },
+  { name: 'content_hash', type: 'text', optional: true }
+]
+
+/**
+ * Derive pgvector table schemas from the indexer collections config. Adds the
+ * standard sync columns + the embedding vector column to the user-defined
+ * fields, so the table matches exactly what the syncer upserts.
+ */
+export const deriveCollectionSchemas = (config: PgvectorPluginConfig): PgvectorCollectionSchema[] => {
+  const { collections, dimensions, embeddingField = 'embedding', distance = 'cosine' } = config
+  const schemas: PgvectorCollectionSchema[] = []
+
+  for (const [slug, tableConfigs] of Object.entries(collections)) {
+    for (const tableConfig of tableConfigs) {
+      if (!tableConfig.enabled) continue
+
+      const chunked = Boolean(tableConfig.embedding?.chunking)
+      const standard = chunked ? chunkStandardFields() : docStandardFields()
+      const standardNames = new Set(standard.map(f => f.name))
+      const userByName = new Map(tableConfig.fields.map(f => [f.name, f]))
+
+      // Merge the user's index/optional flags onto standard columns they also
+      // declare (e.g. index:true on slug), instead of silently dropping them.
+      const mergedStandard: PgFieldSchema[] = standard.map(s => {
+        const u = userByName.get(s.name)
+        if (!u) return s
+        return { ...s, index: u.index ?? s.index, optional: u.optional ?? s.optional }
+      })
+
+      const userFields: PgFieldSchema[] = tableConfig.fields
+        .filter(field => !standardNames.has(field.name))
+        .map(field => ({
+          name: field.name,
+          type: field.type,
+          index: field.index,
+          optional: field.optional ?? true
+        }))
+
+      const embeddingColumn: PgFieldSchema = { name: embeddingField, type: 'vector', dimensions }
+
+      schemas.push({
+        name: tableConfig.tableName ?? slug,
+        idField: 'id',
+        embeddingField,
+        embedFrom: chunked ? ['chunk_text'] : [],
+        fields: [...mergedStandard, ...userFields, embeddingColumn],
+        hnsw: { distance }
+      })
+    }
+  }
+
+  return schemas
+}

--- a/packages/payload-pgvector/src/plugin/types.ts
+++ b/packages/payload-pgvector/src/plugin/types.ts
@@ -1,0 +1,36 @@
+import type { FieldMapping, IndexableCollectionConfig } from '@zetesis/payload-indexer'
+import type { PgvectorAdapter } from '../adapter/pgvector-adapter'
+import type { PgFieldType } from '../adapter/types'
+
+/**
+ * Field mapping for pgvector collections. `type` is the SQL column type used to
+ * build the table. Extends the indexer's base FieldMapping (name/payloadField/
+ * transform), mirroring how TypesenseFieldMapping extends it.
+ */
+export interface PgvectorFieldMapping extends FieldMapping {
+  /** SQL column type for this field. */
+  type: PgFieldType
+  /** Create a btree (scalar) / GIN (text[]) index on this column. */
+  index?: boolean
+  /** Whether the column is nullable. Defaults to true. */
+  optional?: boolean
+}
+
+/**
+ * Config for the pgvector schema-sync plugin. Pair it with createIndexerPlugin
+ * (which handles the actual document sync via hooks). This plugin only ensures
+ * the tables exist on startup — the equivalent of payload-typesense's onInit
+ * schema sync.
+ */
+export interface PgvectorPluginConfig {
+  /** The pgvector adapter (same instance passed to createIndexerPlugin). */
+  adapter: PgvectorAdapter
+  /** Collections to ensure tables for. */
+  collections: IndexableCollectionConfig<PgvectorFieldMapping>
+  /** Embedding dimensionality of the vector column (must match the provider). */
+  dimensions: number
+  /** Name of the vector column. Defaults to `embedding`. */
+  embeddingField?: string
+  /** Distance metric for the HNSW index. Defaults to `cosine`. */
+  distance?: 'cosine' | 'l2' | 'ip'
+}

--- a/packages/payload-pgvector/tsconfig.json
+++ b/packages/payload-pgvector/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "rootDir": "./src" },
+  "references": [{ "path": "../payload-indexer" }],
+  "include": ["src/**/*"]
+}

--- a/packages/payload-pgvector/tsdown.config.ts
+++ b/packages/payload-pgvector/tsdown.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'tsdown'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { resolve: true },
+  sourcemap: true,
+  clean: true,
+  treeshake: true,
+  outDir: 'dist',
+  tsconfig: './tsconfig.json',
+  external: ['@zetesis/payload-indexer', 'payload', 'pg']
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   apps/mcp:
     dependencies:
+      '@zetesis/mcp-pgvector':
+        specifier: workspace:*
+        version: link:../../packages/mcp-pgvector
       '@zetesis/mcp-typesense':
         specifier: workspace:*
         version: link:../../packages/mcp-typesense
@@ -75,6 +78,9 @@ importers:
       '@zetesis/payload-lexical-blocks-builder':
         specifier: workspace:*
         version: link:../../packages/payload-lexical-blocks-builder
+      '@zetesis/payload-pgvector':
+        specifier: workspace:*
+        version: link:../../packages/payload-pgvector
       '@zetesis/payload-taxonomies':
         specifier: workspace:*
         version: link:../../packages/payload-taxonomies

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,37 @@ importers:
         specifier: ^5.0.0
         version: 5.7.3
 
+  packages/mcp-pgvector:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@zetesis/payload-pgvector':
+        specifier: workspace:*
+        version: link:../payload-pgvector
+      pg:
+        specifier: ^8.13.1
+        version: 8.16.3
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.5.4
+        version: 22.19.13
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+      tsdown:
+        specifier: ^0.16.5
+        version: 0.16.8(typescript@5.7.3)
+      typescript:
+        specifier: 5.7.3
+        version: 5.7.3
+
   packages/mcp-typesense:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -263,7 +294,7 @@ importers:
         version: 2.1.0
       drizzle-orm:
         specifier: '>=0.36'
-        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.10.2)(bun-types@1.3.11)(pg@8.16.3)
+        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(pg@8.16.3)
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -303,7 +334,7 @@ importers:
         version: 2.1.1
       drizzle-orm:
         specifier: '>=0.36'
-        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.10.2)(bun-types@1.3.11)(pg@8.16.3)
+        version: 0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(pg@8.16.3)
       tailwind-merge:
         specifier: ^3.0.0
         version: 3.5.0
@@ -451,6 +482,37 @@ importers:
         version: 0.16.8(typescript@5.7.3)
       typescript:
         specifier: ^5.0.0
+        version: 5.7.3
+
+  packages/payload-pgvector:
+    dependencies:
+      '@zetesis/payload-indexer':
+        specifier: workspace:*
+        version: link:../payload-indexer
+      payload:
+        specifier: ^3.81.0
+        version: 3.81.0(graphql@16.13.1)(typescript@5.7.3)
+      pg:
+        specifier: ^8.13.1
+        version: 8.16.3
+      zod:
+        specifier: ^4.1.11
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.5.4
+        version: 22.19.13
+      '@types/pg':
+        specifier: ^8.11.10
+        version: 8.20.0
+      rimraf:
+        specifier: 3.0.2
+        version: 3.0.2
+      tsdown:
+        specifier: ^0.16.5
+        version: 0.16.8(typescript@5.7.3)
+      typescript:
+        specifier: 5.7.3
         version: 5.7.3
 
   packages/payload-taxonomies:
@@ -3605,6 +3667,9 @@ packages:
 
   '@types/pg@8.10.2':
     resolution: {integrity: sha512-MKFs9P6nJ+LAeHLU3V0cODEOgyThJ3OAnmOlsZsxux6sfQs3HRXR5bBn7xG5DjckEFhTAxsXi7k7cd0pCMxpJw==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
@@ -10831,6 +10896,12 @@ snapshots:
       pg-protocol: 1.13.0
       pg-types: 4.1.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.13
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
       '@types/react': 19.1.8
@@ -11714,6 +11785,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.10.2
+      bun-types: 1.3.11
+      pg: 8.16.3
+
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(bun-types@1.3.11)(pg@8.16.3):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/pg': 8.20.0
       bun-types: 1.3.11
       pg: 8.16.3
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,6 +56,12 @@
       "changelog-path": "CHANGELOG.md",
       "release-type": "node"
     },
+    "packages/payload-pgvector": {
+      "package-name": "@zetesis/payload-pgvector",
+      "component": "payload-pgvector",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node"
+    },
     "packages/payload-taxonomies": {
       "package-name": "@zetesis/payload-taxonomies",
       "component": "payload-taxonomies",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,8 +1,10 @@
 export default [
+  'packages/mcp-pgvector',
   'packages/mcp-typesense',
   'packages/nexus-queue',
   'packages/payload-agents-core',
   'packages/payload-agents-metrics',
   'packages/payload-indexer',
+  'packages/payload-pgvector',
   'packages/payload-typesense'
 ]


### PR DESCRIPTION
## What

First, minimal slice of pgvector support — the two building-block packages, nothing else:

- **`@zetesis/payload-pgvector`** — a Postgres + pgvector `IndexerAdapter` (sibling of `payload-typesense`), with app-side embeddings via any OpenAI-compatible endpoint (OpenAI, a LiteLLM gateway, TEI/Ollama).
- **`@zetesis/mcp-pgvector`** — a thin MCP server over a pgvector index, for A/B comparison vs the Typesense MCP (private/internal eval tool).

## Scope (intentionally minimal)

- **Single adapter, no selector** — no multi-adapter routing layer.
- **No LiteLLM routing** — the MCP is evaluated standalone; the app is untouched.
- **No breaking changes** — builds against `main`'s `payload-indexer` as-is. No `_syncStatus` namespacing: that rename only existed to let two adapters coexist on one collection; with a single adapter it isn't needed.

This is the clean, additive foundation. The multi-adapter selector and routing-through-LiteLLM — with all the authorization work that implies — are deliberately deferred. See the full audit + conclusions in #115.

## How to evaluate

Index content into the `pgvector` schema (via `createIndexerPlugin` + the adapter, or a seed that calls `adapter.upsertDocuments`), run `mcp-pgvector` standalone, and compare results against the Typesense MCP for the same queries. See each package's README.

## Verification

- TS: `tsc --noEmit` + Biome clean; **31 vitest** pass.
- Compiled `mcp-pgvector` artifact **starts** under `node`.
- Search / collection allowlist / non-overridable scope verified **end-to-end** against a live MCP + populated DB (devcontainer).

Branches from `main` directly — no submodule/PR dependency.
