### PR TITLE
fix(mcp-typesense): enforce retrieval profile scope as a ceiling, not a default

### DIFF
--- a/packages/mcp-typesense/src/auth/profile-scope.spec.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.spec.ts
@@ -18,17 +18,23 @@ const auth: McpAuthContext = {
   }
 }
 
+/** Unwrap a successful result; fails the test when the scope errored. */
+const unwrap = (result: Awaited<ReturnType<typeof applyProfileScope>>): McpAuthContext | null => {
+  if (!result.ok) throw new Error(`expected ok, got ${result.error.error}`)
+  return result.auth
+}
+
 describe('applyProfileScope', () => {
   it('returns auth unchanged when no slug', async () => {
-    expect(await applyProfileScope(auth, undefined)).toBe(auth)
+    expect(unwrap(await applyProfileScope(auth, undefined))).toBe(auth)
   })
 
   it('returns null auth as-is', async () => {
-    expect(await applyProfileScope(null, 'a')).toBeNull()
+    expect(unwrap(await applyProfileScope(null, 'a'))).toBeNull()
   })
 
   it('applies the chosen profile filters + lente from groupProfiles (header/token route)', async () => {
-    const scoped = await applyProfileScope(auth, 'a')
+    const scoped = unwrap(await applyProfileScope(auth, 'a'))
     expect(scoped?.taxonomySlugs).toEqual(['mises'])
     expect(scoped?.folderSlugs).toEqual(['f1'])
     expect(scoped?.retrieval?.learnedHead).toEqual(lente)
@@ -39,8 +45,16 @@ describe('applyProfileScope', () => {
 
   it('header source takes priority over the resolver', async () => {
     const resolver = vi.fn()
-    const scoped = await applyProfileScope(auth, 'a', resolver)
+    const scoped = unwrap(await applyProfileScope(auth, 'a', resolver))
     expect(scoped?.taxonomySlugs).toEqual(['mises'])
+    expect(resolver).not.toHaveBeenCalled()
+  })
+
+  it('skips the resolver when the request already carries that profile scope', async () => {
+    const resolver = vi.fn()
+    const applied: McpAuthContext = { tenantSlug: 't', taxonomySlugs: ['bastos'], defaultProfileSlug: 'bastos' }
+    const scoped = unwrap(await applyProfileScope(applied, 'bastos', resolver))
+    expect(scoped).toBe(applied)
     expect(resolver).not.toHaveBeenCalled()
   })
 
@@ -49,22 +63,33 @@ describe('applyProfileScope', () => {
 
     it('resolves the scope by slug+tenant when not in headers', async () => {
       const resolver = vi.fn().mockResolvedValue({ taxonomySlugs: ['plotino'], retrieval: { learnedHead: lente } })
-      const scoped = await applyProfileScope(bare, 'neo', resolver)
+      const scoped = unwrap(await applyProfileScope(bare, 'neo', resolver))
       expect(resolver).toHaveBeenCalledWith('t', 'neo')
       expect(scoped?.taxonomySlugs).toEqual(['plotino'])
       expect(scoped?.retrieval?.learnedHead).toEqual(lente)
     })
 
-    it('returns base auth when the resolver finds nothing', async () => {
+    it('fails closed when the resolver finds nothing', async () => {
       const resolver = vi.fn().mockResolvedValue(null)
-      expect(await applyProfileScope(bare, 'zzz', resolver)).toBe(bare)
+      const result = await applyProfileScope(bare, 'zzz', resolver)
+      expect(result.ok).toBe(false)
+      if (result.ok) return
+      expect(result.error.error).toBe('retrieval_profile_unresolved')
+      expect(result.error.profile).toBe('zzz')
+      expect(result.error.message).toMatch(/NOT executed/)
     })
 
-    it('does not call the resolver without a tenant', async () => {
+    it('fails closed without a tenant instead of searching unscoped', async () => {
       const resolver = vi.fn()
       const noTenant: McpAuthContext = { availableProfiles: [] }
-      expect(await applyProfileScope(noTenant, 'neo', resolver)).toBe(noTenant)
+      const result = await applyProfileScope(noTenant, 'neo', resolver)
+      expect(result.ok).toBe(false)
       expect(resolver).not.toHaveBeenCalled()
+    })
+
+    it('fails closed when no resolver is configured', async () => {
+      const result = await applyProfileScope(bare, 'neo')
+      expect(result.ok).toBe(false)
     })
   })
 })

--- a/packages/mcp-typesense/src/auth/profile-scope.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.ts
@@ -1,14 +1,23 @@
 /**
  * Resolve a caller-chosen retrieval profile's scope (filters + lente) onto the
- * base auth context. Two sources, in priority order:
+ * base auth context. Three sources, in priority order:
  *
  * 1. **Header-provided** (`auth.groupProfiles[slug]`): the proxy already
  *    resolved the profile and shipped it (token route's `compare_perspectives`).
- * 2. **On-demand resolver** (`resolveProfileScope`): fetch the profile's scope
+ * 2. **Already applied upstream** (`slug === auth.defaultProfileSlug`): whoever
+ *    sent `x-retrieval-profile` also sent that profile's resolved scope headers
+ *    (`x-taxonomy-slugs`, `x-folder-slugs`, retrieval params), so there is
+ *    nothing left to fetch.
+ * 3. **On-demand resolver** (`resolveProfileScope`): fetch the profile's scope
  *    server-side by slug+tenant. This is the path for callers that send only the
- *    slug — e.g. the Agno agent — so lente weights never cross to the agent.
+ *    slug — e.g. the Agno agent picking a non-default profile — so lente weights
+ *    never cross to the agent.
  *
- * Returns the base auth unchanged when there's no slug, no match, or no resolver.
+ * **Fail closed.** When a slug was chosen and none of the three sources can
+ * resolve it, this returns an error instead of the unscoped base auth. Falling
+ * back to "no profile" would run the query without the profile's hard filters
+ * and return content outside the caller's scope — exactly the failure this
+ * guard exists to prevent.
  *
  * Used by `search_collections` (chosen `retrieval_profile`) and by
  * `compare_perspectives` (per group).
@@ -17,34 +26,61 @@
 import type { ProfileScopeResolver } from '../retrieval-profile/resolver'
 import type { McpAuthContext } from '../types'
 
+export interface ProfileScopeError {
+  error: 'retrieval_profile_unresolved'
+  message: string
+  profile: string
+}
+
+export type ProfileScopeResult = { ok: true; auth: McpAuthContext | null } | { ok: false; error: ProfileScopeError }
+
 export async function applyProfileScope(
   auth: McpAuthContext | null,
   slug: string | undefined,
   resolveProfileScope?: ProfileScopeResolver | null
-): Promise<McpAuthContext | null> {
-  if (!auth || !slug) return auth
+): Promise<ProfileScopeResult> {
+  if (!auth || !slug) return { ok: true, auth }
 
   const fromHeader = auth.groupProfiles?.[slug]
   if (fromHeader) {
     return {
-      ...auth,
-      taxonomySlugs: fromHeader.taxonomySlugs,
-      folderSlugs: fromHeader.folderSlugs,
-      retrieval: fromHeader.retrieval
+      ok: true,
+      auth: {
+        ...auth,
+        taxonomySlugs: fromHeader.taxonomySlugs,
+        folderSlugs: fromHeader.folderSlugs,
+        retrieval: fromHeader.retrieval
+      }
     }
   }
+
+  // The scope headers on this request already describe this very profile.
+  if (slug === auth.defaultProfileSlug) return { ok: true, auth }
 
   if (resolveProfileScope && auth.tenantSlug) {
     const scope = await resolveProfileScope(auth.tenantSlug, slug)
     if (scope) {
       return {
-        ...auth,
-        taxonomySlugs: scope.taxonomySlugs,
-        folderSlugs: scope.folderSlugs,
-        retrieval: scope.retrieval
+        ok: true,
+        auth: {
+          ...auth,
+          taxonomySlugs: scope.taxonomySlugs,
+          folderSlugs: scope.folderSlugs,
+          retrieval: scope.retrieval
+        }
       }
     }
   }
 
-  return auth
+  return {
+    ok: false,
+    error: {
+      error: 'retrieval_profile_unresolved',
+      profile: slug,
+      message:
+        `Retrieval profile "${slug}" could not be resolved, so the search was NOT executed — ` +
+        "running it without the profile's hard filters would return content outside your scope. " +
+        'Call list_retrieval_profiles to check the available slugs and retry.'
+    }
+  }
 }

--- a/packages/mcp-typesense/src/defaults.ts
+++ b/packages/mcp-typesense/src/defaults.ts
@@ -21,6 +21,11 @@ SEARCH RULES:
 - In semantic/hybrid, vector recall is fixed (top 100 neighbors); \`per_page\` only paginates the page you see.
 - \`total_found\` is only reliable in \`mode: "lexical"\`.
 
+RETRIEVAL PROFILES AND SCOPE:
+- When \`list_retrieval_profiles\` returns profiles, the \`retrieval_profile\` you pass sets the HARD scope of the search. \`filters\` can only NARROW inside it, never widen it.
+- Slugs outside the profile are dropped and reported in \`scope_notice\`; if the whole filter falls outside, you get zero hits. To reach other content, switch \`retrieval_profile\` — not \`filters\`.
+- \`filters.tenant\` is ignored: the tenant comes from your credentials.
+
 PARAMETER TYPES:
 - \`filters\` MUST be a JSON object, not a stringified JSON.
 - \`taxonomy_slugs\` and \`folder_slugs\` accept a string OR a string array.
@@ -38,6 +43,18 @@ export const DEFAULT_GUIDE = `# MCP Search Server — Agent Guide
 - Use \`folder_slugs\` **FILTERS** to scope by folder. The slug chain mirrors the folder breadcrumb (root → leaf), so filtering by an ancestor folder's slug selects everything below it.
 - Use the \`headers\` filter to search within a specific book section.
 - Do NOT add meta-words like "opinion", "thinks", "says", "believes" — they are not in the content.
+
+## Filters vs retrieval profiles
+
+If your credentials expose retrieval profiles, the chosen \`retrieval_profile\` is the hard boundary of what you can read and \`filters\` only narrow within it:
+
+- Different author/perspective → switch \`retrieval_profile\`
+- Sub-topic, folder or section inside your profile → add \`filters\`
+- Different tenant → not possible, it comes from your credentials
+
+Out-of-scope slugs are dropped and explained in \`scope_notice\`. Zero hits with a \`scope_notice\` means scope enforcement, not missing content — do not retry the same filter with a shorter query.
+
+With no profiles attached, \`filters\` are unrestricted and this section does not apply.
 
 ## Query length and lexical AND
 

--- a/packages/mcp-typesense/src/tools/compare-perspectives.ts
+++ b/packages/mcp-typesense/src/tools/compare-perspectives.ts
@@ -88,12 +88,24 @@ export async function comparePerspectives(
   const groupResults = await Promise.all(
     input.groups.map(async g => {
       const filters = g.taxonomy_slugs ? { taxonomy_slugs: g.taxonomy_slugs } : undefined
-      const groupAuth = await applyProfileScope(
-        auth,
-        g.retrieval_profile ?? input.retrieval_profile,
-        ctx.resolveProfileScope
-      )
+      const profile = g.retrieval_profile ?? input.retrieval_profile
+      const groupScope = await applyProfileScope(auth, profile, ctx.resolveProfileScope)
 
+      // A group whose profile can't be resolved reports the error instead of
+      // silently running unscoped; the other groups still return their hits.
+      if (!groupScope.ok) {
+        return {
+          name: g.name,
+          taxonomy_slugs: g.taxonomy_slugs,
+          retrieval_profile: profile,
+          total_found: 0,
+          hits: [],
+          error: groupScope.error
+        }
+      }
+
+      // `searchCollections` intersects `filters.taxonomy_slugs` with the
+      // profile's own scope, so a group can only narrow within its profile.
       const result = await searchCollections(
         {
           query: input.query,
@@ -105,15 +117,16 @@ export async function comparePerspectives(
           expand_context: input.expand_context
         },
         ctx,
-        groupAuth
+        groupScope.auth
       )
 
       return {
         name: g.name,
         taxonomy_slugs: g.taxonomy_slugs,
-        retrieval_profile: g.retrieval_profile ?? input.retrieval_profile,
+        retrieval_profile: profile,
         total_found: result.total_found,
-        hits: result.hits
+        hits: result.hits,
+        ...(result.scope_notice ? { scope_notice: result.scope_notice } : {})
       }
     })
   )

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -174,7 +174,10 @@ export function registerTools(opts: RegisterToolsOptions): void {
       // token route, where the proxy already resolved `auth.retrieval`.
       const chosen = input.retrieval_profile ?? auth?.defaultProfileSlug
       const scoped = await applyProfileScope(auth, chosen, ctx.resolveProfileScope)
-      const result = await searchCollections(input, ctx, scoped)
+      // Fail closed: an unresolvable profile aborts the search instead of
+      // degrading to an unfiltered one.
+      if (!scoped.ok) return toolResult(scoped.error, input.format as OutputFormat)
+      const result = await searchCollections(input, ctx, scoped.auth)
       return toolResult(result, input.format as OutputFormat)
     }
   )

--- a/packages/mcp-typesense/src/tools/scope-filters.spec.ts
+++ b/packages/mcp-typesense/src/tools/scope-filters.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import type { McpAuthContext } from '../types'
+import { applyScopeToFilters } from './scope-filters'
+
+const bastos: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos'] }
+
+describe('applyScopeToFilters', () => {
+  it('passes filters through when there is no auth scope', () => {
+    const result = applyScopeToFilters({ taxonomy_slugs: 'escohotado' }, null)
+    expect(result.filters).toEqual({ taxonomy_slugs: 'escohotado' })
+    expect(result.outOfScope).toBe(false)
+    expect(result.notices).toEqual([])
+  })
+
+  it('applies the profile scope when the caller asks for nothing', () => {
+    const result = applyScopeToFilters(undefined, bastos)
+    expect(result.filters).toEqual({ tenant: 'internal', taxonomy_slugs: 'bastos' })
+    expect(result.notices).toEqual([])
+  })
+
+  it('refuses to widen the profile scope (the reported bug)', () => {
+    const result = applyScopeToFilters({ taxonomy_slugs: 'escohotado' }, bastos)
+    expect(result.outOfScope).toBe(true)
+    expect(result.filters?.taxonomy_slugs).toBe('bastos')
+    expect(result.notices[0]).toMatch(/entirely outside it/)
+  })
+
+  it('narrows to the intersection and reports what it dropped', () => {
+    const multi: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos', 'economia', 'libertad'] }
+    const result = applyScopeToFilters({ taxonomy_slugs: ['economia', 'escohotado'] }, multi)
+    expect(result.outOfScope).toBe(false)
+    expect(result.filters?.taxonomy_slugs).toBe('economia')
+    expect(result.notices[0]).toMatch(/escohotado/)
+  })
+
+  it('keeps a caller filter fully inside the scope without notices', () => {
+    const multi: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos', 'economia'] }
+    const result = applyScopeToFilters({ taxonomy_slugs: 'bastos' }, multi)
+    expect(result.filters?.taxonomy_slugs).toBe('bastos')
+    expect(result.notices).toEqual([])
+  })
+
+  it('never lets the caller switch tenant', () => {
+    const result = applyScopeToFilters({ tenant: 'la-forja' }, bastos)
+    expect(result.filters?.tenant).toBe('internal')
+    expect(result.notices[0]).toMatch(/fixed to "internal"/)
+  })
+
+  it('enforces folder_slugs the same way', () => {
+    const scoped: McpAuthContext = { tenantSlug: 'internal', folderSlugs: ['proyectos'] }
+    expect(applyScopeToFilters({ folder_slugs: 'privado' }, scoped).outOfScope).toBe(true)
+    expect(applyScopeToFilters(undefined, scoped).filters?.folder_slugs).toBe('proyectos')
+  })
+
+  it('leaves unscoped fields untouched', () => {
+    const result = applyScopeToFilters({ headers: ['Capítulo 1'] }, bastos)
+    expect(result.filters).toEqual({ headers: ['Capítulo 1'], tenant: 'internal', taxonomy_slugs: 'bastos' })
+  })
+
+  it('returns undefined filters when there is nothing to filter by', () => {
+    expect(applyScopeToFilters(undefined, null).filters).toBeUndefined()
+  })
+})

--- a/packages/mcp-typesense/src/tools/scope-filters.ts
+++ b/packages/mcp-typesense/src/tools/scope-filters.ts
@@ -1,0 +1,95 @@
+/**
+ * Enforce the caller's scope (tenant + the chosen profile's hard filters) over
+ * the filters the caller asked for.
+ *
+ * The scope is a **ceiling, not a default**: caller-supplied `taxonomy_slugs` /
+ * `folder_slugs` may only narrow *within* what the profile allows, and `tenant`
+ * is never negotiable. Previously the auth-derived filters were applied only
+ * when the caller left the field empty, so any agent that passed
+ * `filters.taxonomy_slugs` (which the server instructions actively encourage)
+ * silently replaced its profile's hard filters — and `filters.tenant` let a
+ * caller read another tenant's content.
+ *
+ * Fields the scope says nothing about (`headers`, …) pass through untouched.
+ */
+
+import type { McpAuthContext } from '../types'
+
+export type FilterMap = Record<string, string | string[]>
+
+export interface ScopedFilterResult {
+  /** Filters to send to Typesense, with the scope enforced. */
+  filters: FilterMap | undefined
+  /** What the scope changed about the request, surfaced back to the agent. */
+  notices: string[]
+  /** The caller asked exclusively for values outside its scope — nothing can match. */
+  outOfScope: boolean
+}
+
+/** Scope-governed filter fields and the auth key holding their allow-list. */
+const SCOPED_FIELDS = [
+  { field: 'taxonomy_slugs', key: 'taxonomySlugs' },
+  { field: 'folder_slugs', key: 'folderSlugs' }
+] as const
+
+const toList = (value: string | string[]): string[] => (Array.isArray(value) ? value : [value])
+
+/** Typesense filters read better as a scalar when there is a single value. */
+const collapse = (slugs: string[]): string | string[] => (slugs.length === 1 ? (slugs[0] as string) : slugs)
+
+export function applyScopeToFilters(requested: FilterMap | undefined, auth: McpAuthContext | null): ScopedFilterResult {
+  const filters: FilterMap = { ...requested }
+  const notices: string[] = []
+  let outOfScope = false
+
+  // Tenant is set by the credentials, never by the request.
+  if (auth?.tenantSlug) {
+    const asked = filters.tenant
+    if (asked !== undefined && toList(asked).some(t => t !== auth.tenantSlug)) {
+      notices.push(`\`tenant\` is fixed to "${auth.tenantSlug}" by your credentials; the value you passed was ignored.`)
+    }
+    filters.tenant = auth.tenantSlug
+  }
+
+  for (const { field, key } of SCOPED_FIELDS) {
+    const allowed = auth?.[key]
+    if (!allowed?.length) continue
+
+    const asked = filters[field]
+    if (asked === undefined) {
+      filters[field] = collapse(allowed)
+      continue
+    }
+
+    const askedList = toList(asked)
+    const kept = askedList.filter(slug => allowed.includes(slug))
+    const dropped = askedList.filter(slug => !allowed.includes(slug))
+
+    if (kept.length === 0) {
+      // Nothing the caller asked for is inside the scope. Keep the scope's own
+      // filter (never the caller's) and let the tool short-circuit.
+      filters[field] = collapse(allowed)
+      outOfScope = true
+      notices.push(
+        `Your retrieval profile restricts \`${field}\` to [${allowed.join(', ')}]. ` +
+          `You asked for [${askedList.join(', ')}], which is entirely outside it — no results. ` +
+          'Search within the profile scope, or pick a different `retrieval_profile`.'
+      )
+      continue
+    }
+
+    filters[field] = collapse(kept)
+    if (dropped.length > 0) {
+      notices.push(
+        `\`${field}\` was narrowed to [${kept.join(', ')}]: ` +
+          `[${dropped.join(', ')}] is outside your retrieval profile's scope.`
+      )
+    }
+  }
+
+  return {
+    filters: Object.keys(filters).length > 0 ? filters : undefined,
+    notices,
+    outOfScope
+  }
+}

--- a/packages/mcp-typesense/src/tools/search-collections.spec.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * End-to-end guard for scope enforcement: asserts on the `filter_by` string
+ * that actually reaches Typesense, not just on the helper in isolation.
+ *
+ * Regression covered: a caller passing `filters.taxonomy_slugs` used to REPLACE
+ * its profile's hard filters (and `filters.tenant` let it read another tenant),
+ * so an agent scoped to one author could retrieve any other.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { ToolContext } from '../context'
+import type { McpAuthContext } from '../types'
+import { searchCollections } from './search-collections'
+
+const chunkDef = {
+  name: 'posts',
+  displayName: 'Posts',
+  kind: 'post',
+  chunkCollection: 'posts_chunk',
+  chunkSearchFields: ['chunk_text', 'title']
+}
+
+/** Captures the searches sent to Typesense and returns an empty result set. */
+function makeCtx() {
+  const perform = vi.fn().mockResolvedValue({ results: [{ found: 0, hits: [], search_time_ms: 1 }] })
+  const ctx = {
+    typesense: { multiSearch: { perform } },
+    collections: {
+      chunks: [chunkDef],
+      documents: [],
+      books: [],
+      byChunkName: (name: string) => (name === 'posts_chunk' ? chunkDef : undefined),
+      has: (name: string) => name === 'posts_chunk'
+    },
+    taxonomy: { resolveSlugs: vi.fn().mockResolvedValue([]) },
+    content: null,
+    resolveReranker: null,
+    resolveProfileScope: null
+  } as unknown as ToolContext
+  return { ctx, perform }
+}
+
+/** Filter clauses as a set — key order follows the caller's object, which is not meaningful. */
+const filterOf = (perform: ReturnType<typeof vi.fn>): string[] =>
+  (perform.mock.calls[0]?.[0]?.searches?.[0]?.filter_by ?? '').split(' && ').filter(Boolean).sort()
+
+const bastos: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos'] }
+
+describe('searchCollections scope enforcement', () => {
+  it('applies the profile filters when the caller passes none', async () => {
+    const { ctx, perform } = makeCtx()
+    await searchCollections({ query: 'justicia' }, ctx, bastos)
+    expect(filterOf(perform)).toEqual(['taxonomy_slugs:=bastos', 'tenant:=internal'])
+  })
+
+  it('does not run the query when the caller asks outside its profile scope', async () => {
+    const { ctx, perform } = makeCtx()
+    const result = await searchCollections({ query: 'drogas', filters: { taxonomy_slugs: 'escohotado' } }, ctx, bastos)
+    expect(perform).not.toHaveBeenCalled()
+    expect(result.hits).toEqual([])
+    expect(result.total_found).toBe(0)
+    expect(result.scope_notice).toMatch(/outside it/)
+  })
+
+  it('ignores a caller-supplied tenant', async () => {
+    const { ctx, perform } = makeCtx()
+    const result = await searchCollections({ query: 'empresa', filters: { tenant: 'la-forja' } }, ctx, bastos)
+    expect(filterOf(perform)).toEqual(['taxonomy_slugs:=bastos', 'tenant:=internal'])
+    expect(result.scope_notice).toMatch(/fixed to "internal"/)
+  })
+
+  it('lets the caller narrow within its scope', async () => {
+    const { ctx, perform } = makeCtx()
+    const multi: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos', 'economia'] }
+    await searchCollections({ query: 'dinero', filters: { taxonomy_slugs: 'economia' } }, ctx, multi)
+    expect(filterOf(perform)).toEqual(['taxonomy_slugs:=economia', 'tenant:=internal'])
+  })
+
+  it('leaves unscoped callers unrestricted', async () => {
+    const { ctx, perform } = makeCtx()
+    await searchCollections({ query: 'drogas', filters: { taxonomy_slugs: 'escohotado' } }, ctx, null)
+    expect(filterOf(perform)).toEqual(['taxonomy_slugs:=escohotado'])
+  })
+
+  it('honors an explicit per_page over the profile topK', async () => {
+    const { ctx } = makeCtx()
+    const capped: McpAuthContext = { tenantSlug: 'internal', retrieval: { topK: 10 } }
+    const result = await searchCollections({ query: 'x', per_page: 2 }, ctx, capped)
+    expect(result.per_page).toBe(2)
+  })
+})

--- a/packages/mcp-typesense/src/tools/search-collections.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.ts
@@ -10,6 +10,7 @@ import type { ToolContext } from '../context'
 import { applyQueryRewriteTemplate } from '../query-rewrite'
 import { setAttributes, withSpan } from '../tracing'
 import type { ChunkCollectionConfig, McpAuthContext } from '../types'
+import { applyScopeToFilters } from './scope-filters'
 
 /** Chunk document shape as returned by Typesense. Loose because the schema evolves per collection. */
 type ChunkDoc = DocumentSchema
@@ -41,7 +42,9 @@ export const searchCollectionsSchema = z.object({
     .record(z.union([z.string(), z.array(z.string())]))
     .optional()
     .describe(
-      'Facet filters to apply. Keys are field names (tenant, taxonomy_slugs, folder_slugs, headers), values are strings or arrays.'
+      'Facet filters to apply. Keys are field names (taxonomy_slugs, folder_slugs, headers), values are strings or arrays. ' +
+        'These filters can only NARROW your retrieval profile scope, never widen it: slugs outside the profile are dropped, ' +
+        'and `tenant` is always fixed by your credentials.'
     ),
   per_page: z
     .number()
@@ -140,6 +143,12 @@ export interface SearchResult {
   per_page: number
   search_time_ms: number
   snippet_length: number
+  /**
+   * Present when the caller's filters were narrowed (or emptied) by the scope
+   * of its retrieval profile / credentials. Tells the agent why it got fewer
+   * hits than it asked for instead of silently returning a different scope.
+   */
+  scope_notice?: string
 }
 
 function buildFilterString(filters: Record<string, string | string[]>): string {
@@ -438,23 +447,19 @@ async function executeSearch(
   auth: McpAuthContext | null,
   parentSpan: import('@opentelemetry/api').Span
 ): Promise<SearchResult> {
-  // Auto-scope by tenant, taxonomy, and folder when auth provides them.
-  let scopedFilters = input.filters
-  if (auth?.tenantSlug && !scopedFilters?.tenant) {
-    scopedFilters = { ...scopedFilters, tenant: auth.tenantSlug }
-  }
-  if (auth?.taxonomySlugs?.length && !scopedFilters?.taxonomy_slugs) {
-    scopedFilters = {
-      ...scopedFilters,
-      taxonomy_slugs: auth.taxonomySlugs.length === 1 ? auth.taxonomySlugs[0] : auth.taxonomySlugs
-    }
-  }
-  if (auth?.folderSlugs?.length && !scopedFilters?.folder_slugs) {
-    scopedFilters = {
-      ...scopedFilters,
-      folder_slugs: auth.folderSlugs.length === 1 ? auth.folderSlugs[0] : auth.folderSlugs
-    }
-  }
+  // Enforce the caller's scope over the requested filters. Tenant is fixed by
+  // the credentials; the profile's taxonomy/folder filters are a ceiling the
+  // caller can narrow but never widen.
+  const scope = applyScopeToFilters(input.filters, auth)
+  const scopedFilters = scope.filters
+  const scopeNotice = scope.notices.length > 0 ? scope.notices.join(' ') : undefined
+  setAttributes(parentSpan, {
+    'retrieval.scope.enforced': scope.notices.length > 0,
+    'retrieval.scope.out_of_scope': scope.outOfScope
+  })
+  // Everything the caller asked for is outside its scope — running the query
+  // would only return content it is not allowed to see.
+  if (scope.outOfScope) return { ...emptyResult(input), scope_notice: scopeNotice }
 
   const targets = resolveTargets(ctx, input.collections)
   if (targets === null) return emptyResult(input)
@@ -484,10 +489,13 @@ async function executeSearch(
   // to the reranker (or to the caller when no reranker is configured).
   // hybridAlpha weights vector vs lexical in hybrid mode. topK caps the
   // final response — defaults to perPage so the legacy single-stage
-  // behavior is preserved when no profile is attached.
+  // behavior is preserved when no profile is attached. An explicit `per_page`
+  // wins over the profile's topK: the caller asked for a page size, and
+  // silently returning a different count reads as a bug.
   const inputK = clampPositiveInt(auth?.retrieval?.inputK, DEFAULT_VECTOR_K, 1, 1000)
   const hybridAlpha = clampNumber(auth?.retrieval?.hybridAlpha, DEFAULT_HYBRID_ALPHA, 0, 1)
-  const topK = clampPositiveInt(auth?.retrieval?.topK, perPage, 1, MAX_PER_PAGE)
+  const topK =
+    input.per_page !== undefined ? perPage : clampPositiveInt(auth?.retrieval?.topK, perPage, 1, MAX_PER_PAGE)
   const fetchPerCollection = Math.min(inputK, MAX_PER_PAGE)
 
   const learnedHead = auth?.retrieval?.learnedHead
@@ -577,7 +585,8 @@ async function executeSearch(
     page,
     per_page: topK,
     search_time_ms: totalTime,
-    snippet_length: snippetLength
+    snippet_length: snippetLength,
+    ...(scopeNotice ? { scope_notice: scopeNotice } : {})
   }
 }
 


### PR DESCRIPTION
## Problema

Los filtros de un search profile no eran *hard filters*: eran defaults sobrescribibles. En `search-collections.ts` cada campo del scope se aplicaba **solo si el llamante no lo había puesto**:

```ts
if (auth?.taxonomySlugs?.length && !scopedFilters?.taxonomy_slugs) { ... }
```

Es decir, cualquier agente que pasara `filters.taxonomy_slugs` **descartaba por completo** los filtros duros de su perfil. Y con `filters.tenant`, el aislamiento multi-tenant también se saltaba.

Agravante: las instrucciones que sirve el propio MCP le decían al agente que acotara justamente así (`Scope authors/topics via filters.taxonomy_slugs`), con el ejemplo literal `{ taxonomy_slugs: "bastos" }`. El comportamiento normal del agente disparaba el bug en cada query.

## Reproducción (prod)

Contra el MCP de `zetesis-portal-prod`, con las mismas cabeceras que manda el agno agent:

| Caso | Resultado antes |
|---|---|
| Perfil `bastos` + `filters.taxonomy_slugs: "escohotado"` | 305 hits, **cero de Bastos**, todos de Escohotado |
| `x-tenant-slug: internal` + `filters.tenant: "la-forja"` | 52 docs del tenant `la-forja` |
| `compare_perspectives` con `retrieval_profile: "bastos"` y grupos por autor | Escohotado y Recuenco íntegros |
| `x-retrieval-profile: bastos-typo` (perfil inexistente) | Búsqueda global sin filtros (*fail-open*) |

## Solución

El scope pasa a ser un **techo**, no un default.

- **`scope-filters.ts` (nuevo)** — `taxonomy_slugs` / `folder_slugs` se intersectan con el scope del perfil. Lo que caiga fuera se descarta y se explica en un nuevo campo `scope_notice` de la respuesta. `tenant` se toma siempre de las credenciales.
- **Cortocircuito** — si todo lo pedido queda fuera del scope, no se llega a lanzar la query a Typesense.
- **Fail-closed en `applyProfileScope`** — un slug irresoluble devuelve `retrieval_profile_unresolved` en vez de buscar sin filtros. Además se salta el resolver cuando la request ya trae el scope de ese perfil (evita un round-trip redundante a `profile-resolve`).
- **`compare_perspectives`** — los `taxonomy_slugs` por grupo solo pueden estrechar dentro del perfil; un grupo con perfil irresoluble reporta su error sin tumbar los demás.
- **`per_page` explícito** gana sobre el `topK` del perfil (antes pedir `per_group: 2` devolvía 10).
- **Instrucciones** (`defaults.ts`) — nueva sección explicando que para cambiar de autor se cambia de `retrieval_profile`, no de `filters`, y que cero hits con `scope_notice` es enforcement, no falta de contenido.

## Tests

47/47 en verde. Los tres escenarios reproducidos en prod tienen cobertura:

- `scope-filters.spec.ts` (9) — intersección, drop parcial, tenant fijo, folder_slugs, campos no gobernados.
- `search-collections.spec.ts` (nuevo, 6) — assertions sobre el `filter_by` **literal** que llega a Typesense, no solo sobre el helper.
- `profile-scope.spec.ts` — actualizado al contrato fail-closed.

## Compatibilidad

`applyProfileScope` es API interna (no se exporta desde el entry point) y `SearchResult` solo gana un campo opcional → sin breaking change.

⚠️ **Cambio de comportamiento**: tokens o agentes que hoy dependan de ampliar su scope vía `filters` verán menos resultados. Es el objetivo del PR, pero conviene saberlo antes de desplegar.

PR del repo principal: pendiente de enlazar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
