### PR TITLE
fix(mcp-typesense): never trust a bare retrieval-profile slug as already-applied scope

### DIFF
--- a/packages/mcp-typesense/src/auth/profile-scope.spec.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { McpAuthContext } from '../types'
-import { applyProfileScope } from './profile-scope'
+import { applyProfileScope, isProfileGranted } from './profile-scope'
 
 const lente = { w: [0.1, 0.2], b: 0.5 }
 
@@ -23,6 +23,30 @@ const unwrap = (result: Awaited<ReturnType<typeof applyProfileScope>>): McpAuthC
   if (!result.ok) throw new Error(`expected ok, got ${result.error.error}`)
   return result.auth
 }
+
+describe('cross-profile authorization (privilege boundary)', () => {
+  it('rejects a slug the caller was not granted, before resolving anything', async () => {
+    const resolver = vi.fn().mockResolvedValue({ taxonomySlugs: ['secret'] })
+    const single: McpAuthContext = { tenantSlug: 't', defaultProfileSlug: 'bastos' }
+    const result = await applyProfileScope(single, 'escohotado', resolver)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.error.error).toBe('retrieval_profile_forbidden')
+    expect(resolver).not.toHaveBeenCalled()
+  })
+
+  it('allows the default, the catalog, and pre-resolved group profiles', () => {
+    expect(isProfileGranted({ tenantSlug: 't', defaultProfileSlug: 'bastos' }, 'bastos')).toBe(true)
+    expect(isProfileGranted(auth, 'a')).toBe(true) // catalog
+    expect(isProfileGranted(auth, 'b')).toBe(true) // catalog + groupProfiles
+    expect(isProfileGranted(auth, 'zzz')).toBe(false)
+  })
+
+  it('treats an unscoped token as open (any slug allowed)', () => {
+    expect(isProfileGranted({ tenantSlug: 't' }, 'anything')).toBe(true)
+    expect(isProfileGranted(null, 'anything')).toBe(true)
+  })
+})
 
 describe('applyProfileScope', () => {
   it('returns auth unchanged when no slug', async () => {
@@ -98,13 +122,15 @@ describe('applyProfileScope', () => {
       expect(scoped?.retrieval?.learnedHead).toEqual(lente)
     })
 
-    it('fails closed when the resolver finds nothing', async () => {
+    it('fails closed when a GRANTED slug cannot be resolved', async () => {
+      // 'neo' is in the catalog (granted) but the resolver comes up empty —
+      // this is the fail-closed path, distinct from an ungranted slug (forbidden).
       const resolver = vi.fn().mockResolvedValue(null)
-      const result = await applyProfileScope(bare, 'zzz', resolver)
+      const result = await applyProfileScope(bare, 'neo', resolver)
       expect(result.ok).toBe(false)
       if (result.ok) return
       expect(result.error.error).toBe('retrieval_profile_unresolved')
-      expect(result.error.profile).toBe('zzz')
+      expect(result.error.profile).toBe('neo')
       expect(result.error.message).toMatch(/NOT executed/)
     })
 

--- a/packages/mcp-typesense/src/auth/profile-scope.spec.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.spec.ts
@@ -50,12 +50,41 @@ describe('applyProfileScope', () => {
     expect(resolver).not.toHaveBeenCalled()
   })
 
-  it('skips the resolver when the request already carries that profile scope', async () => {
-    const resolver = vi.fn()
+  it('REGRESSION (Agno single-profile): a bare default slug with no scope headers is resolved, never trusted', async () => {
+    // The Agno builder sends `x-retrieval-profile: bastos` alone when the
+    // agent doc carries no taxonomy filters of its own. Trusting the bare slug
+    // ran the search with no profile filters at all — the original leak.
+    const resolver = vi.fn().mockResolvedValue({ taxonomySlugs: ['bastos'] })
+    const bareSlug: McpAuthContext = { tenantSlug: 't', defaultProfileSlug: 'bastos' }
+    const scoped = unwrap(await applyProfileScope(bareSlug, 'bastos', resolver))
+    expect(resolver).toHaveBeenCalledWith('t', 'bastos')
+    expect(scoped?.taxonomySlugs).toEqual(['bastos'])
+  })
+
+  it('fails closed on a bare default slug when no resolver is configured', async () => {
+    const bareSlug: McpAuthContext = { tenantSlug: 't', defaultProfileSlug: 'bastos' }
+    const result = await applyProfileScope(bareSlug, 'bastos')
+    expect(result.ok).toBe(false)
+  })
+
+  it('prefers the resolved profile over the header scope (profile doc is the source of truth)', async () => {
+    const resolver = vi.fn().mockResolvedValue({ taxonomySlugs: ['fresh'] })
+    const applied: McpAuthContext = { tenantSlug: 't', taxonomySlugs: ['stale'], defaultProfileSlug: 'bastos' }
+    const scoped = unwrap(await applyProfileScope(applied, 'bastos', resolver))
+    expect(scoped?.taxonomySlugs).toEqual(['fresh'])
+  })
+
+  it('falls back to header scope when the resolver finds nothing for the applied default profile', async () => {
+    const resolver = vi.fn().mockResolvedValue(null)
     const applied: McpAuthContext = { tenantSlug: 't', taxonomySlugs: ['bastos'], defaultProfileSlug: 'bastos' }
     const scoped = unwrap(await applyProfileScope(applied, 'bastos', resolver))
     expect(scoped).toBe(applied)
-    expect(resolver).not.toHaveBeenCalled()
+  })
+
+  it('accepts header scope for the default profile when no resolver is configured', async () => {
+    const applied: McpAuthContext = { tenantSlug: 't', taxonomySlugs: ['bastos'], defaultProfileSlug: 'bastos' }
+    const scoped = unwrap(await applyProfileScope(applied, 'bastos'))
+    expect(scoped).toBe(applied)
   })
 
   describe('on-demand resolver (Agno route — no groupProfiles)', () => {

--- a/packages/mcp-typesense/src/auth/profile-scope.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.ts
@@ -30,12 +30,32 @@ import type { ProfileScopeResolver } from '../retrieval-profile/resolver'
 import type { McpAuthContext } from '../types'
 
 export interface ProfileScopeError {
-  error: 'retrieval_profile_unresolved'
+  error: 'retrieval_profile_unresolved' | 'retrieval_profile_forbidden'
   message: string
   profile: string
 }
 
 export type ProfileScopeResult = { ok: true; auth: McpAuthContext | null } | { ok: false; error: ProfileScopeError }
+
+/**
+ * The profiles a caller was actually granted: its catalog (`availableProfiles`,
+ * sent for multi-profile callers), its default (`defaultProfileSlug`, the single
+ * profile the proxy/builder attached), and any profile the proxy pre-resolved
+ * for THIS request (`groupProfiles`, compare_perspectives). A caller with none
+ * of these is an unscoped legacy token.
+ */
+export function profileGrantedSet(auth: McpAuthContext | null): Set<string> {
+  const granted = new Set<string>((auth?.availableProfiles ?? []).map(p => p.slug))
+  if (auth?.defaultProfileSlug) granted.add(auth.defaultProfileSlug)
+  for (const slug of Object.keys(auth?.groupProfiles ?? {})) granted.add(slug)
+  return granted
+}
+
+/** Whether the caller may search/read under `slug`. Open (unscoped) tokens may use any. */
+export function isProfileGranted(auth: McpAuthContext | null, slug: string): boolean {
+  const granted = profileGrantedSet(auth)
+  return granted.size === 0 || granted.has(slug)
+}
 
 export async function applyProfileScope(
   auth: McpAuthContext | null,
@@ -43,6 +63,21 @@ export async function applyProfileScope(
   resolveProfileScope?: ProfileScopeResolver | null
 ): Promise<ProfileScopeResult> {
   if (!auth || !slug) return { ok: true, auth }
+
+  // Authorization gate. `applyProfileScope` is the single chokepoint every
+  // caller-chosen slug flows through — search, compare, AND the read tools — so
+  // rejecting an ungranted slug here closes cross-profile access everywhere at
+  // once, before the resolver would fetch another profile's scope by slug.
+  if (!isProfileGranted(auth, slug)) {
+    return {
+      ok: false,
+      error: {
+        error: 'retrieval_profile_forbidden',
+        profile: slug,
+        message: `You are not authorized to use retrieval_profile "${slug}". Use one of the profiles available to you.`
+      }
+    }
+  }
 
   const fromHeader = auth.groupProfiles?.[slug]
   if (fromHeader) {

--- a/packages/mcp-typesense/src/auth/profile-scope.ts
+++ b/packages/mcp-typesense/src/auth/profile-scope.ts
@@ -4,14 +4,17 @@
  *
  * 1. **Header-provided** (`auth.groupProfiles[slug]`): the proxy already
  *    resolved the profile and shipped it (token route's `compare_perspectives`).
- * 2. **Already applied upstream** (`slug === auth.defaultProfileSlug`): whoever
- *    sent `x-retrieval-profile` also sent that profile's resolved scope headers
- *    (`x-taxonomy-slugs`, `x-folder-slugs`, retrieval params), so there is
- *    nothing left to fetch.
- * 3. **On-demand resolver** (`resolveProfileScope`): fetch the profile's scope
- *    server-side by slug+tenant. This is the path for callers that send only the
- *    slug — e.g. the Agno agent picking a non-default profile — so lente weights
- *    never cross to the agent.
+ * 2. **On-demand resolver** (`resolveProfileScope`): fetch the profile's scope
+ *    server-side by slug+tenant. The profile document is the source of truth
+ *    and the resolver caches per (tenant, slug), so this is the default path —
+ *    it is what keeps callers that ship ONLY the slug (the Agno builder for
+ *    single-profile agents) scoped, and lente weights never cross to the agent.
+ * 3. **Header fallback** (`slug === auth.defaultProfileSlug` AND the request
+ *    actually carries scope data): when the resolver is absent or finds
+ *    nothing but the proxy demonstrably resolved this same profile into
+ *    `x-taxonomy-slugs`/`x-folder-slugs`/retrieval headers, trust those.
+ *    A bare slug with no scope alongside is never trusted — treating it as
+ *    "already applied" is how the original leak came back.
  *
  * **Fail closed.** When a slug was chosen and none of the three sources can
  * resolve it, this returns an error instead of the unscoped base auth. Falling
@@ -54,9 +57,16 @@ export async function applyProfileScope(
     }
   }
 
-  // The scope headers on this request already describe this very profile.
-  if (slug === auth.defaultProfileSlug) return { ok: true, auth }
+  // Whether the transport headers actually shipped scope data alongside the
+  // slug. The web proxy always sends the default profile's filters together
+  // with `x-retrieval-profile`; the Agno builder may send the slug ALONE.
+  // A bare slug is a reference, not a scope — trusting it unresolved ran the
+  // search with no profile filters at all (the original leak, reintroduced).
+  const headersCarryScope =
+    Boolean(auth.taxonomySlugs?.length) || Boolean(auth.folderSlugs?.length) || auth.retrieval !== undefined
 
+  // Resolver first: the profile document is the source of truth, the resolver
+  // caches per (tenant, slug), and this covers callers that ship only the slug.
   if (resolveProfileScope && auth.tenantSlug) {
     const scope = await resolveProfileScope(auth.tenantSlug, slug)
     if (scope) {
@@ -71,6 +81,10 @@ export async function applyProfileScope(
       }
     }
   }
+
+  // Resolver missing or came up empty: accept the request's own scope only
+  // when the proxy demonstrably resolved this same profile into headers.
+  if (slug === auth.defaultProfileSlug && headersCarryScope) return { ok: true, auth }
 
   return {
     ok: false,

--- a/packages/mcp-typesense/src/tools/profile-selection.spec.ts
+++ b/packages/mcp-typesense/src/tools/profile-selection.spec.ts
@@ -33,4 +33,31 @@ describe('requireProfileSelection', () => {
   it('accepts a valid slug', () => {
     expect(requireProfileSelection(withProfiles(['a', 'b']), 'b')).toBeNull()
   })
+
+  describe('single-profile authorization (privilege boundary)', () => {
+    const singleProfile = (slug: string): McpAuthContext => ({ tenantSlug: 't', defaultProfileSlug: slug })
+
+    it('applies the default when no slug is given', () => {
+      expect(requireProfileSelection(singleProfile('bastos'), undefined)).toBeNull()
+    })
+
+    it('accepts the caller’s own default slug', () => {
+      expect(requireProfileSelection(singleProfile('bastos'), 'bastos')).toBeNull()
+    })
+
+    it('REJECTS a different profile slug of the same tenant (no cross-profile read)', () => {
+      const err = requireProfileSelection(singleProfile('bastos'), 'escohotado')
+      expect(err?.error).toBe('retrieval_profile_required')
+      expect(err?.message).toMatch(/escohotado/)
+    })
+
+    it('rejects an unknown slug even when the catalog was sent but the slug is outside it', () => {
+      const auth: McpAuthContext = {
+        tenantSlug: 't',
+        defaultProfileSlug: 'a',
+        availableProfiles: [{ slug: 'a', name: 'a', description: '' }]
+      }
+      expect(requireProfileSelection(auth, 'b')?.error).toBe('retrieval_profile_required')
+    })
+  })
 })

--- a/packages/mcp-typesense/src/tools/search-collections.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.ts
@@ -6,6 +6,7 @@
 import type { DocumentSchema, SearchResponse, SearchResponseHit } from 'typesense/lib/Typesense/Documents'
 import type { MultiSearchRequestSchema } from 'typesense/lib/Typesense/Types'
 import { z } from 'zod'
+import { profileGrantedSet } from '../auth/profile-scope'
 import type { ToolContext } from '../context'
 import { applyQueryRewriteTemplate } from '../query-rewrite'
 import { setAttributes, withSpan } from '../tracing'
@@ -88,34 +89,28 @@ export interface ProfileRequiredError {
 }
 
 /**
- * Enforce profile selection AND authorization: the caller may only search under
- * a profile it was actually granted — its catalog (`availableProfiles`, sent for
- * multi-profile callers) plus its default (`defaultProfileSlug`, the single
- * profile the proxy/builder attached). A caller with neither is an unscoped
- * legacy token and may query raw.
+ * Enforce profile selection AND authorization at the search entry point: the
+ * caller may only search under a profile it was granted (its catalog plus its
+ * default), and a multi-profile caller must pick one explicitly rather than
+ * silently defaulting.
  *
- * This is a privilege boundary, not just UX: `applyProfileScope` will resolve
- * ANY slug that exists in the caller's tenant, so without this gate an agent
- * granted profile A could read under a more permissive profile B of the same
- * tenant just by naming B's slug (e.g. via prompt injection). We reject a slug
- * the caller wasn't granted before it ever reaches the resolver.
- *
- * Returns an error payload to surface back to the agent, or null to proceed.
+ * The authorization itself is enforced centrally in `applyProfileScope` (which
+ * every read tool also goes through); this guard adds the search-only "must
+ * pick" rule and surfaces the caller's available profiles in the error so the
+ * LLM can recover. A caller with no profile attached is an unscoped legacy
+ * token and may query raw.
  */
 export function requireProfileSelection(
   auth: McpAuthContext | null,
   chosen: string | undefined
 ): ProfileRequiredError | null {
   const profiles = auth?.availableProfiles ?? []
-  const granted = new Set(profiles.map(p => p.slug))
-  if (auth?.defaultProfileSlug) granted.add(auth.defaultProfileSlug)
+  const granted = profileGrantedSet(auth)
 
   // No profile attached at all → unscoped legacy token, open search.
   if (granted.size === 0) return null
 
   if (chosen) {
-    // A named profile must be one the caller was granted — in single- and
-    // multi-profile alike. This is the line that blocks cross-profile reads.
     if (granted.has(chosen)) return null
     return {
       error: 'retrieval_profile_required',

--- a/packages/mcp-typesense/src/tools/search-collections.ts
+++ b/packages/mcp-typesense/src/tools/search-collections.ts
@@ -88,25 +88,53 @@ export interface ProfileRequiredError {
 }
 
 /**
- * Enforce profile selection: when the caller's token exposes retrieval profiles,
- * every search MUST pick one (the agent can't query "raw"). Returns an error
- * payload to surface back to the agent, or null when the call may proceed
- * (no profiles configured, or a valid one was chosen).
+ * Enforce profile selection AND authorization: the caller may only search under
+ * a profile it was actually granted — its catalog (`availableProfiles`, sent for
+ * multi-profile callers) plus its default (`defaultProfileSlug`, the single
+ * profile the proxy/builder attached). A caller with neither is an unscoped
+ * legacy token and may query raw.
+ *
+ * This is a privilege boundary, not just UX: `applyProfileScope` will resolve
+ * ANY slug that exists in the caller's tenant, so without this gate an agent
+ * granted profile A could read under a more permissive profile B of the same
+ * tenant just by naming B's slug (e.g. via prompt injection). We reject a slug
+ * the caller wasn't granted before it ever reaches the resolver.
+ *
+ * Returns an error payload to surface back to the agent, or null to proceed.
  */
 export function requireProfileSelection(
   auth: McpAuthContext | null,
   chosen: string | undefined
 ): ProfileRequiredError | null {
   const profiles = auth?.availableProfiles ?? []
-  if (profiles.length === 0) return null
-  if (chosen && profiles.some(p => p.slug === chosen)) return null
-  return {
-    error: 'retrieval_profile_required',
-    message: chosen
-      ? `Unknown retrieval_profile "${chosen}". You must search with one of the available profiles.`
-      : 'This search requires a retrieval_profile. Call list_retrieval_profiles and pass the slug of the profile that best fits the query.',
-    available_profiles: profiles
+  const granted = new Set(profiles.map(p => p.slug))
+  if (auth?.defaultProfileSlug) granted.add(auth.defaultProfileSlug)
+
+  // No profile attached at all → unscoped legacy token, open search.
+  if (granted.size === 0) return null
+
+  if (chosen) {
+    // A named profile must be one the caller was granted — in single- and
+    // multi-profile alike. This is the line that blocks cross-profile reads.
+    if (granted.has(chosen)) return null
+    return {
+      error: 'retrieval_profile_required',
+      message: `Unknown retrieval_profile "${chosen}". You must search with one of the profiles available to you.`,
+      available_profiles: profiles
+    }
   }
+
+  // No choice: multi-profile callers must pick one; a single granted profile
+  // (single-profile agents / token) applies as the default.
+  if (profiles.length >= 2) {
+    return {
+      error: 'retrieval_profile_required',
+      message:
+        'This search requires a retrieval_profile. Call list_retrieval_profiles and pass the slug of the profile that best fits the query.',
+      available_profiles: profiles
+    }
+  }
+  return null
 }
 
 interface TaxonomyInfo {


### PR DESCRIPTION
Hotfix sobre #132/#134. El atajo de v1 (`slug === defaultProfileSlug → devolver auth sin tocar`) asumía que quien manda `x-retrieval-profile` manda también el scope resuelto de ese perfil. El proxy web lo hace; **el builder de Agno manda el slug solo** cuando el agente no tiene taxonomy filters propios → el atajo se saltaba el resolver → búsqueda sin filtros de perfil.

**Reproducido en prod** (mcp v0.4.10): cabeceras `{x-tenant-slug, x-retrieval-profile: bastos}` sin `x-taxonomy-slugs` → hits de Menéndez Pelayo, Campbell y Barraycoa. Es el bug reportado en el chat de producción.

Fix: el resolver pasa a ser la vía por defecto (el doc del perfil es la fuente de verdad, cacheado por tenant+slug); las cabeceras solo se aceptan como fallback si el resolver no existe/no encuentra Y las cabeceras llevan datos de scope para ese mismo slug. Un slug pelado sin scope al lado → fail-closed.

Tests: 68/68, incluido el de regresión con las cabeceras exactas del caso real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
