### PR TITLE
chore: drop payload-pgvector release-as after initial 0.1.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -60,8 +60,7 @@
       "package-name": "@zetesis/payload-pgvector",
       "component": "payload-pgvector",
       "changelog-path": "CHANGELOG.md",
-      "release-type": "node",
-      "release-as": "0.1.0"
+      "release-type": "node"
     },
     "packages/payload-taxonomies": {
       "package-name": "@zetesis/payload-taxonomies",


### PR DESCRIPTION
Follow-up to Zetesis-Labs/PayloadAgents#118.

`release-as: 0.1.0` was a one-shot to make `payload-pgvector` debut at **0.1.0** instead of release-please's default **1.0.0**. But `release-as` is **sticky** — while it's in the config, feature commits can't bump the version.

This PR removes it so normal pre-major patch bumps resume (`0.1.0 → 0.1.1 → …`).

## ⚠️ Merge order
**Kept as draft on purpose.** Merge this **only after** `@zetesis/payload-pgvector@0.1.0` is actually published to npm (i.e. after the release PR for 0.1.0 is merged). Merging it before would let release-please recompute the pending release back to 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)