### PR TITLE
chore: pin payload-pgvector initial release to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -60,7 +60,8 @@
       "package-name": "@zetesis/payload-pgvector",
       "component": "payload-pgvector",
       "changelog-path": "CHANGELOG.md",
-      "release-type": "node"
+      "release-type": "node",
+      "release-as": "0.1.0"
     },
     "packages/payload-taxonomies": {
       "package-name": "@zetesis/payload-taxonomies",


### PR DESCRIPTION
release-please defaults a brand-new component to **1.0.0**, which over-claims API stability for an experimental A/B package while its siblings (`payload-indexer`, `payload-typesense`) sit at 0.4.x and the config deliberately keeps everything pre-major (`bump-patch-for-minor-pre-major`).

Pins `payload-pgvector`'s first release to **0.1.0** via `release-as`.

Once the release PR publishes 0.1.0, **remove this `release-as`** so feature commits resume normal pre-major patch bumps (0.1.0 → 0.1.1 → …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)