### PR TITLE
docs: rename chat-agent -> agent-ui in architecture docs

### DIFF
--- a/docs/architecture/npm-publishability.md
+++ b/docs/architecture/npm-publishability.md
@@ -131,7 +131,7 @@ El consumidor que instala el paquete recibe estos tipos genericos. Su propia app
 | payload-indexer | `["dist"]` | Solo artefactos compilados |
 | payload-typesense | `["dist"]` | Solo artefactos compilados |
 | payload-betterauth-stripe | `["dist", "README.md"]` | + documentacion |
-| chat-agent | `["dist", "src", "README.md"]` | + source (para CSS/Tailwind) |
+| agent-ui | `["dist", "src", "README.md"]` | + source (para CSS/Tailwind) |
 
 **Regla general**: Solo incluir `dist/`. El source (`src/`) solo se incluye si el consumidor lo necesita (e.g. CSS con Tailwind que necesita escanear source para purge).
 
@@ -566,7 +566,7 @@ grep -r "from '\.\." dist/*.d.mts  # No debe haber imports relativos que salgan 
 | payload-betterauth-stripe | `.`, `./server`, `./client`, `./rsc` | 4 entry points |
 | payload-lexical-blocks-builder | `.`, `./builder`, `./renderer` | 3 entry points |
 | payload-taxonomies | `.`, `./constants` | 2 entry points |
-| chat-agent | `.`, `./styles.css` | 1 TS + 1 CSS |
+| agent-ui | `.`, `./styles.css` | 1 TS + 1 CSS |
 
 ---
 

--- a/docs/architecture/typescript-monorepo-types.md
+++ b/docs/architecture/typescript-monorepo-types.md
@@ -148,14 +148,14 @@ const user = (await payload.findByID({
 ### Grafo de dependencias
 
 ```
-chat-agent                      (leaf - sin deps Payload)
+agent-ui                      (leaf - sin deps Payload)
 payload-indexer                 (leaf)
 payload-taxonomies              (leaf)
 payload-lexical-blocks-builder  (leaf)
 payload-betterauth-stripe       (leaf)
 payload-typesense               -> payload-indexer
 
-apps/server -> chat-agent, payload-betterauth-stripe,
+apps/server -> agent-ui, payload-betterauth-stripe,
                payload-indexer, payload-taxonomies,
                payload-typesense
 ```


### PR DESCRIPTION
The chat-agent package was renamed to agent-ui. This updates the package-name references in the type-architecture docs (dependency graph in typescript-monorepo-types.md + npm files tables in npm-publishability.md) to match. Docs-only; no code or version impact. Part of a cross-repo documentation sync with ZetesisPortal.