### PR TITLE
fix(mcp-typesense): extend retrieval profile scope to the read and metadata tools (v2)

### DIFF
--- a/packages/mcp-typesense/src/defaults.ts
+++ b/packages/mcp-typesense/src/defaults.ts
@@ -24,6 +24,7 @@ SEARCH RULES:
 RETRIEVAL PROFILES AND SCOPE:
 - When \`list_retrieval_profiles\` returns profiles, the \`retrieval_profile\` you pass sets the HARD scope of the search. \`filters\` can only NARROW inside it, never widen it.
 - Slugs outside the profile are dropped and reported in \`scope_notice\`; if the whole filter falls outside, you get zero hits. To reach other content, switch \`retrieval_profile\` — not \`filters\`.
+- Read tools (\`get_chunks_by_ids\`, \`summarize_document\`, \`extract_claims\`) and metadata tools (\`get_taxonomy_tree\`, \`get_filter_criteria\`) are scoped the same way. Pass the SAME \`retrieval_profile\` you searched with — ids found under one profile are not readable under another; omitting it falls back to your default profile.
 - \`filters.tenant\` is ignored: the tenant comes from your credentials.
 
 PARAMETER TYPES:
@@ -53,6 +54,8 @@ If your credentials expose retrieval profiles, the chosen \`retrieval_profile\` 
 - Different tenant → not possible, it comes from your credentials
 
 Out-of-scope slugs are dropped and explained in \`scope_notice\`. Zero hits with a \`scope_notice\` means scope enforcement, not missing content — do not retry the same filter with a shorter query.
+
+Reads inherit the same boundary: \`get_chunks_by_ids\`, \`summarize_document\` and \`extract_claims\` accept \`retrieval_profile\` and only return chunks inside that profile's scope. Always pass the profile you searched with; without it the read runs under your default profile and chunks found under another profile come back missing (with a \`scope_notice\`).
 
 With no profiles attached, \`filters\` are unrestricted and this section does not apply.
 

--- a/packages/mcp-typesense/src/resources/index.ts
+++ b/packages/mcp-typesense/src/resources/index.ts
@@ -61,7 +61,9 @@ export function registerResources(opts: RegisterResourcesOptions): void {
       mimeType: 'text/toon'
     },
     async () => {
-      const result = await getTaxonomyTree({}, ctx)
+      // Same scope as the tool: a profile-scoped caller sees only its own
+      // taxonomies here, not the full author list.
+      const result = await getTaxonomyTree({}, ctx, getCurrentAuth())
       return {
         contents: [
           {

--- a/packages/mcp-typesense/src/tools/extract-claims.ts
+++ b/packages/mcp-typesense/src/tools/extract-claims.ts
@@ -53,7 +53,13 @@ export const extractClaimsSchema = z.object({
     .array(z.enum(CLAIM_TYPES))
     .optional()
     .describe('Filter claims by type: factual, normative, definitional, predictive.'),
-  max_claims_per_chunk: z.number().int().min(1).max(10).optional().describe('Budget per chunk. Default: 5.')
+  max_claims_per_chunk: z.number().int().min(1).max(10).optional().describe('Budget per chunk. Default: 5.'),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe(
+      'Profile slug whose scope governs this read. Pass the SAME profile you searched with. Defaults to your default profile.'
+    )
 })
 
 export type ExtractClaimsInput = z.infer<typeof extractClaimsSchema>

--- a/packages/mcp-typesense/src/tools/get-chunks-by-ids.ts
+++ b/packages/mcp-typesense/src/tools/get-chunks-by-ids.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod'
 import type { ToolContext } from '../context'
 import type { McpAuthContext } from '../types'
+import { scopeFilterClauses } from './scope-filters'
 
 export const getChunksByIdsSchema = z.object({
   collection: z.string().describe('Chunk collection name'),
@@ -34,7 +35,9 @@ export async function getChunksByIds(input: GetChunksByIdsInput, ctx: ToolContex
     }
   }
 
-  const tenantSlug = auth?.tenantSlug ?? null
+  // Ids alone are not an authorization: without the caller's scope an agent
+  // could search inside its retrieval profile and then read outside it by id.
+  const filterParts = [`id:[${input.ids.join(',')}]`, ...scopeFilterClauses(auth)]
 
   const result = await ctx.typesense
     .collections(input.collection)
@@ -42,7 +45,7 @@ export async function getChunksByIds(input: GetChunksByIdsInput, ctx: ToolContex
     .search({
       q: '*',
       query_by: def.chunkSearchFields[0] || 'title',
-      filter_by: `id:[${input.ids.join(',')}]${tenantSlug ? ` && tenant:=${tenantSlug}` : ''}`,
+      filter_by: filterParts.join(' && '),
       per_page: input.ids.length,
       exclude_fields: 'embedding'
     })
@@ -62,5 +65,13 @@ export async function getChunksByIds(input: GetChunksByIdsInput, ctx: ToolContex
     }
   })
 
-  return { chunks, total: chunks.length }
+  // Tell the agent why it got fewer chunks than it asked for, so a scope drop
+  // does not read as "these chunks do not exist".
+  const missing = input.ids.length - chunks.length
+  const scopeNotice =
+    missing > 0 && scopeFilterClauses(auth).length > 0
+      ? `${missing} of the ${input.ids.length} requested chunks are outside your scope and were not returned.`
+      : undefined
+
+  return { chunks, total: chunks.length, ...(scopeNotice ? { scope_notice: scopeNotice } : {}) }
 }

--- a/packages/mcp-typesense/src/tools/get-chunks-by-ids.ts
+++ b/packages/mcp-typesense/src/tools/get-chunks-by-ids.ts
@@ -10,7 +10,13 @@ import { scopeFilterClauses } from './scope-filters'
 
 export const getChunksByIdsSchema = z.object({
   collection: z.string().describe('Chunk collection name'),
-  ids: z.array(z.string()).min(1).describe('Array of chunk document IDs to retrieve')
+  ids: z.array(z.string()).min(1).describe('Array of chunk document IDs to retrieve'),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe(
+      'Profile slug whose scope governs this read. Pass the SAME profile you searched with — ids found under one profile are not readable under another. Defaults to your default profile.'
+    )
 })
 
 export type GetChunksByIdsInput = z.infer<typeof getChunksByIdsSchema>
@@ -66,11 +72,15 @@ export async function getChunksByIds(input: GetChunksByIdsInput, ctx: ToolContex
   })
 
   // Tell the agent why it got fewer chunks than it asked for, so a scope drop
-  // does not read as "these chunks do not exist".
+  // does not read as "these chunks do not exist". We cannot distinguish a
+  // nonexistent id from a scope-filtered one without a second unscoped query,
+  // so the notice names both and points at the usual cause (wrong profile).
   const missing = input.ids.length - chunks.length
   const scopeNotice =
     missing > 0 && scopeFilterClauses(auth).length > 0
-      ? `${missing} of the ${input.ids.length} requested chunks are outside your scope and were not returned.`
+      ? `${missing} of the ${input.ids.length} requested chunks were not returned — they do not exist or are outside ` +
+        'the scope of the retrieval profile used for this read. If they came from a search under a different profile, ' +
+        'retry with that `retrieval_profile`.'
       : undefined
 
   return { chunks, total: chunks.length, ...(scopeNotice ? { scope_notice: scopeNotice } : {}) }

--- a/packages/mcp-typesense/src/tools/get-chunks-by-parent.ts
+++ b/packages/mcp-typesense/src/tools/get-chunks-by-parent.ts
@@ -7,6 +7,7 @@
 import { z } from 'zod'
 import type { ToolContext } from '../context'
 import type { McpAuthContext } from '../types'
+import { scopeFilterClauses } from './scope-filters'
 
 const MAX_PER_PAGE = 100
 const DEFAULT_PER_PAGE = 50
@@ -70,13 +71,14 @@ export async function getChunksByParent(
     }
   }
 
-  const tenantSlug = auth?.tenantSlug ?? null
   const perPage = Math.min(input.per_page ?? DEFAULT_PER_PAGE, MAX_PER_PAGE)
   const page = input.page ?? 1
 
-  // Build filter: parent_doc_id + optional tenant + optional chunk_index range
-  const filterParts: string[] = [`parent_doc_id:=${input.parent_doc_id}`]
-  if (tenantSlug) filterParts.push(`tenant:=${tenantSlug}`)
+  // Build filter: parent_doc_id + the caller's scope (tenant + profile
+  // taxonomy/folder) + optional chunk_index range. Scoping here keeps a parent
+  // read inside the same boundary search_collections enforces — a parent_doc_id
+  // surfaced by one profile must not become a back door into another.
+  const filterParts: string[] = [`parent_doc_id:=${input.parent_doc_id}`, ...scopeFilterClauses(auth)]
   if (input.start_chunk !== undefined) filterParts.push(`chunk_index:>=${input.start_chunk}`)
   if (input.end_chunk !== undefined) filterParts.push(`chunk_index:<${input.end_chunk}`)
   const filter_by = filterParts.join(' && ')

--- a/packages/mcp-typesense/src/tools/get-collection-stats.ts
+++ b/packages/mcp-typesense/src/tools/get-collection-stats.ts
@@ -5,6 +5,7 @@
 
 import type { ToolContext } from '../context'
 import type { ChunkCollectionConfig, McpAuthContext } from '../types'
+import { scopeFilterClauses } from './scope-filters'
 
 interface TaxonomyStat {
   slug: string
@@ -26,9 +27,12 @@ interface CollectionStats {
 async function getStatsForCollection(
   ctx: ToolContext,
   collectionDef: ChunkCollectionConfig,
-  tenantSlug: string | null
+  auth: McpAuthContext | null
 ): Promise<CollectionStats> {
   const taxonomyMap = await ctx.taxonomy.getTaxonomyMap()
+  // Distribution computed within the caller's scope: a profile-scoped agent
+  // sees only its own taxonomies' counts, not the whole tenant's author list.
+  const scopeFilter = scopeFilterClauses(auth).join(' && ')
 
   try {
     const result = await ctx.typesense
@@ -40,7 +44,7 @@ async function getStatsForCollection(
         facet_by: 'taxonomy_slugs',
         max_facet_values: 200,
         per_page: 0,
-        ...(tenantSlug ? { filter_by: `tenant:=${tenantSlug}` } : {})
+        ...(scopeFilter ? { filter_by: scopeFilter } : {})
       })
 
     const facetCounts = result.facet_counts?.find(f => f.field_name === 'taxonomy_slugs')
@@ -84,7 +88,6 @@ export async function getCollectionStats(
   ctx: ToolContext,
   auth: McpAuthContext | null
 ): Promise<{ collections: CollectionStats[] }> {
-  const tenantSlug = auth?.tenantSlug ?? null
-  const results = await Promise.all(ctx.collections.chunks.map(c => getStatsForCollection(ctx, c, tenantSlug)))
+  const results = await Promise.all(ctx.collections.chunks.map(c => getStatsForCollection(ctx, c, auth)))
   return { collections: results }
 }

--- a/packages/mcp-typesense/src/tools/get-filter-criteria.ts
+++ b/packages/mcp-typesense/src/tools/get-filter-criteria.ts
@@ -6,6 +6,7 @@
 import { z } from 'zod'
 import type { ToolContext } from '../context'
 import type { ChunkCollectionConfig, McpAuthContext } from '../types'
+import { scopeFilterClauses } from './scope-filters'
 
 export const getFilterCriteriaSchema = z.object({
   collection: z
@@ -30,9 +31,13 @@ interface CollectionFilters {
 async function getFacetsForCollection(
   ctx: ToolContext,
   collectionDef: ChunkCollectionConfig,
-  tenantSlug: string | null
+  auth: McpAuthContext | null
 ): Promise<CollectionFilters> {
   const facets: FacetValues[] = []
+  const tenantSlug = auth?.tenantSlug ?? null
+  // Facet counts computed within the caller's scope, so the returned filter
+  // options never advertise taxonomies/folders it cannot actually read.
+  const scopeFilter = scopeFilterClauses(auth).join(' && ')
 
   for (const facetField of collectionDef.chunkFacetFields) {
     // Skip parent_doc_id as it's not useful as a user-facing filter
@@ -50,7 +55,7 @@ async function getFacetsForCollection(
           facet_by: facetField,
           max_facet_values: 100,
           per_page: 0,
-          ...(tenantSlug ? { filter_by: `tenant:=${tenantSlug}` } : {})
+          ...(scopeFilter ? { filter_by: scopeFilter } : {})
         })
 
       const facetCounts = result.facet_counts?.find(f => f.field_name === facetField)
@@ -93,7 +98,6 @@ export async function getFilterCriteria(input: GetFilterCriteriaInput, ctx: Tool
     targets.push(...ctx.collections.chunks)
   }
 
-  const tenantSlug = auth?.tenantSlug ?? null
-  const results = await Promise.all(targets.map(t => getFacetsForCollection(ctx, t, tenantSlug)))
+  const results = await Promise.all(targets.map(t => getFacetsForCollection(ctx, t, auth)))
   return { collections: results }
 }

--- a/packages/mcp-typesense/src/tools/get-filter-criteria.ts
+++ b/packages/mcp-typesense/src/tools/get-filter-criteria.ts
@@ -12,7 +12,11 @@ export const getFilterCriteriaSchema = z.object({
   collection: z
     .string()
     .optional()
-    .describe('Specific collection name to get filters for. If omitted, returns filters for all chunk collections.')
+    .describe('Specific collection name to get filters for. If omitted, returns filters for all chunk collections.'),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe("Profile slug whose scope bounds the facet counts. Defaults to your default profile's scope.")
 })
 
 export type GetFilterCriteriaInput = z.infer<typeof getFilterCriteriaSchema>

--- a/packages/mcp-typesense/src/tools/get-taxonomy-tree.ts
+++ b/packages/mcp-typesense/src/tools/get-taxonomy-tree.ts
@@ -16,6 +16,12 @@ export const getTaxonomyTreeSchema = z.object({
     .optional()
     .describe(
       'Output shape. "flat" (default, RECOMMENDED) returns a flat list with parent_slug references — TOON tabularizes it as one CSV-style row per node, ~3x more compact than tree. "tree" returns the nested hierarchy. "both" returns both at ~2x token cost.'
+    ),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe(
+      "Profile slug whose scope bounds the tree — you only see the taxonomies that profile can filter by. Defaults to your default profile's scope."
     )
 })
 

--- a/packages/mcp-typesense/src/tools/get-taxonomy-tree.ts
+++ b/packages/mcp-typesense/src/tools/get-taxonomy-tree.ts
@@ -6,6 +6,7 @@
 
 import { z } from 'zod'
 import type { ResolvedTaxonomy, ToolContext } from '../context'
+import type { McpAuthContext } from '../types'
 
 export const getTaxonomyTreeSchema = z.object({
   type: z.string().optional().describe('Filter by taxonomy type (e.g. "author", "topic"). If omitted, returns all.'),
@@ -70,8 +71,23 @@ function sortTreeBySlug(nodes: TaxonomyNode[]): void {
   }
 }
 
-export async function getTaxonomyTree(input: GetTaxonomyTreeInput, ctx: ToolContext) {
-  const docs = await ctx.taxonomy.getAll()
+/**
+ * Restrict the taxonomy universe to the caller's retrieval-profile scope. A
+ * profile scoped to `taxonomy_slugs: [bastos]` can only ever filter by those
+ * slugs (search intersects against the same allow-list), so listing every
+ * author in the tree would advertise content it cannot read — the exact "it
+ * returns taxonomies it shouldn't" leak. A profile with no taxonomy scope
+ * (folder-only or open token) sees the full tree, matching what it can filter.
+ */
+function scopeDocs(docs: ResolvedTaxonomy[], auth: McpAuthContext | null): ResolvedTaxonomy[] {
+  const allowed = auth?.taxonomySlugs
+  if (!allowed?.length) return docs
+  const allow = new Set(allowed)
+  return docs.filter(doc => allow.has(doc.slug))
+}
+
+export async function getTaxonomyTree(input: GetTaxonomyTreeInput, ctx: ToolContext, auth: McpAuthContext | null) {
+  const docs = scopeDocs(await ctx.taxonomy.getAll(), auth)
   let tree = buildTree(docs)
 
   // Filter by type

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -70,7 +70,7 @@ export function registerTools(opts: RegisterToolsOptions): void {
       }
     },
     async input => {
-      const result = await getTaxonomyTree(input, ctx)
+      const result = await getTaxonomyTree(input, ctx, getCurrentAuth())
       return toolResult(result, input.format as OutputFormat)
     }
   )

--- a/packages/mcp-typesense/src/tools/index.ts
+++ b/packages/mcp-typesense/src/tools/index.ts
@@ -57,6 +57,18 @@ export function registerTools(opts: RegisterToolsOptions): void {
   const hasContent = ctx.content !== null
   const llmSamplingEnabled = features.llmSampling !== false
 
+  /**
+   * Resolve the scope a read/metadata tool runs under: the caller-chosen
+   * profile, else the default. Reads deliberately skip the selection guard —
+   * a multi-profile agent that omits the slug falls back to its default
+   * profile and gets a `scope_notice` pointing at `retrieval_profile` when
+   * that scope drops chunks, instead of a hard error on every read.
+   */
+  const resolveReadScope = (profileSlug: string | undefined) => {
+    const auth = getCurrentAuth()
+    return applyProfileScope(auth, profileSlug ?? auth?.defaultProfileSlug, ctx.resolveProfileScope)
+  }
+
   // -- OVERVIEW --------------------------------------------------------------
 
   server.registerTool(
@@ -70,7 +82,9 @@ export function registerTools(opts: RegisterToolsOptions): void {
       }
     },
     async input => {
-      const result = await getTaxonomyTree(input, ctx, getCurrentAuth())
+      const scoped = await resolveReadScope(input.retrieval_profile)
+      if (!scoped.ok) return toolResult(scoped.error, input.format as OutputFormat)
+      const result = await getTaxonomyTree(input, ctx, scoped.auth)
       return toolResult(result, input.format as OutputFormat)
     }
   )
@@ -92,7 +106,9 @@ export function registerTools(opts: RegisterToolsOptions): void {
       }
     },
     async input => {
-      const result = await getFilterCriteria(input, ctx, getCurrentAuth())
+      const scoped = await resolveReadScope(input.retrieval_profile)
+      if (!scoped.ok) return toolResult(scoped.error, input.format as OutputFormat)
+      const result = await getFilterCriteria(input, ctx, scoped.auth)
       return toolResult(result, input.format as OutputFormat)
     }
   )
@@ -218,7 +234,9 @@ export function registerTools(opts: RegisterToolsOptions): void {
       }
     },
     async input => {
-      const result = await getChunksByIds(input, ctx, getCurrentAuth())
+      const scoped = await resolveReadScope(input.retrieval_profile)
+      if (!scoped.ok) return toolResult(scoped.error, input.format as OutputFormat)
+      const result = await getChunksByIds(input, ctx, scoped.auth)
       return toolResult(result, input.format as OutputFormat)
     }
   )
@@ -242,7 +260,9 @@ export function registerTools(opts: RegisterToolsOptions): void {
         }
       },
       async (input, extra) => {
-        const result = await summarizeDocument(input, ctx, getCurrentAuth(), server, extra.signal)
+        const scoped = await resolveReadScope(input.retrieval_profile)
+        if (!scoped.ok) return toolResult(scoped.error, input.format as OutputFormat)
+        const result = await summarizeDocument(input, ctx, scoped.auth, server, extra.signal)
         return toolResult(result, input.format as OutputFormat)
       }
     )
@@ -259,7 +279,9 @@ export function registerTools(opts: RegisterToolsOptions): void {
         }
       },
       async (input, extra) => {
-        const result = await extractClaims(input, ctx, getCurrentAuth(), server, extra.signal)
+        const scoped = await resolveReadScope(input.retrieval_profile)
+        if (!scoped.ok) return toolResult(scoped.error, input.format as OutputFormat)
+        const result = await extractClaims(input, ctx, scoped.auth, server, extra.signal)
         return toolResult(result, input.format as OutputFormat)
       }
     )

--- a/packages/mcp-typesense/src/tools/read-scope.spec.ts
+++ b/packages/mcp-typesense/src/tools/read-scope.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Scope enforcement on the read tools. v1 only closed the search path; an agent
+ * could still read outside its retrieval profile by id/parent, and the metadata
+ * tools advertised the whole tenant's taxonomies. These assert on the actual
+ * `filter_by` sent to Typesense (or the taxonomy set returned).
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import type { ToolContext } from '../context'
+import type { McpAuthContext } from '../types'
+import { getChunksByIds } from './get-chunks-by-ids'
+import { getChunksByParent } from './get-chunks-by-parent'
+import { getCollectionStats } from './get-collection-stats'
+import { getFilterCriteria } from './get-filter-criteria'
+import { getTaxonomyTree } from './get-taxonomy-tree'
+
+const chunkDef = {
+  name: 'posts',
+  displayName: 'Posts',
+  kind: 'post',
+  chunkCollection: 'posts_chunk',
+  chunkSearchFields: ['chunk_text', 'title'],
+  chunkFacetFields: ['tenant', 'taxonomy_slugs', 'parent_doc_id']
+}
+
+/** Fake Typesense: records the search params and returns a canned response. */
+function makeCtx(searchImpl?: (params: Record<string, unknown>) => unknown) {
+  const search = vi.fn(async (params: Record<string, unknown>) => searchImpl?.(params) ?? { hits: [], found: 0 })
+  const documents = { search }
+  const ctx = {
+    typesense: { collections: () => ({ documents: () => documents }) },
+    collections: {
+      chunks: [chunkDef],
+      chunkNames: ['posts_chunk'],
+      byChunkName: (name: string) => (name === 'posts_chunk' ? chunkDef : undefined)
+    },
+    taxonomy: {
+      getAll: vi.fn().mockResolvedValue([
+        { id: 1, name: 'Bastos', slug: 'bastos', types: ['author'], breadcrumb: 'Bastos', parentSlug: null },
+        {
+          id: 2,
+          name: 'Escohotado',
+          slug: 'escohotado',
+          types: ['author'],
+          breadcrumb: 'Escohotado',
+          parentSlug: null
+        }
+      ]),
+      getTaxonomyMap: vi.fn().mockResolvedValue(new Map())
+    }
+  } as unknown as ToolContext
+  return { ctx, search }
+}
+
+const filterOf = (search: ReturnType<typeof vi.fn>): string =>
+  ((search.mock.calls[0]?.[0]?.filter_by as string) ?? '').split(' && ').filter(Boolean).sort().join(' && ')
+
+const bastos: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos'] }
+
+describe('get_chunks_by_ids scope', () => {
+  it('constrains the id lookup to the caller scope', async () => {
+    const { ctx, search } = makeCtx()
+    await getChunksByIds({ collection: 'posts_chunk', ids: ['156_chunk_3'] }, ctx, bastos)
+    expect(filterOf(search)).toBe('id:[156_chunk_3] && taxonomy_slugs:=bastos && tenant:=internal')
+  })
+
+  it('reports chunks dropped by scope instead of pretending they are missing', async () => {
+    const { ctx } = makeCtx(() => ({ hits: [], found: 0 }))
+    const result = await getChunksByIds({ collection: 'posts_chunk', ids: ['a', 'b'] }, ctx, bastos)
+    expect(result.total).toBe(0)
+    expect(result.scope_notice).toMatch(/2 of the 2/)
+  })
+
+  it('adds no scope filter for an unscoped caller', async () => {
+    const { ctx, search } = makeCtx()
+    await getChunksByIds({ collection: 'posts_chunk', ids: ['x'] }, ctx, null)
+    expect(filterOf(search)).toBe('id:[x]')
+  })
+})
+
+describe('get_chunks_by_parent scope', () => {
+  it('constrains a parent read to the caller scope', async () => {
+    const { ctx, search } = makeCtx()
+    await getChunksByParent({ collection: 'posts_chunk', parent_doc_id: '156' }, ctx, bastos)
+    expect(filterOf(search)).toBe('parent_doc_id:=156 && taxonomy_slugs:=bastos && tenant:=internal')
+  })
+
+  it('keeps the chunk_index range alongside the scope', async () => {
+    const { ctx, search } = makeCtx()
+    await getChunksByParent(
+      { collection: 'posts_chunk', parent_doc_id: '156', start_chunk: 2, end_chunk: 5 },
+      ctx,
+      bastos
+    )
+    const f = search.mock.calls[0]?.[0]?.filter_by as string
+    expect(f).toContain('taxonomy_slugs:=bastos')
+    expect(f).toContain('chunk_index:>=2')
+    expect(f).toContain('chunk_index:<5')
+  })
+})
+
+describe('get_filter_criteria scope', () => {
+  it('facets within the caller scope, not the whole tenant', async () => {
+    const { ctx, search } = makeCtx(() => ({ facet_counts: [{ field_name: 'taxonomy_slugs', counts: [] }] }))
+    await getFilterCriteria({ collection: 'posts_chunk' }, ctx, bastos)
+    const f = search.mock.calls[0]?.[0]?.filter_by as string
+    expect(f).toContain('taxonomy_slugs:=bastos')
+    expect(f).toContain('tenant:=internal')
+  })
+})
+
+describe('get_collection_stats scope', () => {
+  it('computes the distribution within the caller scope', async () => {
+    const { ctx, search } = makeCtx(() => ({ found: 0, facet_counts: [] }))
+    await getCollectionStats(ctx, bastos)
+    const f = search.mock.calls[0]?.[0]?.filter_by as string
+    expect(f).toContain('taxonomy_slugs:=bastos')
+  })
+})
+
+describe('get_taxonomy_tree scope', () => {
+  it('returns only the profile taxonomies, not the full tree', async () => {
+    const { ctx } = makeCtx()
+    const result = await getTaxonomyTree({}, ctx, bastos)
+    expect(result.total).toBe(1)
+    expect(result.flat?.map(n => n.slug)).toEqual(['bastos'])
+  })
+
+  it('returns the full tree for an unscoped caller', async () => {
+    const { ctx } = makeCtx()
+    const result = await getTaxonomyTree({}, ctx, null)
+    expect(result.total).toBe(2)
+  })
+})

--- a/packages/mcp-typesense/src/tools/read-scope.spec.ts
+++ b/packages/mcp-typesense/src/tools/read-scope.spec.ts
@@ -69,6 +69,19 @@ describe('get_chunks_by_ids scope', () => {
     const result = await getChunksByIds({ collection: 'posts_chunk', ids: ['a', 'b'] }, ctx, bastos)
     expect(result.total).toBe(0)
     expect(result.scope_notice).toMatch(/2 of the 2/)
+    // Multi-profile agents recover by re-reading under the profile they
+    // searched with — the notice must point them there.
+    expect(result.scope_notice).toMatch(/retrieval_profile/)
+  })
+
+  it('reads under whichever profile scope the handler resolved', async () => {
+    // Simulates the multi-profile flow: the handler resolves the chosen
+    // profile (e.g. "escohotado") via applyProfileScope and passes that auth —
+    // the read must follow it, not the default profile.
+    const { ctx, search } = makeCtx()
+    const escohotado: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['escohotado'] }
+    await getChunksByIds({ collection: 'posts_chunk', ids: ['156_chunk_3'] }, ctx, escohotado)
+    expect(filterOf(search)).toBe('id:[156_chunk_3] && taxonomy_slugs:=escohotado && tenant:=internal')
   })
 
   it('adds no scope filter for an unscoped caller', async () => {

--- a/packages/mcp-typesense/src/tools/scope-filters.spec.ts
+++ b/packages/mcp-typesense/src/tools/scope-filters.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { McpAuthContext } from '../types'
-import { applyScopeToFilters } from './scope-filters'
+import { applyScopeToFilters, buildFilterString, scopeFilterClauses } from './scope-filters'
 
 const bastos: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos'] }
 
@@ -59,5 +59,41 @@ describe('applyScopeToFilters', () => {
 
   it('returns undefined filters when there is nothing to filter by', () => {
     expect(applyScopeToFilters(undefined, null).filters).toBeUndefined()
+  })
+})
+
+describe('buildFilterString', () => {
+  it('emits an exact-match clause for a scalar', () => {
+    expect(buildFilterString({ tenant: 'internal' })).toBe('tenant:=internal')
+  })
+
+  it('emits an OR set for an array', () => {
+    expect(buildFilterString({ taxonomy_slugs: ['bastos', 'economia'] })).toBe('taxonomy_slugs:[bastos,economia]')
+  })
+
+  it('joins multiple fields with &&', () => {
+    expect(buildFilterString({ tenant: 'internal', taxonomy_slugs: 'bastos' })).toBe(
+      'tenant:=internal && taxonomy_slugs:=bastos'
+    )
+  })
+})
+
+describe('scopeFilterClauses', () => {
+  it('is empty without an auth scope', () => {
+    expect(scopeFilterClauses(null)).toEqual([])
+  })
+
+  it('yields one clause per scoped field', () => {
+    expect(scopeFilterClauses(bastos)).toEqual(['tenant:=internal', 'taxonomy_slugs:=bastos'])
+  })
+
+  it('OR-joins a multi-slug scope in a single clause', () => {
+    const multi: McpAuthContext = { tenantSlug: 'internal', taxonomySlugs: ['bastos', 'economia'] }
+    expect(scopeFilterClauses(multi)).toEqual(['tenant:=internal', 'taxonomy_slugs:[bastos,economia]'])
+  })
+
+  it('includes folder scope', () => {
+    const scoped: McpAuthContext = { tenantSlug: 'internal', folderSlugs: ['proyectos'] }
+    expect(scopeFilterClauses(scoped)).toEqual(['tenant:=internal', 'folder_slugs:=proyectos'])
   })
 })

--- a/packages/mcp-typesense/src/tools/scope-filters.ts
+++ b/packages/mcp-typesense/src/tools/scope-filters.ts
@@ -37,6 +37,24 @@ const toList = (value: string | string[]): string[] => (Array.isArray(value) ? v
 /** Typesense filters read better as a scalar when there is a single value. */
 const collapse = (slugs: string[]): string | string[] => (slugs.length === 1 ? (slugs[0] as string) : slugs)
 
+/** One Typesense clause per filter entry. Arrays become an OR set, scalars an exact match. */
+export function buildFilterString(filters: FilterMap): string {
+  return Object.entries(filters)
+    .map(([key, value]) => (Array.isArray(value) ? `${key}:[${value.join(',')}]` : `${key}:=${value}`))
+    .join(' && ')
+}
+
+/**
+ * The caller's scope as standalone Typesense clauses, ready to `&&` into any
+ * query. Read tools (`get_chunks_by_ids`, `get_chunks_by_parent`, …) use this
+ * to stay inside the same boundary `search_collections` enforces — otherwise
+ * an agent could search within its profile and then read outside it by id.
+ */
+export function scopeFilterClauses(auth: McpAuthContext | null): string[] {
+  const scoped = applyScopeToFilters(undefined, auth)
+  return scoped.filters ? Object.entries(scoped.filters).map(([k, v]) => buildFilterString({ [k]: v })) : []
+}
+
 export function applyScopeToFilters(requested: FilterMap | undefined, auth: McpAuthContext | null): ScopedFilterResult {
   const filters: FilterMap = { ...requested }
   const notices: string[] = []

--- a/packages/mcp-typesense/src/tools/summarize-document.ts
+++ b/packages/mcp-typesense/src/tools/summarize-document.ts
@@ -53,7 +53,13 @@ export const summarizeDocumentSchema = z.object({
     .min(1)
     .max(MAX_MAX_CHUNKS)
     .optional()
-    .describe(`Hard cap on chunks processed. Default: ${DEFAULT_MAX_CHUNKS}. Max: ${MAX_MAX_CHUNKS}.`)
+    .describe(`Hard cap on chunks processed. Default: ${DEFAULT_MAX_CHUNKS}. Max: ${MAX_MAX_CHUNKS}.`),
+  retrieval_profile: z
+    .string()
+    .optional()
+    .describe(
+      'Profile slug whose scope governs this read. Pass the SAME profile you searched with. Defaults to your default profile.'
+    )
 })
 
 export type SummarizeDocumentInput = z.infer<typeof summarizeDocumentSchema>


### PR DESCRIPTION
Continuación de **#132**. Aquel PR hizo que los filtros de un search profile fueran un techo duro, pero solo en la ruta de búsqueda (`search_collections`, `compare_perspectives`, `get_post_summaries`). El resto de tools seguían filtrando **solo por tenant**, así que un agente acotado a un perfil podía saltarse el techo por otra puerta.

## Fugas que quedaban (verificadas en prod, perfil `bastos`)

| Tool | Antes |
|---|---|
| `get_chunks_by_ids` | Leyó chunks de **Escohotado** (`156_chunk_3`, `174_chunk_3`) con texto completo |
| `get_taxonomy_tree` + resource `taxonomy://tree` | Expuso las **172 taxonomías** del árbol, todos los autores |
| `get_filter_criteria` | Faceteaba las **27 taxonomías** del tenant |
| `get_collection_stats` + `stats://collections` | Distribución de taxonomías de todo el tenant |
| `get_chunks_by_parent` | Cualquier documento del tenant por `parent_doc_id` |

El agujero práctico: `search_collections` (ya acotado) devuelve `chunk_id` y `parent_doc_id`, y con esos IDs `get_chunks_by_ids` / `get_chunks_by_parent` leían fuera del perfil. Y `get_taxonomy_tree` le listaba por su nombre a todos los autores que no debería ver — que es literalmente el síntoma reportado: *"me devuelve taxonomías que no debería"*.

## Solución

- **`scopeFilterClauses` / `buildFilterString`** (nuevos en `scope-filters.ts`) — convierten el scope del llamante en cláusulas Typesense sueltas, reutilizables en todos los tools de lectura.
- **`get_chunks_by_ids` / `get_chunks_by_parent`** — la lectura se restringe al scope. Un id caído por scope se reporta con `scope_notice`, no como "el chunk no existe".
- **`get_taxonomy_tree`** — se limita a los `taxonomy_slugs` del perfil (árbol completo si el perfil no tiene scope de taxonomía, coherente con lo que puede filtrar). El resource `taxonomy://tree` comparte el scope.
- **`get_filter_criteria` / `get_collection_stats`** — facetean dentro del scope.

`summarize_document` / `extract_claims` heredan el fix vía `get_chunks_by_parent`; `synthesize_comparison` vía `compare_perspectives`.

**Fuera de este PR**: `get_book_toc` tira libros del content source (Payload), no de Typesense, y sigue tenant-only. Follow-up si aparecen perfiles con scope de libro.

## Tests

63/63 en verde (+22 sobre v1):
- `scope-filters.spec.ts` — `scopeFilterClauses`, `buildFilterString`, OR-join multi-slug, folder scope.
- `read-scope.spec.ts` (nuevo, 9) — assertan sobre el `filter_by` literal enviado a Typesense en cada read tool y sobre el árbol de taxonomías scopeado.

## Verificación local

- `pnpm tsc --noEmit` (submodule y repo principal) — limpio
- `biome check` — limpio
- `vitest` 63/63
- `tsdown` build — OK

⚠️ Mismo aviso que #132: agentes que hoy dependan de leer fuera de su perfil (o de ver el árbol completo) verán menos. Es el objetivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
