### PR TITLE
fix: tenant-isolate agno chat sessions (stamp tenant at creation, filter list, deny null)

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -34,9 +34,17 @@ def build_agent(
 
     proxy_key = resolve_litellm_proxy_key(cfg)
 
+    # Stamp the agent's tenant into every session it creates. Agno persists the
+    # agent's static `metadata` onto the session row at creation, so ownership is
+    # tenant-scoped from the start (see multiTenantSessionStrategy in
+    # payload-agents-core) instead of relying on a lazy first-touch back-fill.
+    # Stored as a string to match the `metadata->>'tenant_id'` text comparison.
+    session_metadata = {"tenant_id": str(cfg.tenant_id)} if cfg.tenant_id is not None else None
+
     return Agent(
         name=cfg.name,
         id=cfg.slug,
+        metadata=session_metadata,
         model=build_model(
             llm_model,
             cfg.api_key.get_secret_value(),

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -78,6 +78,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
 
     tenant = doc.get("tenant")
     tenant_slug = tenant.get("slug") if isinstance(tenant, dict) else None
+    tenant_id = tenant.get("id") if isinstance(tenant, dict) else None
 
     # The agent can carry several retrieval profiles (`retrievalProfiles`, the
     # multi-lente catalog). Fall back to a legacy single `defaultRetrievalProfile`
@@ -148,6 +149,7 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         if isinstance(doc.get("systemPrompt"), str)
         else None,
         tenant_slug=tenant_slug,
+        tenant_id=tenant_id,
         taxonomy_slugs=taxonomy_slugs,
         folder_slugs=folder_slugs,
         search_collections=search_collections,

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -57,6 +57,10 @@ class AgentConfig(BaseModel):
     litellm_virtual_key: SecretStr | None = None
     instructions_extra: str | None = None
     tenant_slug: str | None = None
+    # Numeric tenant id (Payload relationship id). Stamped into the Agno session
+    # `metadata.tenant_id` at creation so session ownership is tenant-scoped from
+    # the start instead of relying on a lazy first-touch back-fill.
+    tenant_id: int | str | None = None
     taxonomy_slugs: list[str] = []
     folder_slugs: list[str] = []
     search_collections: list[str] = []

--- a/packages/payload-agents-core/src/endpoints/sessions.ts
+++ b/packages/payload-agents-core/src/endpoints/sessions.ts
@@ -4,6 +4,7 @@
  * Proxies to Agno `GET /sessions?type=agent&user_id=…`.
  */
 
+import { sql } from 'drizzle-orm'
 import type { PayloadHandler } from 'payload'
 import { runtimeFetch } from '../lib/runtime-client'
 import { getUserId } from '../lib/user'
@@ -53,7 +54,29 @@ export function createSessionsListHandler(config: ResolvedPluginConfig): Payload
         }>
       }
 
-      const sessions = (body.data || []).map(s => ({
+      let rows = body.data || []
+
+      // Tenant-scope the list: a multi-tenant user must not see sessions that
+      // belong to their *other* tenants. The runtime stamps `metadata.tenant_id`
+      // on each session at creation, so we post-filter this user's sessions to
+      // those matching the active tenant. Sessions without a tenant are excluded.
+      // (No tenant resolver configured = single-tenant deployment = no filter.)
+      const tenantId = config.extractTenantId?.(user, req)
+      if (tenantId !== undefined && tenantId !== null && tenantId !== '' && rows.length > 0) {
+        const drizzle = (
+          req.payload.db as unknown as {
+            drizzle: { execute: (q: unknown) => Promise<{ rows: Record<string, unknown>[] }> }
+          }
+        ).drizzle
+        const { rows: owned } = await drizzle.execute(sql`
+          SELECT session_id FROM agno.agno_sessions
+          WHERE user_id = ${String(userId)} AND metadata->>'tenant_id' = ${String(tenantId)}
+        `)
+        const allowed = new Set(owned.map(r => r.session_id as string))
+        rows = rows.filter(s => allowed.has(s.session_id))
+      }
+
+      const sessions = rows.map(s => ({
         conversation_id: s.session_id,
         title: s.session_name || undefined,
         last_activity: s.updated_at || s.created_at || '',

--- a/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
@@ -113,14 +113,15 @@ describe('multiTenantSessionStrategy — validateSessionOwnership', () => {
     expect(warn).toHaveBeenCalledOnce()
   })
 
-  it('back-fills tenant_id and returns true when stored tenant_id is null but user_id matches', async () => {
+  it('denies and returns false when stored tenant_id is null, even if user_id matches', async () => {
     const strategy = multiTenantSessionStrategy({ extractTenantId: () => 1 })
     const { payload, execute, warn } = makePayload([{ user_id: '42', tenant_id: null }])
     const ok = await strategy.validateSessionOwnership('s', { user: alice, payload, req: makeReq() })
-    expect(ok).toBe(true)
-    expect(warn).not.toHaveBeenCalled()
-    // Two queries: SELECT to read the row, UPDATE to back-fill metadata.tenant_id.
-    expect(execute).toHaveBeenCalledTimes(2)
+    expect(ok).toBe(false)
+    expect(warn).toHaveBeenCalledOnce()
+    // Only the SELECT runs — no first-touch back-fill UPDATE (a tenant-less session
+    // is an anomaly now that the runtime stamps tenant_id at creation).
+    expect(execute).toHaveBeenCalledOnce()
   })
 
   it('does not back-fill and returns false when stored tenant_id is null but user_id differs', async () => {

--- a/packages/payload-agents-core/src/lib/multi-tenant.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.ts
@@ -45,6 +45,11 @@ export interface MultiTenantSessionStrategy {
   buildSessionId: BuildSessionId
   validateSessionOwnership: ValidateSessionOwnership
   /**
+   * Resolves the active tenant id for the current request. Passed through to
+   * `agentPlugin` so the session-list endpoint can scope results to the tenant.
+   */
+  extractTenantId: (user: TypedUser, req: PayloadRequest) => string | number | null | undefined
+  /**
    * Forwards the current tenant id as `X-Tenant-Id` to the agent-runtime
    * so it can persist it into the Agno session's `metadata` JSONB.
    * Pass this into `agentPlugin({ getRuntimeHeaders })`.
@@ -162,5 +167,5 @@ export function multiTenantSessionStrategy(options: MultiTenantSessionStrategyOp
     return { 'X-Tenant-Id': String(tenantId) }
   }
 
-  return { buildSessionId, validateSessionOwnership, getRuntimeHeaders }
+  return { buildSessionId, validateSessionOwnership, extractTenantId: options.extractTenantId, getRuntimeHeaders }
 }

--- a/packages/payload-agents-core/src/lib/multi-tenant.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.ts
@@ -7,13 +7,14 @@
  *   `user_id` (native column) and `metadata->>'tenant_id'` (back-filled by
  *   this strategy on the first validate; see below).
  *
- * Tenant back-fill: Agno (>=2.5) only writes the agent's static `metadata`
- * to the session row, ignoring the per-run `metadata=` kwarg the runtime
- * forwards from `X-Tenant-Id`. To keep `metadata.tenant_id` accurate without
- * patching Agno, `validateSessionOwnership` updates the column the first
- * time it sees a row with `metadata.tenant_id IS NULL` and a matching
- * `user_id`. An expression index on `(metadata->>'tenant_id')` is
- * recommended for query performance.
+ * Tenant stamping: the agent-runtime sets the agent's static `metadata` to
+ * `{ tenant_id }`, and Agno persists that onto every session row it creates,
+ * so `metadata.tenant_id` is populated from creation. `validateSessionOwnership`
+ * fails closed: it rejects a session whose stored tenant doesn't match the
+ * active tenant, and rejects a tenant-less session outright (no first-touch
+ * back-fill — that would let a session be pulled into whichever tenant reaches
+ * it first). An expression index on `(metadata->>'tenant_id')` is recommended
+ * for query performance.
  */
 
 import { sql } from 'drizzle-orm'
@@ -126,21 +127,15 @@ export function multiTenantSessionStrategy(options: MultiTenantSessionStrategyOp
     }
 
     if (storedTenantId === null) {
-      // Two pitfalls in this UPDATE:
-      //   1. pg can't infer the type of jsonb_build_object's anyelement arg, so
-      //      the parameter needs an explicit ::text cast (else 42P18).
-      //   2. Postgres's `||` on non-object operands wraps both into an array
-      //      (e.g. 'null'::jsonb || {} → [null, {}]). COALESCE only catches SQL
-      //      NULL, not JSONB null/scalars/arrays — so we normalize via
-      //      jsonb_typeof before merging.
-      await db.execute(sql`
-        UPDATE agno.agno_sessions
-        SET metadata = (
-          CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END
-        ) || jsonb_build_object('tenant_id', ${String(tenantId)}::text)
-        WHERE session_id = ${sessionId}
-      `)
-      return true
+      // Fail closed. The runtime stamps `metadata.tenant_id` at session creation
+      // (Agent static metadata in agno-agent-builder), so a tenant-less session is
+      // an anomaly — not an unclaimed row to back-fill. Claiming it for whoever
+      // validates first would let a session be pulled into the wrong tenant.
+      payload.logger.warn(
+        { sessionId, expectedTenantId: String(tenantId) },
+        '[multi-tenant] session ownership denied: session has no tenant_id'
+      )
+      return false
     }
 
     if (storedTenantId !== String(tenantId)) {

--- a/packages/payload-agents-core/src/plugin.ts
+++ b/packages/payload-agents-core/src/plugin.ts
@@ -64,6 +64,7 @@ function resolveConfig(userConfig: AgentPluginConfig): ResolvedPluginConfig {
     getDailyLimit: userConfig.getDailyLimit,
     buildSessionId: userConfig.buildSessionId ?? defaultBuildSessionId,
     validateSessionOwnership: userConfig.validateSessionOwnership ?? defaultValidateSessionOwnership,
+    extractTenantId: userConfig.extractTenantId,
     getRuntimeHeaders: userConfig.getRuntimeHeaders,
     collectionSlug: userConfig.collectionSlug ?? 'agents',
     basePath: userConfig.basePath ?? '/agents',

--- a/packages/payload-agents-core/src/types.ts
+++ b/packages/payload-agents-core/src/types.ts
@@ -100,6 +100,15 @@ export interface AgentPluginConfig {
   }) => Record<string, string> | Promise<Record<string, string>>
 
   /**
+   * Resolve the active tenant id for the current request. Used to scope the
+   * session list (`GET {basePath}/sessions`) to the current tenant so a
+   * multi-tenant user doesn't see sessions from their other tenants. When
+   * omitted the list is not tenant-filtered (single-tenant deployments).
+   * Provided automatically by `multiTenantSessionStrategy`.
+   */
+  extractTenantId?: (user: TypedUser, req: PayloadRequest) => string | number | null | undefined
+
+  /**
    * Override the Payload collection slug. Default: `'agents'`.
    */
   collectionSlug?: string
@@ -253,6 +262,7 @@ export interface ResolvedPluginConfig {
   getDailyLimit: (payload: Payload, userId: string | number) => Promise<number>
   buildSessionId: BuildSessionId
   validateSessionOwnership: ValidateSessionOwnership
+  extractTenantId: ((user: TypedUser, req: PayloadRequest) => string | number | null | undefined) | undefined
   getRuntimeHeaders:
     | ((ctx: {
         user: TypedUser


### PR DESCRIPTION
## Problem

A multi-tenant user (a user with roles in more than one tenant) could see — and in some cases continue — chat sessions belonging to their **other** tenants. Two gaps:

1. **`GET {basePath}/sessions` had no tenant filter** — it listed every session for the `user_id`, so a user working in tenant B saw the titles/timestamps of their tenant-A sessions.
2. **Sessions were created with no `tenant_id`** and only got one via a lazy first-touch back-fill in `validateSessionOwnership`, which **claimed a tenant-less session for whichever tenant reached it first** — pulling a session into the wrong tenant.

Bounding (not a cross-user breach): `user_id` is always checked, so user A never sees user B's sessions. The leak is one user seeing/mixing their own data across their own tenants — but tenant isolation is exactly the boundary that's supposed to hold for shared users (consultants/operators serving multiple clients).

Found via cross-review (independently flagged by Codex) and verified against the code.

## Fix (3 commits, root → leak → fail-closed)

1. **`fix(agno-agent-builder)`: stamp `tenant_id` at session creation.** Agno persists the agent's *static* `metadata` onto every session row it creates, so setting `Agent(metadata={"tenant_id": ...})` scopes ownership from the start. Surfaces the tenant id (not just slug) through `AgentConfig` + `PayloadAgentSource`. The agent is already config-bound to one tenant, so its tenant is the session's tenant — unambiguous.
2. **`fix(payload-agents-core)`: tenant-scope the session list.** The list endpoint now filters to sessions whose `metadata.tenant_id` matches the active tenant (resolved via a new `extractTenantId` config, exposed by `multiTenantSessionStrategy` — no app wiring change needed). No resolver = single-tenant = unfiltered.
3. **`fix(payload-agents-core)`: deny tenant-less sessions.** `validateSessionOwnership` no longer back-fills a NULL `tenant_id` and allows access; it fails closed. Now that (1) stamps at creation, a tenant-less session is an anomaly. Spec updated.

## Why no migration / flag

The owner confirmed there is **no production session data at risk right now**, so the usual "existing rows are all NULL → filtering hides them / deny breaks them → migrate first" sequencing doesn't apply. Shipped directly.

## ⚠️ Verify in staging before prod

The fix rests on one runtime behavior I could confirm by API surface but not end-to-end: **that Agno persists `Agent.metadata` to the session row as `metadata.tenant_id`**. Confirmed: `Agent` accepts `metadata` (agno `agent.py:339,580`) and `AgentSession` carries `metadata` (`session/agent.py:33,73`); the existing `multiTenantSessionStrategy` comment documents this Agno behavior. **Before prod**, run one chat in staging and check `SELECT metadata FROM agno.agno_sessions` shows `tenant_id` — because commit 3 (deny-null) would block sessions if stamping silently failed.

## Tests

`payload-agents-core`: 93/93 pass (multi-tenant spec updated for the deny-null behavior). Build + biome + ruff green. Session-list filter has no unit test yet (no existing `sessions.spec.ts`) — follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
