### PR TITLE
fix: restore chat continuity — back-fill session tenant from the caller, not the agent

### DIFF
--- a/backend/agno-agent-builder/agno_agent_builder/builder.py
+++ b/backend/agno-agent-builder/agno_agent_builder/builder.py
@@ -34,17 +34,9 @@ def build_agent(
 
     proxy_key = resolve_litellm_proxy_key(cfg)
 
-    # Stamp the agent's tenant into every session it creates. Agno persists the
-    # agent's static `metadata` onto the session row at creation, so ownership is
-    # tenant-scoped from the start (see multiTenantSessionStrategy in
-    # payload-agents-core) instead of relying on a lazy first-touch back-fill.
-    # Stored as a string to match the `metadata->>'tenant_id'` text comparison.
-    session_metadata = {"tenant_id": str(cfg.tenant_id)} if cfg.tenant_id is not None else None
-
     return Agent(
         name=cfg.name,
         id=cfg.slug,
-        metadata=session_metadata,
         model=build_model(
             llm_model,
             cfg.api_key.get_secret_value(),

--- a/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/payload.py
@@ -78,7 +78,6 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
 
     tenant = doc.get("tenant")
     tenant_slug = tenant.get("slug") if isinstance(tenant, dict) else None
-    tenant_id = tenant.get("id") if isinstance(tenant, dict) else None
 
     # The agent can carry several retrieval profiles (`retrievalProfiles`, the
     # multi-lente catalog). Fall back to a legacy single `defaultRetrievalProfile`
@@ -149,7 +148,6 @@ def payload_doc_to_agent_config(doc: dict[str, Any]) -> AgentConfig:
         if isinstance(doc.get("systemPrompt"), str)
         else None,
         tenant_slug=tenant_slug,
-        tenant_id=tenant_id,
         taxonomy_slugs=taxonomy_slugs,
         folder_slugs=folder_slugs,
         search_collections=search_collections,

--- a/backend/agno-agent-builder/agno_agent_builder/sources/types.py
+++ b/backend/agno-agent-builder/agno_agent_builder/sources/types.py
@@ -57,10 +57,6 @@ class AgentConfig(BaseModel):
     litellm_virtual_key: SecretStr | None = None
     instructions_extra: str | None = None
     tenant_slug: str | None = None
-    # Numeric tenant id (Payload relationship id). Stamped into the Agno session
-    # `metadata.tenant_id` at creation so session ownership is tenant-scoped from
-    # the start instead of relying on a lazy first-touch back-fill.
-    tenant_id: int | str | None = None
     taxonomy_slugs: list[str] = []
     folder_slugs: list[str] = []
     search_collections: list[str] = []

--- a/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.spec.ts
@@ -113,15 +113,14 @@ describe('multiTenantSessionStrategy — validateSessionOwnership', () => {
     expect(warn).toHaveBeenCalledOnce()
   })
 
-  it('denies and returns false when stored tenant_id is null, even if user_id matches', async () => {
+  it('back-fills tenant_id and returns true when stored tenant_id is null but user_id matches', async () => {
     const strategy = multiTenantSessionStrategy({ extractTenantId: () => 1 })
     const { payload, execute, warn } = makePayload([{ user_id: '42', tenant_id: null }])
     const ok = await strategy.validateSessionOwnership('s', { user: alice, payload, req: makeReq() })
-    expect(ok).toBe(false)
-    expect(warn).toHaveBeenCalledOnce()
-    // Only the SELECT runs — no first-touch back-fill UPDATE (a tenant-less session
-    // is an anomaly now that the runtime stamps tenant_id at creation).
-    expect(execute).toHaveBeenCalledOnce()
+    expect(ok).toBe(true)
+    expect(warn).not.toHaveBeenCalled()
+    // Two queries: SELECT to read the row, UPDATE to back-fill metadata.tenant_id.
+    expect(execute).toHaveBeenCalledTimes(2)
   })
 
   it('does not back-fill and returns false when stored tenant_id is null but user_id differs', async () => {

--- a/packages/payload-agents-core/src/lib/multi-tenant.ts
+++ b/packages/payload-agents-core/src/lib/multi-tenant.ts
@@ -7,14 +7,15 @@
  *   `user_id` (native column) and `metadata->>'tenant_id'` (back-filled by
  *   this strategy on the first validate; see below).
  *
- * Tenant stamping: the agent-runtime sets the agent's static `metadata` to
- * `{ tenant_id }`, and Agno persists that onto every session row it creates,
- * so `metadata.tenant_id` is populated from creation. `validateSessionOwnership`
- * fails closed: it rejects a session whose stored tenant doesn't match the
- * active tenant, and rejects a tenant-less session outright (no first-touch
- * back-fill — that would let a session be pulled into whichever tenant reaches
- * it first). An expression index on `(metadata->>'tenant_id')` is recommended
- * for query performance.
+ * Tenant back-fill: Agno (>=2.5) only writes the agent's static `metadata`
+ * to the session row, ignoring the per-run `metadata=` kwarg the runtime
+ * forwards from `X-Tenant-Id`. The agent's static metadata is the *agent's*
+ * tenant, not the *user's* active tenant — and ownership is keyed on the
+ * user's tenant — so we never stamp from the runtime. Instead,
+ * `validateSessionOwnership` back-fills `metadata.tenant_id` with the caller's
+ * active tenant the first time it sees a row with `metadata.tenant_id IS NULL`
+ * and a matching `user_id`. An expression index on `(metadata->>'tenant_id')`
+ * is recommended for query performance.
  */
 
 import { sql } from 'drizzle-orm'
@@ -127,15 +128,23 @@ export function multiTenantSessionStrategy(options: MultiTenantSessionStrategyOp
     }
 
     if (storedTenantId === null) {
-      // Fail closed. The runtime stamps `metadata.tenant_id` at session creation
-      // (Agent static metadata in agno-agent-builder), so a tenant-less session is
-      // an anomaly — not an unclaimed row to back-fill. Claiming it for whoever
-      // validates first would let a session be pulled into the wrong tenant.
-      payload.logger.warn(
-        { sessionId, expectedTenantId: String(tenantId) },
-        '[multi-tenant] session ownership denied: session has no tenant_id'
-      )
-      return false
+      // Back-fill with the *caller's* active tenant (the session was created by
+      // this user; Agno can't stamp the per-user tenant at creation — see header).
+      // Two pitfalls in this UPDATE:
+      //   1. pg can't infer the type of jsonb_build_object's anyelement arg, so
+      //      the parameter needs an explicit ::text cast (else 42P18).
+      //   2. Postgres's `||` on non-object operands wraps both into an array
+      //      (e.g. 'null'::jsonb || {} → [null, {}]). COALESCE only catches SQL
+      //      NULL, not JSONB null/scalars/arrays — so we normalize via
+      //      jsonb_typeof before merging.
+      await db.execute(sql`
+        UPDATE agno.agno_sessions
+        SET metadata = (
+          CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END
+        ) || jsonb_build_object('tenant_id', ${String(tenantId)}::text)
+        WHERE session_id = ${sessionId}
+      `)
+      return true
     }
 
     if (storedTenantId !== String(tenantId)) {


### PR DESCRIPTION
## The regression

#120 broke multi-turn chat continuity. Root cause, confirmed in prod logs:

```
expectedTenantId:"5"  storedTenantId:"2"  → "tenant mismatch" → ownership DENIED
```
3 sessions, 1 run each — every message spawned a new session and lost history.

#120 stamped the session's `metadata.tenant_id` with the **agent's** tenant (`cfg.tenant_id`) via Agno static metadata. But `validateSessionOwnership` keys on the **user's active tenant** (`extractTenantId`). When they differ (agent in tenant A, user active in B — a normal multi-tenant case), every continue is denied. Agno can't stamp the per-user tenant at creation (it ignores the per-run metadata kwarg), so the agent-static approach was fundamentally wrong.

## The fix (keeps the security win)

- ❌ **Revert** the agent-tenant stamping (`agno-agent-builder`) and the deny-null path.
- ✅ **Restore** the back-fill: `validateSessionOwnership` sets `metadata.tenant_id` to the **caller's** active tenant on first touch (the proven, working behavior).
- ✅ **Keep** the tenant-scoped session list (`extractTenantId` + filter) — the real isolation win from #120 — and the mismatch-denial boundary (unchanged).

Net: continuity restored, session list still tenant-scoped.

## Tests
`payload-agents-core` 13/13 (back-fill test restored). Build + ruff + biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)